### PR TITLE
Drop untracked PRs to prevent feature/#0 ghost branches

### DIFF
--- a/dani/service.py
+++ b/dani/service.py
@@ -138,6 +138,8 @@ class DaniService:
         review_round = int(signature["round"])
         pr_number = int(signature["pr"])
         issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
+        if issue_number is None:
+            return {"status": "ignored", "reason": "untracked_pr"}
         repo = self.storage.get_repo(event.repo_full_name)
         if repo is None:
             return {"status": "ignored", "reason": "missing_repo"}
@@ -170,6 +172,8 @@ class DaniService:
         if not self._is_pr_open(event.repo_full_name, pr_number):
             return {"status": "ignored", "reason": "pr_not_open"}
         issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
+        if issue_number is None:
+            return {"status": "ignored", "reason": "untracked_pr"}
         latest_review_round = self._latest_review_round(event.repo_full_name, pr_number)
         pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
         if latest_review_round >= self.config.review_rounds:
@@ -871,6 +875,8 @@ class DaniService:
                 self.storage.update_job(signature["job"], status="completed", pr_number=event.number)
         if issue_number is None:
             issue_number = self._extract_issue_number(event.body)
+        if issue_number is None:
+            return {"status": "ignored", "reason": "untracked_pr"}
         job = self._enqueue_job(
             repo,
             stage="review_round",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -426,7 +426,7 @@ def test_duplicate_review_round_event_is_ignored(tmp_path: Path) -> None:
         number=77,
         actor_login="agent",
         payload={},
-        body=build_signature(stage="review_round", job="job-1", pr=77, round=1),
+        body=build_signature(stage="review_round", job="job-1", pr=77, round=1, issue=5),
         title="Feature/#5",
         is_pull_request=True,
     )
@@ -725,3 +725,73 @@ def test_final_verdict_stops_when_pr_is_closed(tmp_path: Path) -> None:
     assert result["status"] == "ignored"
     assert result["reason"] == "pr_not_open"
     assert github.merged == []
+
+
+def test_pr_opened_without_issue_reference_is_ignored(tmp_path: Path) -> None:
+    """A PR opened without any linked issue number is dropped as untracked."""
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=42,
+            actor_login="external-contributor",
+            payload={},
+            body="Some changes without issue reference",
+            title="External contribution",
+            base_branch="dev",
+            head_branch="feature/external",
+            is_pull_request=True,
+        )
+    )
+
+    assert result == {"status": "ignored", "reason": "untracked_pr"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=42) == []
+    assert omx_runner.launches == []
+
+
+def test_review_round_without_issue_drops_untracked_pr(tmp_path: Path) -> None:
+    """Review-round agent event for a PR with no traceable issue is dropped."""
+    service, _, omx_runner = make_service(tmp_path)
+
+    review_event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=42,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="review_round", job="r-1", pr=42, round=1),
+        title="External contribution",
+        is_pull_request=True,
+    )
+    result = service.handle_event(review_event)
+
+    assert result == {"status": "ignored", "reason": "untracked_pr"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=42) == []
+    assert omx_runner.launches == []
+
+
+def test_implementation_without_issue_drops_untracked_pr(tmp_path: Path) -> None:
+    """Implementation agent event for a PR with no traceable issue is dropped."""
+    service, _, omx_runner = make_service(tmp_path)
+
+    impl_event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=42,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="implementation", job="impl-1", pr=42),
+        title="External contribution",
+        is_pull_request=True,
+    )
+    result = service.handle_event(impl_event)
+
+    assert result == {"status": "ignored", "reason": "untracked_pr"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=42) == []
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=42) == []
+    assert omx_runner.launches == []


### PR DESCRIPTION
## Summary
- PRs without a traceable issue number (manual/external PRs) now return `untracked_pr` instead of entering the review→implementation cycle
- Guards added at `_handle_review_round_agent_event`, `_handle_implementation_agent_event`, and `_queue_pull_request_review`
- Prevents the `issue_number or 0` fallback from creating `feature/#0` ghost branches and infinite loops

Closes #18

## Test plan
- [x] `test_pr_opened_without_issue_reference_is_ignored` — external PR without issue ref is dropped
- [x] `test_review_round_without_issue_drops_untracked_pr` — review-round signature missing issue field is dropped
- [x] `test_implementation_without_issue_drops_untracked_pr` — implementation signature missing issue field is dropped
- [x] All 82 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)