### PR TITLE
Handle transient model-capacity failures with retry/fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+## Tooling
+
+- Package manager: `uv`
+- Run tests: `uv run pytest`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+## Tooling
+
+- Package manager: `uv`
+- Run tests: `uv run pytest`

--- a/dani/errors.py
+++ b/dani/errors.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import re
+
+TRANSIENT_CAPACITY_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"Selected model is at capacity", re.IGNORECASE),
+    re.compile(r"model is currently overloaded", re.IGNORECASE),
+]
+
+
+class TransientCapacityError(Exception):
+    """Raised when an OMX session fails due to a transient model-capacity issue."""
+
+    def __init__(self, message: str, pattern: str) -> None:
+        super().__init__(message)
+        self.pattern = pattern
+
+
+def check_transient_capacity_error(stderr_text: str) -> None:
+    """Raise ``TransientCapacityError`` if *stderr_text* contains a known capacity pattern."""
+    for pattern in TRANSIENT_CAPACITY_PATTERNS:
+        match = pattern.search(stderr_text)
+        if match:
+            raise TransientCapacityError(match.group(0), pattern.pattern)

--- a/dani/omx_runner.py
+++ b/dani/omx_runner.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Protocol, TextIO
 from uuid import uuid4
 
+from dani.errors import check_transient_capacity_error
 from dani.models import JobRecord, SessionRecord
 
 
@@ -134,6 +135,15 @@ class OmxRunner:
         except subprocess.TimeoutExpired as exc:
             msg = f"omx exec process did not exit before timeout: {runtime_handle}"
             raise TimeoutError(msg) from exc
+
+        self._check_stderr_for_transient_error(runtime_handle)
+
+    def _check_stderr_for_transient_error(self, runtime_handle: str) -> None:
+        stderr_path = self.run_dir / runtime_handle / "stderr.log"
+        if not stderr_path.exists():
+            return
+        stderr_text = stderr_path.read_text(encoding="utf-8", errors="replace")
+        check_transient_capacity_error(stderr_text)
 
     def close_session(self, runtime_handle: str) -> None:
         with self._lock:

--- a/dani/service.py
+++ b/dani/service.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import contextlib
+import logging
 import re
+import time
 from pathlib import Path
 from typing import Any
 
+from dani.errors import TransientCapacityError
 from dani.git_sync import DevSyncConflictError, GitDevSyncer
 from dani.github import GitHubCLI, MergeConflictError
 from dani.models import DaniConfig, JobRecord, NormalizedEvent, RepoConfig, SessionRecord, utc_now
@@ -14,6 +18,10 @@ from dani.signatures import build_signature, parse_signature
 from dani.storage import JsonStorage
 
 ISSUE_REF_PATTERN = re.compile(r"#(?P<number>\d+)")
+
+RETRY_BACKOFF_SECONDS: list[int] = [60, 180, 600]
+
+logger = logging.getLogger(__name__)
 
 
 class DaniService:
@@ -267,23 +275,117 @@ class DaniService:
             self._run_dev_sync_job(repo, job)
             return
 
-        session = None
-        try:
-            prompt = self._build_prompt(repo, job)
-            if job.stage == "issue_followup":
-                session = self.omx_runner.resume(Path(repo.local_path), job, prompt, self._omx_session_id_for(job))
+        retry_history: list[dict[str, str]] = list(job.metadata.get("retry_history", []))
+        max_attempts = len(RETRY_BACKOFF_SECONDS) + 1
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                self._run_job_attempt(repo, job)
+            except TransientCapacityError as exc:
+                if self._handle_transient_failure(repo, job, exc, attempt, max_attempts, retry_history):
+                    return
+            except Exception as exc:
+                self._handle_job_failure(job, exc, attempt, retry_history)
+                return
             else:
-                session = self.omx_runner.launch(Path(repo.local_path), job, prompt)
-            self.storage.create_session(session)
-            self.storage.update_job(job.id, status="launched", session_id=session.id)
+                self.storage.update_job(
+                    job.id,
+                    status="completed",
+                    metadata={**job.metadata, "retry_attempts": attempt - 1, "retry_history": retry_history},
+                )
+                return
+
+    def _run_job_attempt(self, repo: RepoConfig, job: JobRecord) -> None:
+        prompt = self._build_prompt(repo, job)
+        if job.stage == "issue_followup":
+            session = self.omx_runner.resume(Path(repo.local_path), job, prompt, self._omx_session_id_for(job))
+        else:
+            session = self.omx_runner.launch(Path(repo.local_path), job, prompt)
+        self.storage.create_session(session)
+        self.storage.update_job(job.id, status="launched", session_id=session.id)
+        try:
             self.omx_runner.wait(session.runtime_handle)
             self._verify_side_effect(repo, job)
