### PR TITLE
Fix tmux session cleanup for OMX job lifecycle

### DIFF
--- a/dani/models.py
+++ b/dani/models.py
@@ -58,6 +58,8 @@ class SessionRecord:
     id: str = field(default_factory=lambda: uuid4().hex)
     pane_id: str | None = None
     status: str = "launched"
+    ended_at: str | None = None
+    termination_reason: str | None = None
     created_at: str = field(default_factory=utc_now)
     updated_at: str = field(default_factory=utc_now)
 

--- a/dani/omx_runner.py
+++ b/dani/omx_runner.py
@@ -108,6 +108,12 @@ class OmxRunner:
         msg = f"tmux session did not exit before timeout: {tmux_session}"
         raise TimeoutError(msg)
 
+    def close_session(self, tmux_session: str) -> None:
+        completed = subprocess.run(["tmux", "has-session", "-t", tmux_session], capture_output=True, text=True)  # noqa: S603
+        if completed.returncode != 0:
+            return
+        subprocess.run(["tmux", "kill-session", "-t", tmux_session], check=True)  # noqa: S603
+
     def _capture_omx_session_id(
         self,
         *,

--- a/dani/service.py
+++ b/dani/service.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from dani.github import GitHubCLI
-from dani.models import DaniConfig, JobRecord, NormalizedEvent, RepoConfig, SessionRecord
+from dani.models import DaniConfig, JobRecord, NormalizedEvent, RepoConfig, SessionRecord, utc_now
 from dani.omx_runner import OmxRunner
 from dani.prompts import render_prompt
 from dani.queue import RepoQueueManager
@@ -183,13 +183,24 @@ class DaniService:
             self.storage.create_session(session)
             self.storage.update_job(job.id, status="launched", session_id=session.id)
             self.omx_runner.wait(session.tmux_session)
-            self.storage.update_session(session.id, status="completed")
             self._verify_side_effect(repo, job)
+            self._finalize_session(session, status="completed", termination_reason="completed")
             self.storage.update_job(job.id, status="completed")
         except Exception as exc:
             if session is not None:
-                self.storage.update_session(session.id, status="failed")
+                self._finalize_session(session, status="failed", termination_reason=type(exc).__name__)
             self.storage.update_job(job.id, status="failed", metadata={**job.metadata, "error": str(exc)})
+
+    def _finalize_session(self, session: SessionRecord, *, status: str, termination_reason: str) -> None:
+        try:
+            self.omx_runner.close_session(session.tmux_session)
+        finally:
+            self.storage.update_session(
+                session.id,
+                status=status,
+                ended_at=utc_now(),
+                termination_reason=termination_reason,
+            )
 
     def _build_prompt(self, repo: RepoConfig, job: JobRecord) -> str:
         issue_number = job.issue_number or 0

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -85,6 +85,7 @@ class FakeOmxRunner:
         self.github = github
         self.launches: list[LaunchRecord] = []
         self.resumes: list[ResumeRecord] = []
+        self.closed_sessions: list[str] = []
 
     def launch(self, repo_path: Path, job: JobRecord, prompt: str) -> SessionRecord:
         repo_full_name = job.repo_full_name
@@ -166,3 +167,6 @@ class FakeOmxRunner:
 
     def wait(self, tmux_session: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
         return None
+
+    def close_session(self, tmux_session: str) -> None:
+        self.closed_sessions.append(tmux_session)

--- a/tests/test_omx_runner.py
+++ b/tests/test_omx_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
+from unittest.mock import call, patch
 
 from dani.omx_runner import OmxRunner
 from dani.signatures import build_signature
@@ -51,3 +52,31 @@ def test_capture_omx_session_id_matches_signature_and_repo_path(tmp_path: Path) 
     )
 
     assert omx_session_id == "session-123"
+
+
+def test_close_session_kills_existing_tmux_session(tmp_path: Path) -> None:
+    runner = OmxRunner(run_dir=tmp_path / "runs")
+
+    with patch("dani.omx_runner.subprocess.run") as run:
+        run.side_effect = [
+            type("Completed", (), {"returncode": 0})(),
+            type("Completed", (), {"returncode": 0})(),
+        ]
+
+        runner.close_session("tmux-123")
+
+    assert run.call_args_list == [
+        call(["tmux", "has-session", "-t", "tmux-123"], capture_output=True, text=True),
+        call(["tmux", "kill-session", "-t", "tmux-123"], check=True),
+    ]
+
+
+def test_close_session_skips_missing_tmux_session(tmp_path: Path) -> None:
+    runner = OmxRunner(run_dir=tmp_path / "runs")
+
+    with patch("dani.omx_runner.subprocess.run") as run:
+        run.return_value = type("Completed", (), {"returncode": 1})()
+
+        runner.close_session("tmux-123")
+
+    assert run.call_args_list == [call(["tmux", "has-session", "-t", "tmux-123"], capture_output=True, text=True)]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -66,6 +66,11 @@ def test_issue_opened_queues_issue_request(tmp_path: Path) -> None:
     assert result["status"] == "queued"
     assert omx_runner.launches[0]["job"].stage == "issue_request"
     assert service.storage.list_jobs()[0].status == "completed"
+    assert omx_runner.closed_sessions == [f"tmux-{service.storage.list_jobs()[0].id}"]
+    session = service.storage.list_sessions()[0]
+    assert session.status == "completed"
+    assert session.ended_at is not None
+    assert session.termination_reason == "completed"
 
 
 def test_general_issue_comment_resumes_existing_issue_session(tmp_path: Path) -> None:
@@ -144,6 +149,20 @@ def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
     assert result["stage"] == "implementation"
     assert omx_runner.launches[0]["job"].stage == "implementation"
     assert service.storage.list_jobs()[0].status == "completed"
+
+
+def test_failed_job_still_closes_tmux_session_and_marks_failure(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    session = omx_runner.launch(Path(tmp_path), JobRecord(repo_full_name="acme/demo", stage="implementation"), "")
+    service.storage.create_session(session)
+
+    service._finalize_session(session, status="failed", termination_reason="RuntimeError")
+
+    stored = service.storage.list_sessions()[0]
+    assert stored.status == "failed"
+    assert stored.ended_at is not None
+    assert stored.termination_reason == "RuntimeError"
+    assert omx_runner.closed_sessions == [session.tmux_session]
 
 
 def test_pr_opened_from_implementation_signature_queues_review_round(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add explicit session finalization in `DaniService` so completed and failed jobs actively close their tmux session
- record session end metadata (`ended_at`, `termination_reason`) for lifecycle visibility
- cover service-level finalization and low-level tmux close behavior with regression tests

## Why
Issue #4 is satisfied under the `omx resume` interpretation of lifecycle: the durable context lives in `omx_session_id`, while tmux is only the temporary execution shell. That means we should close tmux after each run and recreate a fresh tmux shell on resume, rather than leave stray tmux sessions behind.

## Validation
- `python -m pytest -q`
- `python -m ruff check .`

Closes #4
