### PR TITLE
Serialize issue lifecycles in the job queue

### DIFF
--- a/dani/queue.py
+++ b/dani/queue.py
@@ -9,6 +9,17 @@ from dani.models import JobRecord
 
 JobHandler = Callable[[JobRecord], Any]
 
+# Stages that touch git branches and require exclusive issue access.
+_ISSUE_LOCKED_STAGES = frozenset({
+    "implementation",
+    "review_round",
+    "final_verdict",
+    "merge_conflict_resolution",
+})
+
+# Stages that end an issue's lifecycle and release the lock.
+_TERMINAL_STAGES = frozenset({"final_verdict"})
+
 
 class RepoQueueManager:
     def __init__(self, handler: JobHandler) -> None:
@@ -16,6 +27,8 @@ class RepoQueueManager:
         self._queues: dict[str, queue.Queue[JobRecord]] = {}
         self._threads: dict[str, threading.Thread] = {}
         self._lock = threading.RLock()
+        self._active_issue: dict[str, int] = {}
+        self._deferred: dict[str, list[JobRecord]] = {}
 
     def submit(self, job: JobRecord) -> None:
         with self._lock:
@@ -36,9 +49,40 @@ class RepoQueueManager:
         while True:
             job = repo_queue.get()
             try:
-                self._handler(job)
+                if self._try_execute_or_defer(repo_full_name, job):
+                    self._handler(job)
+                    self._after_job(repo_full_name, job)
             finally:
                 repo_queue.task_done()
+
+    def _needs_issue_lock(self, job: JobRecord) -> bool:
+        return job.issue_number is not None and job.stage in _ISSUE_LOCKED_STAGES
+
+    def _try_execute_or_defer(self, repo: str, job: JobRecord) -> bool:
+        """Return True if the job should execute now, False if deferred."""
+        if not self._needs_issue_lock(job):
+            return True
+        with self._lock:
+            active = self._active_issue.get(repo)
+            issue = job.issue_number  # guaranteed non-None by _needs_issue_lock
+            if active is None or active == issue:
+                self._active_issue[repo] = issue  # type: ignore[assignment]
+                return True
+            self._deferred.setdefault(repo, []).append(job)
+            return False
+
+    def _after_job(self, repo: str, job: JobRecord) -> None:
+        if not self._needs_issue_lock(job):
+            return
+        if job.stage in _TERMINAL_STAGES or job.status == "failed":
+            self._flush_deferred(repo)
+
+    def _flush_deferred(self, repo: str) -> None:
+        with self._lock:
+            self._active_issue.pop(repo, None)
+            deferred = self._deferred.pop(repo, [])
+        for deferred_job in deferred:
+            self._queues[repo].put(deferred_job)
 
     def join_all(self) -> None:
         for repo_queue in self._queues.values():

--- a/dani/queue.py
+++ b/dani/queue.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import logging
 import queue
 import threading
 from collections.abc import Callable
 from typing import Any
 
 from dani.models import JobRecord
+
+logger = logging.getLogger(__name__)
 
 JobHandler = Callable[[JobRecord], Any]
 
@@ -55,7 +58,11 @@ class RepoQueueManager:
                     except Exception:
                         job.status = "failed"
                     finally:
-                        self._after_job(repo_full_name, job)
+                        try:
+                            self._after_job(repo_full_name, job)
+                        except Exception:
+                            logger.exception("_after_job failed for job %s, force-releasing issue lock", job.id)
+                            self._force_release(repo_full_name)
             finally:
                 repo_queue.task_done()
 
@@ -88,6 +95,18 @@ class RepoQueueManager:
         for deferred_job in deferred:
             self._queues[repo].put(deferred_job)
 
+    def _force_release(self, repo: str) -> None:
+        """Emergency release: clear active issue and re-enqueue deferred jobs."""
+        with self._lock:
+            self._active_issue.pop(repo, None)
+            deferred = self._deferred.pop(repo, [])
+        for deferred_job in deferred:
+            self._queues[repo].put(deferred_job)
+
     def join_all(self) -> None:
         for repo_queue in self._queues.values():
             repo_queue.join()
+        with self._lock:
+            for repo, jobs in self._deferred.items():
+                if jobs:
+                    logger.warning("join_all: %d deferred jobs for %s were never flushed", len(jobs), repo)

--- a/dani/queue.py
+++ b/dani/queue.py
@@ -50,8 +50,12 @@ class RepoQueueManager:
             job = repo_queue.get()
             try:
                 if self._try_execute_or_defer(repo_full_name, job):
-                    self._handler(job)
-                    self._after_job(repo_full_name, job)
+                    try:
+                        self._handler(job)
+                    except Exception:
+                        job.status = "failed"
+                    finally:
+                        self._after_job(repo_full_name, job)
             finally:
                 repo_queue.task_done()
 

--- a/dani/service.py
+++ b/dani/service.py
@@ -269,6 +269,7 @@ class DaniService:
         repo = self.storage.get_repo(job.repo_full_name)
         if repo is None:
             self.storage.update_job(job.id, status="failed", metadata={**job.metadata, "error": "missing repo"})