-            self._finalize_session(session, status="completed", termination_reason="completed")
-            self.storage.update_job(job.id, status="completed")
-        except Exception as exc:
-            if session is not None:
-                self._finalize_session(session, status="failed", termination_reason=type(exc).__name__)
-            self.storage.update_job(job.id, status="failed", metadata={**job.metadata, "error": str(exc)})
+        except Exception:
+            self._finalize_session(session, status="failed", termination_reason="failed")
+            raise
+        self._finalize_session(session, status="completed", termination_reason="completed")
+
+    def _handle_transient_failure(
+        self,
+        repo: RepoConfig,
+        job: JobRecord,
+        exc: TransientCapacityError,
+        attempt: int,
+        max_attempts: int,
+        retry_history: list[dict[str, str]],
+    ) -> bool:
+        """Handle a transient capacity error. Return True if the job is terminal (done or exhausted)."""
+        # If the side effect was already posted before the capacity error,
+        # treat the job as completed to avoid duplicate GitHub comments/PRs.
+        side_effect_exists = False
+        with contextlib.suppress(Exception):
+            self._verify_side_effect(repo, job)
+            side_effect_exists = True
+        if side_effect_exists:
+            self.storage.update_job(
+                job.id,
+                status="completed",
+                metadata={
+                    **job.metadata,
+                    "retry_attempts": attempt - 1,
+                    "retry_history": retry_history,
+                    "note": "side_effect_already_posted",
+                },
+            )
+            return True
+        retry_history.append({
+            "attempt": str(attempt),
+            "reason": "transient_capacity",
+            "pattern": exc.pattern,
+            "at": utc_now(),
+        })
+        if attempt >= max_attempts:
+            logger.warning("Job %s exhausted all %d retry attempts", job.id, max_attempts)
+            self.storage.update_job(
+                job.id,
+                status="failed",
+                metadata={
+                    **job.metadata,
+                    "error": f"retry_exhausted: {exc}",
+                    "retry_exhausted": True,
+                    "retry_attempts": attempt,
+                    "retry_history": retry_history,
+                },
+            )
+            return True
+        backoff = RETRY_BACKOFF_SECONDS[attempt - 1]
+        logger.info("Job %s attempt %d hit transient capacity error, retrying in %ds", job.id, attempt, backoff)
+        self.storage.update_job(
+            job.id,
+            status="retrying",
+            metadata={**job.metadata, "retry_attempts": attempt, "retry_history": retry_history},
+        )
+        time.sleep(backoff)
+        return False
+
+    def _handle_job_failure(
+        self,
+        job: JobRecord,
+        exc: Exception,
+        attempt: int,
+        retry_history: list[dict[str, str]],
+    ) -> None:
+        self.storage.update_job(
+            job.id,
+            status="failed",
+            metadata={
+                **job.metadata,
+                "error": str(exc),
+                "retry_attempts": attempt - 1,
+                "retry_history": retry_history,
+            },
+        )
 
     def _run_dev_sync_job(self, repo: RepoConfig, job: JobRecord) -> None:
         session = None

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,10 +4,13 @@ import re
 from pathlib import Path
 from typing import Any, TypedDict
 
+from dani.errors import TransientCapacityError
 from dani.git_sync import DevSyncConflictError, DevSyncContext, DevSyncOutcome
 from dani.github import MergeConflictError
 from dani.models import JobRecord, SessionRecord
 from dani.signatures import build_signature, parse_signature
+
+_CAPACITY_MSG = "capacity"
 
 
 class FakeGitHubCLI:
@@ -118,60 +121,20 @@ class FakeOmxRunner:
         self.launches: list[LaunchRecord] = []
         self.resumes: list[ResumeRecord] = []
         self.closed_sessions: list[str] = []
+        self._transient_failures_remaining: int = 0
+
+    def set_transient_failures(self, count: int) -> None:
+        """Configure the runner to raise TransientCapacityError for the next *count* wait() calls."""
+        self._transient_failures_remaining = count
 
     def launch(self, repo_path: Path, job: JobRecord, prompt: str) -> SessionRecord:
         repo_full_name = job.repo_full_name
         matches = re.findall(r"<!--\s*dani:([^>]+)\s*-->", prompt)
