### PR TITLE
Stop review/implementation cycle when PR is merged or closed

### DIFF
--- a/dani/service.py
+++ b/dani/service.py
@@ -141,6 +141,8 @@ class DaniService:
         repo = self.storage.get_repo(event.repo_full_name)
         if repo is None:
             return {"status": "ignored", "reason": "missing_repo"}
+        if not self._is_pr_open(event.repo_full_name, pr_number):
+            return {"status": "ignored", "reason": "pr_not_open"}
         pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
         next_job = self._enqueue_job(
             repo,
@@ -165,6 +167,8 @@ class DaniService:
         repo = self.storage.get_repo(event.repo_full_name)
         if repo is None:
             return {"status": "ignored", "reason": "missing_repo"}
+        if not self._is_pr_open(event.repo_full_name, pr_number):
+            return {"status": "ignored", "reason": "pr_not_open"}
         issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
         latest_review_round = self._latest_review_round(event.repo_full_name, pr_number)
         pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
@@ -202,6 +206,8 @@ class DaniService:
         if repo is None:
             return {"status": "ignored", "reason": "missing_repo"}
         pr_number = int(signature["pr"])
+        if not self._is_pr_open(event.repo_full_name, pr_number):
+            return {"status": "ignored", "reason": "pr_not_open"}
         pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
         issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
         if issue_number is None:
@@ -220,6 +226,8 @@ class DaniService:
 
     def _handle_final_verdict_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         pr_number = int(signature["pr"])
+        if not self._is_pr_open(event.repo_full_name, pr_number):
+            return {"status": "ignored", "reason": "pr_not_open"}
         try:
             self.github.merge_pull_request(event.repo_full_name, pr_number)
         except MergeConflictError as exc:
@@ -934,6 +942,10 @@ class DaniService:
                     "body": body if isinstance(body, str) else "",
                 }
         return {}
+
+    def _is_pr_open(self, repo_full_name: str, pr_number: int) -> bool:
+        pull_request = self.github.get_pull_request(repo_full_name, pr_number)
+        return pull_request.get("state") == "open"
 
     def _pull_request_metadata(self, repo_full_name: str, pr_number: int) -> dict[str, str]:
         for pull_request in self.github.list_pull_requests(repo_full_name):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -48,6 +48,7 @@ class FakeGitHubCLI:
             "number": pr_number,
             "title": f"PR #{pr_number}",
             "body": "",
+            "state": "open",
             "head": {"ref": f"Feature/#{pr_number}"},
             "base": {"ref": "dev"},
         }
@@ -97,9 +98,16 @@ class FakeGitHubCLI:
             "number": pr_number,
             "title": title or f"Feature/#{pr_number}",
             "body": body,
+            "state": "open",
             "head": {"ref": head_branch or f"Feature/#{pr_number}"},
             "base": {"ref": base_branch},
         })
+
+    def close_pull_request(self, repo_full_name: str, pr_number: int) -> None:
+        for pr in self.prs.get(repo_full_name, []):
+            if pr.get("number") == pr_number:
+                pr["state"] = "closed"
+                return
 
 
 class LaunchRecord(TypedDict):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -645,3 +645,83 @@ def test_dev_sync_conflict_launches_omx_and_cleans_up(tmp_path: Path) -> None:
     assert len(dev_syncer.verify_calls) == 1
     assert len(dev_syncer.cleanup_calls) == 1
     assert jobs[0].status == "completed"
+
+
+def test_review_round_stops_when_pr_is_closed(tmp_path: Path) -> None:
+    """Review round agent event is ignored when the PR has been closed."""
+    service, github, _ = make_service(tmp_path)
+    github.add_pull_request("acme/demo", 77, "Implements #5")
+
+    # Close the PR before the review round event arrives
+    github.close_pull_request("acme/demo", 77)
+
+    review_event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="review_round", job="r-1", pr=77, round=1, issue=5),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+    result = service.handle_event(review_event)
+    service.wait_for_idle()
+
+    assert result["status"] == "ignored"
+    assert result["reason"] == "pr_not_open"
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=77) == []
+
+
+def test_implementation_stops_when_pr_is_closed(tmp_path: Path) -> None:
+    """Implementation agent event is ignored when the PR has been closed."""
+    service, github, _ = make_service(tmp_path)
+    github.add_pull_request("acme/demo", 77, "Implements #5")
+
+    # Close the PR before the implementation event arrives
+    github.close_pull_request("acme/demo", 77)
+
+    impl_event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="implementation", job="impl-1", pr=77, issue=5),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+    result = service.handle_event(impl_event)
+    service.wait_for_idle()
+
+    assert result["status"] == "ignored"
+    assert result["reason"] == "pr_not_open"
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=77) == []
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=77) == []
+
+
+def test_final_verdict_stops_when_pr_is_closed(tmp_path: Path) -> None:
+    """Final verdict agent event is ignored when the PR has been closed."""
+    service, github, _ = make_service(tmp_path)
+    github.add_pull_request("acme/demo", 77, "Implements #5")
+
+    github.close_pull_request("acme/demo", 77)
+
+    verdict_event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="final_verdict", job="v-1", pr=77, verdict="APPROVE"),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+    result = service.handle_event(verdict_event)
+
+    assert result["status"] == "ignored"
+    assert result["reason"] == "pr_not_open"
+    assert github.merged == []


### PR DESCRIPTION
## Summary
- Fixes #17: review round / implementation / final verdict agent handlers now check PR state before enqueueing the next job
- Added `_is_pr_open()` guard in all 4 agent event handlers — returns `{"status": "ignored", "reason": "pr_not_open"}` when PR is no longer open
- 3 new tests covering review round, implementation, and final verdict stopping on closed PR

## Test plan
- [x] `uv run pytest` — 79 tests pass
- [ ] Manually close/merge a PR mid-cycle and verify no further jobs are enqueued

🤖 Generated with [Claude Code](https://claude.com/claude-code)