+            job.status = "failed"
             return
 
         if job.stage == "dev_sync":
@@ -286,6 +287,7 @@ class DaniService:
                     return
             except Exception as exc:
                 self._handle_job_failure(job, exc, attempt, retry_history)
+                job.status = "failed"
                 return
             else:
                 self.storage.update_job(
@@ -293,6 +295,7 @@ class DaniService:
                     status="completed",
                     metadata={**job.metadata, "retry_attempts": attempt - 1, "retry_history": retry_history},
                 )
+                job.status = "completed"
                 return
 
     def _run_job_attempt(self, repo: RepoConfig, job: JobRecord) -> None:
@@ -338,6 +341,7 @@ class DaniService:
                     "note": "side_effect_already_posted",
                 },
             )
+            job.status = "completed"
             return True
         retry_history.append({
             "attempt": str(attempt),
@@ -358,6 +362,7 @@ class DaniService:
                     "retry_history": retry_history,
                 },
             )
+            job.status = "failed"
             return True
         backoff = RETRY_BACKOFF_SECONDS[attempt - 1]
         logger.info("Job %s attempt %d hit transient capacity error, retrying in %ds", job.id, attempt, backoff)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -34,3 +34,154 @@ def test_queue_is_serial_per_repo_and_parallel_across_repos() -> None:
 
     assert repo_a_starts[1] >= repo_a_ends[0]
     assert repo_b_start < repo_a_ends[0]
+
+
+def test_different_issues_serialized() -> None:
+    """Implementation jobs for different issues must not interleave.
+
+    Issue #1's lifecycle (impl → final_verdict) must complete before issue #2's
+    implementation starts.
+    """
+    execution_order: list[tuple[int, str]] = []
+    lock = threading.Lock()
+
+    def handler(job: JobRecord) -> None:
+        with lock:
+            execution_order.append((job.issue_number, job.stage))  # type: ignore[arg-type]
+        # Simulate work
+        time.sleep(0.05)
+        # Simulate final_verdict marking the job as completed
+        if job.stage == "final_verdict":
+            job.status = "completed"
+
+    manager = RepoQueueManager(handler)
+    # Submit impl for issue #1, then impl for issue #2, then final_verdict for #1
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=1))
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=2))
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="final_verdict", issue_number=1))
+    manager.join_all()
+
+    # Issue #2's impl should come AFTER issue #1's final_verdict
+    assert execution_order == [
+        (1, "implementation"),
+        (1, "final_verdict"),
+        (2, "implementation"),
+    ]
+
+
+def test_dev_sync_bypasses_issue_lock() -> None:
+    """dev_sync jobs (no issue_number) run even when an issue is active."""
+    execution_order: list[str] = []
+    lock = threading.Lock()
+    impl_started = threading.Event()
+
+    def handler(job: JobRecord) -> None:
+        if job.stage == "implementation":
+            impl_started.set()
+            # Hold the lock for a bit so dev_sync arrives while active
+            time.sleep(0.1)
+        with lock:
+            execution_order.append(job.stage)
+        if job.stage == "final_verdict":
+            job.status = "completed"
+
+    manager = RepoQueueManager(handler)
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=1))
+    # Wait for implementation to start, then submit dev_sync
+    impl_started.wait(timeout=1)
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="dev_sync"))
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="final_verdict", issue_number=1))
+    manager.join_all()
+
+    # dev_sync should run between implementation and final_verdict (not deferred)
+    assert execution_order == ["implementation", "dev_sync", "final_verdict"]
+
+
+def test_issue_request_not_locked() -> None:
+    """issue_request does not require issue lock, so it runs even when another issue is active."""
+    execution_order: list[tuple[int, str]] = []
+    lock = threading.Lock()
+    impl_started = threading.Event()
+
+    def handler(job: JobRecord) -> None:
+        if job.stage == "implementation" and job.issue_number == 1:
+            impl_started.set()
+            time.sleep(0.1)
+        with lock:
+            execution_order.append((job.issue_number, job.stage))  # type: ignore[arg-type]
+        if job.stage == "final_verdict":
+            job.status = "completed"
+
+    manager = RepoQueueManager(handler)
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=1))
+    impl_started.wait(timeout=1)
+    # issue_request for issue #2 should NOT be deferred
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="issue_request", issue_number=2))
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="final_verdict", issue_number=1))
+    manager.join_all()
+
+    assert execution_order == [
+        (1, "implementation"),
+        (2, "issue_request"),
+        (1, "final_verdict"),
+    ]
+
+
+def test_failed_job_releases_lock() -> None:
+    """A failed locked job releases the issue lock so other issues can proceed."""
+    execution_order: list[tuple[int, str]] = []
+    lock = threading.Lock()
+
+    def handler(job: JobRecord) -> None:
+        with lock:
+            execution_order.append((job.issue_number, job.stage))  # type: ignore[arg-type]
+        # Simulate failure for issue #1
+        if job.issue_number == 1:
+            job.status = "failed"
+
+    manager = RepoQueueManager(handler)
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=1))
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=2))
+    manager.join_all()
+
+    # Issue #2 should run after #1 fails
+    assert execution_order == [
+        (1, "implementation"),
+        (2, "implementation"),
+    ]
+
+
+def test_deferred_jobs_requeued_on_terminal() -> None:
+    """When active issue reaches final_verdict, deferred jobs are re-enqueued.
+
+    Each issue must also reach final_verdict before the next one starts.
+    """
+    execution_order: list[tuple[int, str]] = []
+    lock = threading.Lock()
+
+    def handler(job: JobRecord) -> None:
+        with lock:
+            execution_order.append((job.issue_number, job.stage))  # type: ignore[arg-type]
+        if job.stage == "final_verdict":
+            job.status = "completed"
+
+    manager = RepoQueueManager(handler)
+    # Issue #1 lifecycle
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=1))
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="final_verdict", issue_number=1))
+    # Issue #2 lifecycle (will be deferred until #1 finishes)
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=2))
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="final_verdict", issue_number=2))
+    # Issue #3 lifecycle (will be deferred until #2 finishes)
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=3))
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="final_verdict", issue_number=3))
+    manager.join_all()
+
+    assert execution_order == [
+        (1, "implementation"),
+        (1, "final_verdict"),
+        (2, "implementation"),
+        (2, "final_verdict"),
+        (3, "implementation"),
+        (3, "final_verdict"),
+    ]

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,5 +1,8 @@
+import logging
 import threading
 import time