-        signature = None
-        if matches:
-            signature = parse_signature(f"<!-- dani:{matches[-1]} -->")
-        if job.stage == "issue_request":
-            issue_number = int((signature or {}).get("issue", job.issue_number or 0))
-            self.github.add_issue_signature(
-                repo_full_name,
-                issue_number,
-                build_signature(stage="issue_request", job=job.id, issue=issue_number),
-            )
-        elif job.stage == "implementation":
-            issue_number = int((signature or {}).get("issue", job.issue_number or 0))
-            pr_number = int((signature or {}).get("pr", job.pr_number or 0))
-            if pr_number:
-                signature_fields: dict[str, Any] = {"stage": "implementation", "job": job.id, "pr": pr_number}
-                if issue_number:
-                    signature_fields["issue"] = issue_number
-                self.github.add_pr_signature(
-                    repo_full_name,
-                    pr_number,
-                    build_signature(**signature_fields),
-                )
-            else:
-                signature_fields: dict[str, Any] = {"stage": "implementation", "job": job.id}
-                if issue_number:
-                    signature_fields["issue"] = issue_number
-                self.github.add_pull_request(repo_full_name, 101, build_signature(**signature_fields))
-        elif job.stage == "review_round":
-            pr_number = int((signature or {}).get("pr", job.pr_number or 0))
-            self.github.add_pr_signature(
-                repo_full_name,
-                pr_number,
-                build_signature(stage="review_round", job=job.id, pr=pr_number, round=job.review_round or 1),
-            )
-        elif job.stage == "merge_conflict_resolution":
-            pr_number = int((signature or {}).get("pr", job.pr_number or 0))
-            self.github.add_pr_signature(
-                repo_full_name,
-                pr_number,
-                build_signature(stage="merge_conflict_resolution", job=job.id, pr=pr_number),
-            )
-        elif job.stage == "dev_sync":
-            pass
-        else:
-            self.github.add_pr_signature(
-                repo_full_name,
-                job.pr_number or 0,
-                build_signature(stage="final_verdict", job=job.id, pr=job.pr_number or 0, verdict="APPROVE"),
-            )
-
+        signature = parse_signature(f"<!-- dani:{matches[-1]} -->") if matches else None
+        # If next wait() will raise TransientCapacityError, skip posting side effects
+        # to simulate the OMX session failing before it could post anything.
+        if self._transient_failures_remaining == 0:
+            self._post_side_effect(repo_full_name, job, signature)
         self.launches.append({"repo_path": str(repo_path), "job": job, "prompt": prompt})
         return SessionRecord(
             repo_full_name=repo_full_name,
@@ -186,6 +149,48 @@ class FakeOmxRunner:
             review_round=job.review_round,
             omx_session_id=f"omx-{job.id}",
         )
+
+    def _post_side_effect(self, repo_full_name: str, job: JobRecord, signature: dict[str, str] | None) -> None:
+        if job.stage == "issue_request":
+            issue_number = int((signature or {}).get("issue", job.issue_number or 0))
+            self.github.add_issue_signature(
+                repo_full_name,
+                issue_number,
+                build_signature(stage="issue_request", job=job.id, issue=issue_number),
+            )
+        elif job.stage == "implementation":
+            issue_number = int((signature or {}).get("issue", job.issue_number or 0))
+            pr_number = int((signature or {}).get("pr", job.pr_number or 0))
+            if pr_number:
+                fields: dict[str, Any] = {"stage": "implementation", "job": job.id, "pr": pr_number}
+                if issue_number:
+                    fields["issue"] = issue_number
+                self.github.add_pr_signature(repo_full_name, pr_number, build_signature(**fields))
+            else:
+                fields = {"stage": "implementation", "job": job.id}
+                if issue_number:
+                    fields["issue"] = issue_number
+                self.github.add_pull_request(repo_full_name, 101, build_signature(**fields))
+        elif job.stage == "review_round":
+            pr_number = int((signature or {}).get("pr", job.pr_number or 0))
+            self.github.add_pr_signature(
+                repo_full_name,
+                pr_number,
+                build_signature(stage="review_round", job=job.id, pr=pr_number, round=job.review_round or 1),
+            )
+        elif job.stage == "merge_conflict_resolution":
+            pr_number = int((signature or {}).get("pr", job.pr_number or 0))
+            self.github.add_pr_signature(
+                repo_full_name,
+                pr_number,
+                build_signature(stage="merge_conflict_resolution", job=job.id, pr=pr_number),
+            )
+        elif job.stage != "dev_sync":
+            self.github.add_pr_signature(
+                repo_full_name,
+                job.pr_number or 0,
+                build_signature(stage="final_verdict", job=job.id, pr=job.pr_number or 0, verdict="APPROVE"),
+            )
 
     def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
         issue_number = job.issue_number or 0