+
+import pytest
 
 from dani.models import JobRecord
 from dani.queue import RepoQueueManager
@@ -209,3 +212,20 @@ def test_deferred_jobs_requeued_on_terminal() -> None:
         (3, "implementation"),
         (3, "final_verdict"),
     ]
+
+
+def test_join_all_warns_on_orphaned_deferred_jobs(caplog: pytest.LogCaptureFixture) -> None:
+    """join_all logs a warning when deferred jobs remain unflushed."""
+
+    def handler(job: JobRecord) -> None:
+        pass  # implementation completes but never reaches final_verdict
+
+    manager = RepoQueueManager(handler)
+    # Issue #1 takes the lock, issue #2 gets deferred
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=1))
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=2))
+
+    with caplog.at_level(logging.WARNING, logger="dani.queue"):
+        manager.join_all()
+
+    assert any("deferred jobs" in record.message for record in caplog.records)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -151,6 +151,30 @@ def test_failed_job_releases_lock() -> None:
     ]
 
 
+def test_handler_exception_releases_lock() -> None:
+    """If the handler raises an unhandled exception, the issue lock is still released."""
+    execution_order: list[tuple[int, str]] = []
+    lock = threading.Lock()
+
+    def handler(job: JobRecord) -> None:
+        with lock:
+            execution_order.append((job.issue_number, job.stage))  # type: ignore[arg-type]
+        if job.issue_number == 1:
+            msg = "unexpected storage failure"
+            raise RuntimeError(msg)
+
+    manager = RepoQueueManager(handler)
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=1))
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=2))
+    manager.join_all()
+
+    # Issue #2 must still run even though #1's handler raised
+    assert execution_order == [
+        (1, "implementation"),
+        (2, "implementation"),
+    ]
+
+
 def test_deferred_jobs_requeued_on_terminal() -> None:
     """When active issue reaches final_verdict, deferred jobs are re-enqueued.
 


### PR DESCRIPTION
## Summary
- 한 이슈의 lifecycle(implementation → review_round → ... → final_verdict)이 완료될 때까지 다른 이슈의 branch-touching 작업을 대기시키도록 `RepoQueueManager`를 리팩토링
- Branch를 안 건드리는 stage(`dev_sync`, `issue_request`, `issue_followup`)는 lock 없이 즉시 실행
- Handler 예외, `_after_job` 예외 시에도 issue lock이 영구 잠금되지 않도록 방어 로직 추가
- `join_all()`에서 flush되지 않은 deferred job이 있으면 warning 로그 출력

## Test plan
- [x] `test_different_issues_serialized` — 다른 이슈의 impl이 인터리브되지 않는지 검증
- [x] `test_dev_sync_bypasses_issue_lock` — dev_sync가 lock을 bypass하는지 검증
- [x] `test_issue_request_not_locked` — issue_request가 lock 없이 실행되는지 검증
- [x] `test_failed_job_releases_lock` — 실패한 job이 lock을 해제하는지 검증
- [x] `test_handler_exception_releases_lock` — handler 예외 시 lock 해제 검증
- [x] `test_deferred_jobs_requeued_on_terminal` — terminal 후 deferred jobs 재투입 검증
- [x] `test_join_all_warns_on_orphaned_deferred_jobs` — orphan deferred 경고 검증
- [x] 전체 테스트 76/76 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)