@@ -215,6 +220,9 @@ class FakeOmxRunner:
         )
 
     def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
+        if self._transient_failures_remaining > 0:
+            self._transient_failures_remaining -= 1
+            raise TransientCapacityError(_CAPACITY_MSG, _CAPACITY_MSG)
         return None
 
     def close_session(self, runtime_handle: str) -> None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -169,7 +169,7 @@ class FakeOmxRunner:
             else:
                 fields = {"stage": "implementation", "job": job.id}
                 if issue_number:
-                    fields["issue"] = issue_number
+                    fields["issue"] = str(issue_number)
                 self.github.add_pull_request(repo_full_name, 101, build_signature(**fields))
         elif job.stage == "review_round":
             pr_number = int((signature or {}).get("pr", job.pr_number or 0))

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -115,7 +115,7 @@ def test_non_transient_error_not_retried(mock_sleep: object, tmp_path: Path) -> 
 
     original_launch = omx_runner.launch
 
-    def failing_launch(*args, **kwargs):  # type: ignore[no-untyped-def]
+    def failing_launch(*args, **kwargs):
         result = original_launch(*args, **kwargs)
         # Remove the side effect so verify fails with a non-transient error
         github.issue_comment_map.clear()

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+from dani.errors import TransientCapacityError, check_transient_capacity_error
+from dani.github import GitHubCLI
+from dani.models import DaniConfig, NormalizedEvent
+from dani.omx_runner import OmxRunner
+from dani.service import RETRY_BACKOFF_SECONDS, DaniService
+from dani.storage import JsonStorage
+from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI, FakeOmxRunner
+
+_CAPACITY_MSG = "capacity"
+
+TEST_SECRET = "unit-test-secret"
+
+
+def make_service(
+    tmp_path: Path, *, dev_syncer: FakeGitDevSyncer | None = None
+) -> tuple[DaniService, FakeGitHubCLI, FakeOmxRunner]:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    github = FakeGitHubCLI()
+    omx_runner = FakeOmxRunner(github)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github),
+        omx_runner=cast(OmxRunner, omx_runner),
+        dev_syncer=dev_syncer or FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+    return service, github, omx_runner
+
+
+def _issue_event(number: int = 11) -> NormalizedEvent:
+    return NormalizedEvent(
+        kind="issue_opened",
+        repo_full_name="acme/demo",
+        action="opened",
+        number=number,
+        actor_login="human",
+        payload={},
+        body="Need automation",
+        title="Need automation",
+    )
+
+
+# --- errors.py unit tests ---
+
+
+class TestCheckTransientCapacityError:
+    def test_detects_capacity_message(self) -> None:
+        with pytest.raises(TransientCapacityError, match="Selected model is at capacity"):
+            check_transient_capacity_error("ERROR: Selected model is at capacity. Please try a different model.")
+
+    def test_detects_overloaded_message(self) -> None:
+        with pytest.raises(TransientCapacityError):
+            check_transient_capacity_error("model is currently overloaded")
+
+    def test_ignores_generic_rate_limit(self) -> None:
+        # Generic "rate limit exceeded" should NOT be classified as model capacity error
+        check_transient_capacity_error("rate limit exceeded")
+
+    def test_ignores_normal_stderr(self) -> None:
+        check_transient_capacity_error("some normal log output\nno errors here")
+
+    def test_ignores_empty_string(self) -> None:
+        check_transient_capacity_error("")
+
+
+# --- service.py retry integration tests ---
+
+
+@patch("dani.service.time.sleep")
+def test_retry_succeeds_after_transient_failure(mock_sleep: object, tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    omx_runner.set_transient_failures(1)
+
+    service.handle_event(_issue_event())
+    service.wait_for_idle()
+
+    job = service.storage.list_jobs()[0]
+    assert job.status == "completed"
+    assert job.metadata["retry_attempts"] == 1
+    assert len(job.metadata["retry_history"]) == 1
+    assert job.metadata["retry_history"][0]["reason"] == "transient_capacity"
+    assert len(omx_runner.launches) == 2
+
+
+@patch("dani.service.time.sleep")
+def test_retry_exhaustion_marks_job_failed(mock_sleep: object, tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    max_attempts = len(RETRY_BACKOFF_SECONDS) + 1
+    omx_runner.set_transient_failures(max_attempts)
+
+    service.handle_event(_issue_event())
+    service.wait_for_idle()
+
+    job = service.storage.list_jobs()[0]
+    assert job.status == "failed"
+    assert job.metadata["retry_exhausted"] is True
+    assert job.metadata["retry_attempts"] == max_attempts
+    assert len(job.metadata["retry_history"]) == max_attempts
+    assert "retry_exhausted" in job.metadata["error"]
+
+
+@patch("dani.service.time.sleep")
+def test_non_transient_error_not_retried(mock_sleep: object, tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    original_launch = omx_runner.launch
+
+    def failing_launch(*args, **kwargs):  # type: ignore[no-untyped-def]
+        result = original_launch(*args, **kwargs)
+        # Remove the side effect so verify fails with a non-transient error
+        github.issue_comment_map.clear()
+        return result
+
+    omx_runner.launch = failing_launch  # type: ignore[assignment]
+
+    service.handle_event(_issue_event())
+    service.wait_for_idle()
+
+    job = service.storage.list_jobs()[0]
+    assert job.status == "failed"
+    assert job.metadata.get("retry_exhausted") is not True
+    assert len(job.metadata.get("retry_history", [])) == 0
+
+
+@patch("dani.service.time.sleep")
+def test_retry_backoff_delays_are_correct(mock_sleep: object, tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    omx_runner.set_transient_failures(2)
+
+    service.handle_event(_issue_event())
+    service.wait_for_idle()
+
+    job = service.storage.list_jobs()[0]
+    assert job.status == "completed"
+    assert mock_sleep.call_count == 2  # type: ignore[union-attr]
+    calls = [call.args[0] for call in mock_sleep.call_args_list]  # type: ignore[union-attr]
+    assert calls == RETRY_BACKOFF_SECONDS[:2]
+
+
+@patch("dani.service.time.sleep")
+def test_retrying_status_visible_during_retry(mock_sleep: object, tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    observed_statuses: list[str] = []
+    original_sleep = mock_sleep
+
+    def capture_status(seconds: float) -> None:
+        jobs = service.storage.list_jobs()
+        if jobs:
+            observed_statuses.append(jobs[0].status)
+
+    original_sleep.side_effect = capture_status  # type: ignore[union-attr]
+    omx_runner.set_transient_failures(1)
+
+    service.handle_event(_issue_event())
+    service.wait_for_idle()
+
+    assert "retrying" in observed_statuses
+
+
+@patch("dani.service.time.sleep")
+def test_transient_error_with_side_effect_already_posted_completes(mock_sleep: object, tmp_path: Path) -> None:
+    """If the OMX run posted the GitHub comment before the capacity error, don't retry — mark completed."""
+    service, _, omx_runner = make_service(tmp_path)
+
+    # Don't use set_transient_failures — we want launch() to post the side effect
+    # normally, then have wait() raise a transient error afterward.
+    def wait_that_always_fails(runtime_handle: str, **kwargs: object) -> None:
+        raise TransientCapacityError(_CAPACITY_MSG, _CAPACITY_MSG)
+
+    omx_runner.wait = wait_that_always_fails  # type: ignore[assignment]
+
+    service.handle_event(_issue_event())
+    service.wait_for_idle()
+
+    job = service.storage.list_jobs()[0]
+    assert job.status == "completed"
+    assert job.metadata.get("note") == "side_effect_already_posted"
+    # Should NOT have retried — only 1 launch
+    assert len(omx_runner.launches) == 1


### PR DESCRIPTION
## Summary
- Detect known model-capacity errors (`Selected model is at capacity`, `model is currently overloaded`) in OMX stderr
- Automatically retry with bounded backoff (1m → 3m → 10m, max 4 attempts)
- Skip retry when GitHub side effect was already posted to avoid duplicate comments/PRs
- Track `retry_attempts`, `retry_history`, `retry_exhausted` in job metadata for observability
- New `retrying` job status visible via `dani show-state`

## Test plan
- [x] 69 tests passing (11 new retry-specific tests)
- [x] ruff lint passing
- [ ] Verify on real capacity error scenario when it next occurs

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)