### PR TITLE
Feature/#23

### DIFF
--- a/dani/cli.py
+++ b/dani/cli.py
@@ -78,3 +78,16 @@ def show_state(data_dir: Path = DATA_DIR_OPTION) -> None:
     """Print current dani state."""
     service = build_service(data_dir=data_dir)
     typer.echo(json.dumps(service.state_snapshot(), ensure_ascii=False, indent=2))
+
+
+@app.command("restart-issue")
+def restart_issue(
+    repo_full_name: str = FULL_NAME_ARGUMENT,
+    issue_number: int = typer.Argument(..., help="Issue number"),
+    data_dir: Path = DATA_DIR_OPTION,
+) -> None:
+    """Supersede stale issue jobs, run a fresh issue_request, and wait for completion."""
+    service = build_service(data_dir=data_dir)
+    job = service.restart_issue(repo_full_name, issue_number)
+    service.wait_for_idle()
+    typer.echo(json.dumps(job.to_dict(), ensure_ascii=False, indent=2))

--- a/dani/errors.py
+++ b/dani/errors.py
@@ -7,9 +7,22 @@ TRANSIENT_CAPACITY_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"model is currently overloaded", re.IGNORECASE),
 ]
 
+ROLLOUT_MISSING_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"thread/resume failed", re.IGNORECASE),
+    re.compile(r"no rollout found", re.IGNORECASE),
+]
+
 
 class TransientCapacityError(Exception):
     """Raised when an OMX session fails due to a transient model-capacity issue."""
+
+    def __init__(self, message: str, pattern: str) -> None:
+        super().__init__(message)
+        self.pattern = pattern
+
+
+class RolloutMissingError(Exception):
+    """Raised when a resume target rollout/session can no longer be found."""
 
     def __init__(self, message: str, pattern: str) -> None:
         super().__init__(message)
@@ -22,3 +35,11 @@ def check_transient_capacity_error(stderr_text: str) -> None:
         match = pattern.search(stderr_text)
         if match:
             raise TransientCapacityError(match.group(0), pattern.pattern)
+
+
+def check_rollout_missing_error(stderr_text: str) -> None:
+    """Raise ``RolloutMissingError`` if *stderr_text* matches known missing-rollout patterns."""
+    for pattern in ROLLOUT_MISSING_PATTERNS:
+        match = pattern.search(stderr_text)
+        if match:
+            raise RolloutMissingError(stderr_text.strip() or match.group(0), pattern.pattern)

--- a/dani/github.py
+++ b/dani/github.py
@@ -12,6 +12,7 @@ from dani.signatures import parse_signature
 
 TOKEN_ENV_VARS = ("DANI_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT")
 LOGGER = logging.getLogger(__name__)
+MERGE_CONFLICT_STATUSES = frozenset({405, 409, 422})
 
 
 class MergeConflictError(RuntimeError):
@@ -132,7 +133,9 @@ class GitHubCLI:
         try:
             merge_status = pull_request.merge(merge_method="merge", delete_branch=False)
         except GithubException as exc:
-            raise MergeConflictError(repo_full_name, pr_number, status=exc.status, message=str(exc)) from exc
+            if exc.status in MERGE_CONFLICT_STATUSES:
+                raise MergeConflictError(repo_full_name, pr_number, status=exc.status, message=str(exc)) from exc
+            raise
         if not merge_status.merged:
             raise MergeConflictError(repo_full_name, pr_number, message=merge_status.message)
         try:

--- a/dani/omx_runner.py
+++ b/dani/omx_runner.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Protocol, TextIO
 from uuid import uuid4
 
-from dani.errors import check_transient_capacity_error
+from dani.errors import check_rollout_missing_error, check_transient_capacity_error
 from dani.models import JobRecord, SessionRecord
 
 
@@ -143,6 +143,7 @@ class OmxRunner:
         if not stderr_path.exists():
             return
         stderr_text = stderr_path.read_text(encoding="utf-8", errors="replace")
+        check_rollout_missing_error(stderr_text)
         check_transient_capacity_error(stderr_text)
 
     def close_session(self, runtime_handle: str) -> None:

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -15,6 +15,9 @@ Task: review GitHub issue #$issue_number titled "$issue_title".
 Issue body:
 $issue_body
 
+Existing issue discussion history:
+$discussion
+
 Write one GitHub issue comment.
 Checklist:
 - [ ] AI-understood issue summary

--- a/dani/queue.py
+++ b/dani/queue.py
@@ -85,7 +85,7 @@ class RepoQueueManager:
     def _after_job(self, repo: str, job: JobRecord) -> None:
         if not self._needs_issue_lock(job):
             return
-        if job.stage in _TERMINAL_STAGES or job.status == "failed":
+        if job.stage in _TERMINAL_STAGES or job.status in {"failed", "superseded"}:
             self._flush_deferred(repo)
 
     def _flush_deferred(self, repo: str) -> None:

--- a/dani/service.py
+++ b/dani/service.py
@@ -226,10 +226,13 @@ class DaniService:
     def _handle_merge_conflict_resolution_agent_event(
         self, event: NormalizedEvent, signature: dict[str, str]
     ) -> dict[str, Any]:
+        pr_number = int(signature["pr"])
+        event_key = self._agent_event_key(signature, default_pr=pr_number)
+        if not self.storage.record_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_agent_event"}
         repo = self.storage.get_repo(event.repo_full_name)
         if repo is None:
             return {"status": "ignored", "reason": "missing_repo"}
-        pr_number = int(signature["pr"])
         if not self._is_pr_open(event.repo_full_name, pr_number):
             return {"status": "ignored", "reason": "pr_not_open"}
         pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
@@ -250,6 +253,9 @@ class DaniService:
 
     def _handle_final_verdict_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         pr_number = int(signature["pr"])
+        event_key = self._agent_event_key(signature, default_pr=pr_number)
+        if not self.storage.record_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_agent_event"}
         if not self._is_pr_open(event.repo_full_name, pr_number):
             return {"status": "ignored", "reason": "pr_not_open"}
         try:

--- a/dani/service.py
+++ b/dani/service.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from dani.errors import TransientCapacityError
+from dani.errors import ROLLOUT_MISSING_PATTERNS, RolloutMissingError, TransientCapacityError
 from dani.git_sync import DevSyncConflictError, GitDevSyncer
 from dani.github import GitHubCLI, MergeConflictError
 from dani.models import DaniConfig, JobRecord, NormalizedEvent, RepoConfig, SessionRecord, utc_now
@@ -75,6 +75,26 @@ class DaniService:
 
     def state_snapshot(self) -> dict[str, Any]:
         return self.storage.snapshot()
+
+    def restart_issue(self, repo_full_name: str, issue_number: int) -> JobRecord:
+        repo = self.storage.get_repo(repo_full_name)
+        if repo is None:
+            msg = f"missing_repo: {repo_full_name}"
+            raise RuntimeError(msg)
+
+        for job in self.storage.find_jobs(repo_full_name=repo_full_name, issue_number=issue_number):
+            self.storage.update_job(job.id, status="superseded")
+
+        issue_metadata = self._issue_metadata(repo_full_name, issue_number)
+        return self._enqueue_job(
+            repo,
+            stage="issue_request",
+            issue_number=issue_number,
+            metadata={
+                "title": issue_metadata.get("title", f"Issue #{issue_number}"),
+                "body": issue_metadata.get("body", ""),
+            },
+        )
 
     def handle_event(self, event: NormalizedEvent) -> dict[str, Any]:
         self.storage.append_event({
@@ -278,6 +298,11 @@ class DaniService:
         return job
 
     def _run_job(self, job: JobRecord) -> None:
+        stored_job = self.storage.get_job(job.id)
+        if stored_job is not None and stored_job.status == "superseded":
+            job.status = "superseded"
+            return
+
         repo = self.storage.get_repo(job.repo_full_name)
         if repo is None:
             self.storage.update_job(job.id, status="failed", metadata={**job.metadata, "error": "missing repo"})
@@ -393,16 +418,18 @@ class DaniService:
         attempt: int,
         retry_history: list[dict[str, str]],
     ) -> None:
-        self.storage.update_job(
-            job.id,
-            status="failed",
-            metadata={
-                **job.metadata,
-                "error": str(exc),
-                "retry_attempts": attempt - 1,
-                "retry_history": retry_history,
-            },
-        )
+        metadata = {
+            **job.metadata,
+            "error": str(exc),
+            "retry_attempts": attempt - 1,
+            "retry_history": retry_history,
+        }
+        if self._is_rollout_missing_error(exc):
+            metadata["error"] = "rollout_missing"
+            metadata["error_detail"] = str(exc)
+            with contextlib.suppress(Exception):
+                self._post_session_lost_warning(job)
+        self.storage.update_job(job.id, status="failed", metadata=metadata)
 
     def _run_dev_sync_job(self, repo: RepoConfig, job: JobRecord) -> None:
         session = None
@@ -531,6 +558,7 @@ class DaniService:
                 "issue_number": issue_number,
                 "issue_title": issue_title,
                 "issue_body": issue_body,
+                "discussion": self._render_issue_discussion(repo.full_name, issue_number),
                 "signature": build_signature(stage="issue_request", job=job.id, issue=issue_number),
             },
         )
@@ -709,12 +737,13 @@ class DaniService:
         )
 
     def _verify_issue_request_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
-        if self.github.latest_signature_comment(repo.full_name, int(job.issue_number or 0), kind="issue") is None:
+        signature = build_signature(stage="issue_request", job=job.id, issue=int(job.issue_number or 0))
+        if not self._has_exact_issue_signature(repo.full_name, int(job.issue_number or 0), signature):
             raise RuntimeError("issue-request-comment-missing")
 
     def _verify_issue_followup_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
-        latest_comment = self.github.latest_signature_comment(repo.full_name, int(job.issue_number or 0), kind="issue")
-        if latest_comment is None or latest_comment[1].get("stage") != "issue_followup":
+        signature = build_signature(stage="issue_followup", job=job.id, issue=int(job.issue_number or 0))
+        if not self._has_exact_issue_signature(repo.full_name, int(job.issue_number or 0), signature):
             raise RuntimeError("issue-followup-comment-missing")
 
     def _verify_implementation_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
@@ -774,6 +803,13 @@ class DaniService:
     def _has_exact_pr_signature(self, repo_full_name: str, pr_number: int, signature: str) -> bool:
         return bool(
             self.github.find_comments_by_signature(repo_full_name, pr_number, kind="pr", signature_fragment=signature)
+        )
+
+    def _has_exact_issue_signature(self, repo_full_name: str, issue_number: int, signature: str) -> bool:
+        return bool(
+            self.github.find_comments_by_signature(
+                repo_full_name, issue_number, kind="issue", signature_fragment=signature
+            )
         )
 
     def _is_approve_comment(self, body: str | None) -> bool:
@@ -973,3 +1009,44 @@ class DaniService:
             author = comment.get("user", {}).get("login") or comment.get("author", {}).get("login") or "unknown"
             rendered.append(f"[{author}]\n{body}")
         return "\n\n".join(rendered)
+
+    def _render_issue_discussion(self, repo_full_name: str, issue_number: int, *, limit: int = 8) -> str:
+        comments = self.github.issue_comments(repo_full_name, issue_number)
+        rendered: list[str] = []
+        for comment in comments[-limit:]:
+            body = str(comment.get("body") or "").strip()
+            if not body:
+                continue
+            author = comment.get("user", {}).get("login") or comment.get("author", {}).get("login") or "unknown"
+            rendered.append(f"[{author}]\n{body}")
+        return "\n\n".join(rendered)
+
+    def _is_rollout_missing_error(self, exc: Exception) -> bool:
+        if isinstance(exc, RolloutMissingError):
+            return True
+        error_text = str(exc)
+        return any(pattern.search(error_text) for pattern in ROLLOUT_MISSING_PATTERNS)
+
+    def _post_session_lost_warning(self, job: JobRecord) -> None:
+        if job.stage != "issue_followup" or job.issue_number is None:
+            return
+        event_key = f"repo={job.repo_full_name};stage=session_lost;issue={job.issue_number}"
+        signature = build_signature(stage="session_lost", issue=job.issue_number)
+        if self.github.find_comments_by_signature(
+            job.repo_full_name,
+            job.issue_number,
+            kind="issue",
+            signature_fragment=signature,
+        ):
+            if not self.storage.has_processed_event(event_key):
+                self.storage.record_processed_event(event_key)
+            return
+        if self.storage.has_processed_event(event_key):
+            return
+        body = (
+            "⚠️ dani 세션 기록이 유실되어 이전 대화를 이어갈 수 없습니다. "
+            f"`dani restart-issue {job.repo_full_name} {job.issue_number}` 로 새 세션을 시작해 주세요.\n\n"
+            f"{signature}"
+        )
+        self.github.create_issue_comment(job.repo_full_name, job.issue_number, body)
+        self.storage.record_processed_event(event_key)

--- a/dani/service.py
+++ b/dani/service.py
@@ -259,10 +259,13 @@ class DaniService:
             if repo is None:
                 return {"status": "ignored", "reason": "missing_repo"}
             pull_request = self.github.get_pull_request(event.repo_full_name, pr_number)
+            issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
+            if issue_number is None:
+                issue_number = self._extract_issue_number(pull_request.get("body"))
             merge_conflict_job = self._enqueue_job(
                 repo,
                 stage="merge_conflict_resolution",
-                issue_number=self._extract_issue_number(pull_request.get("body")),
+                issue_number=issue_number,
                 pr_number=pr_number,
                 metadata={
                     "title": pull_request.get("title") or event.title or f"PR #{pr_number}",

--- a/dani/service.py
+++ b/dani/service.py
@@ -254,7 +254,7 @@ class DaniService:
     def _handle_final_verdict_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         pr_number = int(signature["pr"])
         event_key = self._agent_event_key(signature, default_pr=pr_number)
-        if not self.storage.record_processed_event(event_key):
+        if self.storage.has_processed_event(event_key):
             return {"status": "ignored", "reason": "duplicate_agent_event"}
         if not self._is_pr_open(event.repo_full_name, pr_number):
             return {"status": "ignored", "reason": "pr_not_open"}
@@ -281,7 +281,9 @@ class DaniService:
                     "conflict_reason": str(exc),
                 },
             )
+            self.storage.record_processed_event(event_key)
             return {"status": "queued", "job_id": merge_conflict_job.id, "stage": merge_conflict_job.stage}
+        self.storage.record_processed_event(event_key)
         return {"status": "merged", "pr_number": pr_number}
 
     def _enqueue_job(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -84,6 +84,16 @@ class FakeGitHubCLI:
     def add_pr_signature(self, repo_full_name: str, pr_number: int, signature: str) -> None:
         self.pr_comment_map.setdefault((repo_full_name, pr_number), []).append({"body": signature})
 
+    def create_issue_comment(self, repo_full_name: str, issue_number: int, body: str) -> dict[str, Any]:
+        comment = {"body": body}
+        self.issue_comment_map.setdefault((repo_full_name, issue_number), []).append(comment)
+        return comment
+
+    def create_pr_comment(self, repo_full_name: str, pr_number: int, body: str) -> dict[str, Any]:
+        comment = {"body": body}
+        self.pr_comment_map.setdefault((repo_full_name, pr_number), []).append(comment)
+        return comment
+
     def add_pull_request(
         self,
         repo_full_name: str,
@@ -130,10 +140,14 @@ class FakeOmxRunner:
         self.resumes: list[ResumeRecord] = []
         self.closed_sessions: list[str] = []
         self._transient_failures_remaining: int = 0
+        self.resume_error: Exception | None = None
 
     def set_transient_failures(self, count: int) -> None:
         """Configure the runner to raise TransientCapacityError for the next *count* wait() calls."""
         self._transient_failures_remaining = count
+
+    def set_resume_failure(self, exc: Exception) -> None:
+        self.resume_error = exc
 
     def launch(self, repo_path: Path, job: JobRecord, prompt: str) -> SessionRecord:
         repo_full_name = job.repo_full_name
@@ -201,6 +215,8 @@ class FakeOmxRunner:
             )
 
     def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
+        if self.resume_error is not None:
+            raise self.resume_error
         issue_number = job.issue_number or 0
         self.github.add_issue_signature(
             job.repo_full_name,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from typer.testing import CliRunner
 
 import dani.cli as cli_module
 from dani.cli import app
+from dani.models import JobRecord
 
 
 class FakeBootstrapService:
@@ -15,6 +16,18 @@ class FakeBootstrapService:
     def bootstrap_repo(self, repo_full_name: str) -> int:
         self.calls.append(("bootstrap_repo", repo_full_name))
         return self.count
+
+    def wait_for_idle(self) -> None:
+        self.calls.append(("wait_for_idle", None))
+
+
+class FakeRestartService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, int] | tuple[str, None]] = []
+
+    def restart_issue(self, repo_full_name: str, issue_number: int) -> JobRecord:
+        self.calls.append(("restart_issue", repo_full_name, issue_number))
+        return JobRecord(repo_full_name=repo_full_name, stage="issue_request", issue_number=issue_number, id="job-123")
 
     def wait_for_idle(self) -> None:
         self.calls.append(("wait_for_idle", None))
@@ -44,3 +57,19 @@ def test_bootstrap_waits_for_idle_before_exiting(tmp_path: Path, monkeypatch) ->
     assert result.exit_code == 0
     assert fake_service.calls == [("bootstrap_repo", "acme/demo"), ("wait_for_idle", None)]
     assert result.stdout.strip() == "processed 2 issues"
+
+
+def test_restart_issue_invokes_service_waits_for_idle_and_prints_job(tmp_path: Path, monkeypatch) -> None:
+    runner = CliRunner()
+    data_dir = tmp_path / ".dani"
+    fake_service = FakeRestartService()
+    monkeypatch.setattr(cli_module, "build_service", lambda data_dir: fake_service)
+
+    result = runner.invoke(app, ["restart-issue", "acme/demo", "41", "--data-dir", str(data_dir)])
+
+    assert result.exit_code == 0
+    assert fake_service.calls == [("restart_issue", "acme/demo", 41), ("wait_for_idle", None)]
+    payload = json.loads(result.stdout)
+    assert payload["id"] == "job-123"
+    assert payload["stage"] == "issue_request"
+    assert payload["issue_number"] == 41

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -218,6 +218,16 @@ def test_merge_pull_request_raises_merge_conflict_error_for_merge_api_failures(
     assert exc_info.value.status == status
 
 
+def test_merge_pull_request_reraises_non_conflict_github_failures(fake_repo: FakeRepo) -> None:
+    fake_repo.pulls[7].merge_exception = GithubException(500, {"message": "GitHub outage"}, {})
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    with pytest.raises(GithubException) as exc_info:
+        github.merge_pull_request("acme/demo", 7)
+
+    assert exc_info.value.status == 500
+
+
 def test_merge_pull_request_raises_merge_conflict_error_when_merge_status_is_false(fake_repo: FakeRepo) -> None:
     fake_repo.pulls[7].merge_status = FakeMergeStatus(merged=False, message="Pull Request is not mergeable")
     github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))

--- a/tests/test_omx_runner.py
+++ b/tests/test_omx_runner.py
@@ -4,6 +4,9 @@ import json
 import time
 from pathlib import Path
 
+import pytest
+
+from dani.errors import RolloutMissingError
 from dani.omx_runner import OmxRunner
 from dani.signatures import build_signature
 
@@ -102,3 +105,37 @@ def test_build_resume_script_uses_omx_exec_resume(tmp_path: Path) -> None:
     )
 
     assert "omx exec resume session-123 --dangerously-bypass-approvals-and-sandbox" in script
+
+
+def test_wait_raises_rollout_missing_error_when_resume_stderr_mentions_no_rollout_found(tmp_path: Path) -> None:
+    runner = OmxRunner(run_dir=tmp_path / "runs")
+    runtime_handle = "runtime-123"
+    runtime_dir = runner.run_dir / runtime_handle
+    runtime_dir.mkdir(parents=True)
+    stdout_path = tmp_path / "stdout.log"
+    stderr_path = runtime_dir / "stderr.log"
+    stdout_path.write_text("", encoding="utf-8")
+    stderr_path.write_text(
+        "Error: thread/resume failed: no rollout found for thread id 019d6829",
+        encoding="utf-8",
+    )
+    stdout_file = stdout_path.open("w", encoding="utf-8")
+    stderr_file = stderr_path.open("a", encoding="utf-8")
+    process = type(
+        "Process",
+        (),
+        {
+            "poll": lambda self: 1,
+            "terminate": lambda self: None,
+            "wait": lambda self, timeout=None: 1,
+            "kill": lambda self: None,
+        },
+    )()
+    runner._processes[runtime_handle] = (process, stdout_file, stderr_file)
+
+    try:
+        with pytest.raises(RolloutMissingError, match="no rollout found"):
+            runner.wait(runtime_handle)
+    finally:
+        stdout_file.close()
+        stderr_file.close()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -77,6 +77,7 @@ def test_issue_request_prompt_uses_gh_instructions() -> None:
             "issue_number": 7,
             "issue_title": "Need a bot",
             "issue_body": "Implement it",
+            "discussion": "",
             "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
         },
     )
@@ -94,12 +95,31 @@ def test_issue_request_prompt_requires_ai_summary_and_expected_outcome() -> None
             "issue_number": 7,
             "issue_title": "Need a bot",
             "issue_body": "Implement it",
+            "discussion": "",
             "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
         },
     )
 
     assert "AI-understood issue summary" in prompt
     assert "Expected Outcome" in prompt
+
+
+def test_issue_request_prompt_includes_existing_discussion_history() -> None:
+    prompt = render_prompt(
+        "issue_request",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "[human]\nEarlier context",
+            "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
+        },
+    )
+
+    assert "Existing issue discussion history" in prompt
+    assert "Earlier context" in prompt
 
 
 def test_review_round_prompt_requires_code_review_and_verification() -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -154,6 +154,28 @@ def test_failed_job_releases_lock() -> None:
     ]
 
 
+def test_superseded_job_releases_lock() -> None:
+    """A superseded locked job releases the issue lock so other issues can proceed."""
+    execution_order: list[tuple[int, str, str]] = []
+    lock = threading.Lock()
+
+    def handler(job: JobRecord) -> None:
+        with lock:
+            execution_order.append((job.issue_number, job.stage, job.status))  # type: ignore[arg-type]
+        if job.issue_number == 1:
+            job.status = "superseded"
+
+    manager = RepoQueueManager(handler)
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=1))
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=2))
+    manager.join_all()
+
+    assert execution_order == [
+        (1, "implementation", "queued"),
+        (2, "implementation", "queued"),
+    ]
+
+
 def test_handler_exception_releases_lock() -> None:
     """If the handler raises an unhandled exception, the issue lock is still released."""
     execution_order: list[tuple[int, str]] = []

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -187,3 +187,33 @@ def test_transient_error_with_side_effect_already_posted_completes(mock_sleep: o
     assert job.metadata.get("note") == "side_effect_already_posted"
     # Should NOT have retried — only 1 launch
     assert len(omx_runner.launches) == 1
+
+
+@patch("dani.service.time.sleep")
+def test_restart_issue_request_with_stale_signed_comments_does_not_false_complete_on_transient(
+    mock_sleep: object, tmp_path: Path
+) -> None:
+    service, github, _ = make_service(tmp_path)
+    stale_signature = "<!-- dani:stage=issue_request;job=stale-job;issue=11 -->"
+    github.add_issue_signature("acme/demo", 11, stale_signature)
+
+    original_launch = service.omx_runner.launch
+
+    def launch_without_new_side_effect(repo_path: Path, job, prompt: str):
+        session = original_launch(repo_path, job, prompt)
+        github.issue_comment_map[("acme/demo", 11)] = [{"body": stale_signature}]
+        return session
+
+    service.omx_runner.launch = launch_without_new_side_effect  # type: ignore[assignment]
+
+    def wait_that_always_fails(runtime_handle: str, **kwargs: object) -> None:
+        raise TransientCapacityError(_CAPACITY_MSG, _CAPACITY_MSG)
+
+    service.omx_runner.wait = wait_that_always_fails  # type: ignore[assignment]
+
+    service.handle_event(_issue_event())
+    service.wait_for_idle()
+
+    job = service.storage.list_jobs()[0]
+    assert job.status == "failed"
+    assert job.metadata.get("note") != "side_effect_already_posted"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -611,6 +611,53 @@ def test_approve_verdict_with_merge_conflict_queues_resolution_job(tmp_path: Pat
     assert github.merged == []
 
 
+def test_approve_verdict_with_merge_conflict_reuses_tracked_issue_number_without_pr_body_reference(
+    tmp_path: Path,
+) -> None:
+    service, github, _ = make_service(tmp_path)
+    github.merge_conflicts.add(("acme/demo", 77))
+    service.storage.create_job(
+        JobRecord(
+            repo_full_name="acme/demo",
+            stage="review_round",
+            issue_number=5,
+            pr_number=77,
+            review_round=1,
+            status="completed",
+        )
+    )
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "No issue reference in body",
+        title="Feature without issue in body",
+        head_branch="feature/no-issue",
+        base_branch="dev",
+    )
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=77,
+            actor_login="agent",
+            payload={},
+            body=build_signature(stage="final_verdict", job="verdict-1", pr=77, verdict="APPROVE"),
+            title="Feature without issue in body",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    resolution_jobs = service.storage.find_jobs(
+        repo_full_name="acme/demo", stage="merge_conflict_resolution", pr_number=77
+    )
+    assert result["stage"] == "merge_conflict_resolution"
+    assert resolution_jobs[0].issue_number == 5
+    assert resolution_jobs[0].metadata["head_branch"] == "feature/no-issue"
+
+
 def test_merge_conflict_resolution_comment_queues_final_verdict_retry(tmp_path: Path) -> None:
     service, github, omx_runner = make_service(tmp_path)
     pr_body = "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -878,6 +878,50 @@ def test_duplicate_final_verdict_event_is_ignored(tmp_path: Path) -> None:
     assert omx_runner.launches[-1]["job"].pr_number == 77
 
 
+def test_final_verdict_transient_failure_allows_redelivery(tmp_path: Path) -> None:
+    """A transient merge failure must not poison redelivery — the retry must succeed."""
+    from github.GithubException import GithubException
+
+    service, github, _omx_runner = make_service(tmp_path)
+    service.storage.create_job(
+        JobRecord(repo_full_name="acme/demo", stage="review_round", issue_number=5, pr_number=77, review_round=1, status="completed")
+    )
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->",
+        title="Feature/#5",
+        head_branch="feature/5",
+        base_branch="dev",
+    )
+    original_merge = github.merge_pull_request
+
+    def boom(repo_full_name: str, pr_number: int) -> None:
+        raise GithubException(500, {"message": "GitHub outage"}, {})
+
+    github.merge_pull_request = boom  # type: ignore[assignment]
+    event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="final_verdict", job="verdict-1", pr=77, verdict="APPROVE"),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+
+    with pytest.raises(GithubException):
+        service.handle_event(event)
+
+    # Restore normal merge and redeliver the same event
+    github.merge_pull_request = original_merge  # type: ignore[assignment]
+    result = service.handle_event(event)
+    assert result["status"] == "merged"
+    assert ("acme/demo", 77) in github.merged
+
+
 def test_bootstrap_repo_queues_existing_open_issues(tmp_path: Path) -> None:
     service, github, omx_runner = make_service(tmp_path)
     github.open_issues["acme/demo"] = [

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -694,6 +694,41 @@ def test_merge_conflict_resolution_comment_queues_final_verdict_retry(tmp_path: 
     assert omx_runner.launches[-1]["job"].stage == "final_verdict"
 
 
+def test_duplicate_merge_conflict_resolution_event_is_ignored(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->",
+        title="Feature/#5",
+        head_branch="Feature/#5",
+        base_branch="dev",
+    )
+    event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="merge_conflict_resolution", job="resolve-1", pr=77),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+
+    first = service.handle_event(event)
+    service.wait_for_idle()
+    second = service.handle_event(event)
+    service.wait_for_idle()
+
+    verdict_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=77)
+    assert first["status"] == "queued"
+    assert second == {"status": "ignored", "reason": "duplicate_agent_event"}
+    assert len(verdict_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+    assert omx_runner.launches[-1]["job"].pr_number == 77
+
+
 def test_merge_conflict_resolution_requires_its_own_signed_comment(tmp_path: Path) -> None:
     service, github, _ = make_service(tmp_path)
     repo = service.storage.get_repo("acme/demo")
@@ -803,6 +838,44 @@ def test_final_verdict_verification_rejects_unrelated_signed_comment(tmp_path: P
 
     with pytest.raises(RuntimeError, match="final-verdict-comment-missing"):
         service._verify_side_effect(repo, job)
+
+
+def test_duplicate_final_verdict_event_is_ignored(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.merge_conflicts.add(("acme/demo", 77))
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->",
+        title="Feature/#5",
+        head_branch="Feature/#5",
+        base_branch="dev",
+    )
+    event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="final_verdict", job="verdict-1", pr=77, verdict="APPROVE"),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+
+    first = service.handle_event(event)
+    service.wait_for_idle()
+    second = service.handle_event(event)
+    service.wait_for_idle()
+
+    resolution_jobs = service.storage.find_jobs(
+        repo_full_name="acme/demo", stage="merge_conflict_resolution", pr_number=77
+    )
+    assert first["status"] == "queued"
+    assert second == {"status": "ignored", "reason": "duplicate_agent_event"}
+    assert len(resolution_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "merge_conflict_resolution"
+    assert omx_runner.launches[-1]["job"].pr_number == 77
 
 
 def test_bootstrap_repo_queues_existing_open_issues(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3,6 +3,7 @@ from typing import cast
 
 import pytest
 
+from dani.errors import RolloutMissingError
 from dani.github import GitHubCLI
 from dani.models import DaniConfig, JobRecord, NormalizedEvent
 from dani.omx_runner import OmxRunner
@@ -51,6 +52,29 @@ def test_issue_request_persists_omx_session_id(tmp_path: Path) -> None:
 
     session = service.storage.list_sessions()[0]
     assert session.omx_session_id == "omx-" + session.job_id
+
+
+def test_issue_request_verification_requires_exact_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_request", issue_number=21)
+    expected_signature = build_signature(stage="issue_request", job=job.id, issue=21)
+    github.add_issue_signature("acme/demo", 21, build_signature(stage="issue_request", job="stale-job", issue=21))
+    github.add_issue_signature("acme/demo", 21, expected_signature)
+
+    service._verify_side_effect(repo, job)
+
+
+def test_issue_request_verification_rejects_stale_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_request", issue_number=21)
+    github.add_issue_signature("acme/demo", 21, build_signature(stage="issue_request", job="stale-job", issue=21))
+
+    with pytest.raises(RuntimeError, match="issue-request-comment-missing"):
+        service._verify_side_effect(repo, job)
 
 
 def test_issue_opened_queues_issue_request(tmp_path: Path) -> None:
@@ -134,6 +158,250 @@ def test_general_issue_comment_without_existing_issue_session_is_ignored(tmp_pat
 
     assert result == {"status": "ignored", "reason": "missing_issue_session"}
     assert omx_runner.resumes == []
+
+
+def test_issue_followup_verification_requires_exact_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_followup", issue_number=31)
+    expected_signature = build_signature(stage="issue_followup", job=job.id, issue=31)
+    github.add_issue_signature("acme/demo", 31, build_signature(stage="issue_followup", job="stale-job", issue=31))
+    github.add_issue_signature("acme/demo", 31, expected_signature)
+
+    service._verify_side_effect(repo, job)
+
+
+def test_issue_followup_verification_rejects_stale_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_followup", issue_number=31)
+    github.add_issue_signature("acme/demo", 31, build_signature(stage="issue_followup", job="stale-job", issue=31))
+
+    with pytest.raises(RuntimeError, match="issue-followup-comment-missing"):
+        service._verify_side_effect(repo, job)
+
+
+def test_issue_followup_rollout_missing_marks_job_failed_and_posts_restart_warning(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=33,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    omx_runner.set_resume_failure(
+        RolloutMissingError(
+            "thread/resume failed: no rollout found for thread id 019d6829",
+            "no rollout found",
+        )
+    )
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=33,
+            actor_login="human",
+            payload={"issue": {"body": "Need automation"}},
+            body="Please continue.",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    job = service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=33)[0]
+    assert job.status == "failed"
+    assert job.metadata["error"] == "rollout_missing"
+    assert "thread/resume failed" in job.metadata["error_detail"]
+
+    warning_signature = build_signature(stage="session_lost", issue=33)
+    warning_comments = github.find_comments_by_signature(
+        "acme/demo", 33, kind="issue", signature_fragment=warning_signature
+    )
+    assert len(warning_comments) == 1
+    assert "dani restart-issue acme/demo 33" in warning_comments[0]["body"]
+    latest_comment = github.latest_signature_comment("acme/demo", 33, kind="issue")
+    assert latest_comment is not None
+    assert latest_comment[1]["stage"] == "session_lost"
+    assert latest_comment[1]["issue"] == "33"
+
+
+def test_issue_followup_rollout_missing_warning_comment_is_posted_only_once(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=34,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+    omx_runner.set_resume_failure(
+        RolloutMissingError(
+            "thread/resume failed: no rollout found for thread id 019d6829",
+            "no rollout found",
+        )
+    )
+
+    event = NormalizedEvent(
+        kind="issue_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=34,
+        actor_login="human",
+        payload={"issue": {"body": "Need automation"}},
+        body="Please continue.",
+        title="Need automation",
+    )
+
+    service.handle_event(event)
+    service.wait_for_idle()
+    service.handle_event(event)
+    service.wait_for_idle()
+
+    warning_comments = github.find_comments_by_signature(
+        "acme/demo",
+        34,
+        kind="issue",
+        signature_fragment=build_signature(stage="session_lost", issue=34),
+    )
+    assert len(warning_comments) == 1
+    matching_keys = [
+        key
+        for key in service.storage.snapshot()["processed_events"]["keys"]
+        if "stage=session_lost" in key and "issue=34" in key
+    ]
+    assert len(matching_keys) == 1
+    failed_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=34)
+    assert len(failed_jobs) == 2
+    assert all(job.status == "failed" for job in failed_jobs)
+
+
+def test_issue_followup_rollout_missing_retries_warning_after_comment_post_failure(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=35,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+    omx_runner.set_resume_failure(
+        RolloutMissingError(
+            "thread/resume failed: no rollout found for thread id 019d6829",
+            "no rollout found",
+        )
+    )
+
+    original_create_issue_comment = github.create_issue_comment
+    attempts = 0
+
+    def flaky_create_issue_comment(repo_full_name: str, issue_number: int, body: str) -> dict[str, object]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            msg = "temporary GitHub failure"
+            raise RuntimeError(msg)
+        return original_create_issue_comment(repo_full_name, issue_number, body)
+
+    github.create_issue_comment = flaky_create_issue_comment  # type: ignore[assignment]
+
+    event = NormalizedEvent(
+        kind="issue_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=35,
+        actor_login="human",
+        payload={"issue": {"body": "Need automation"}},
+        body="Please continue.",
+        title="Need automation",
+    )
+
+    service.handle_event(event)
+    service.wait_for_idle()
+    service.handle_event(event)
+    service.wait_for_idle()
+
+    warning_comments = github.find_comments_by_signature(
+        "acme/demo",
+        35,
+        kind="issue",
+        signature_fragment=build_signature(stage="session_lost", issue=35),
+    )
+    assert attempts == 2
+    assert len(warning_comments) == 1
+    matching_keys = [
+        key
+        for key in service.storage.snapshot()["processed_events"]["keys"]
+        if "stage=session_lost" in key and "issue=35" in key
+    ]
+    assert len(matching_keys) == 1
+
+
+def test_restart_issue_supersedes_existing_jobs_and_enqueues_new_issue_request(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    service.queue_manager.submit = lambda job: None  # type: ignore[assignment]
+    stale_request = JobRecord(
+        repo_full_name="acme/demo",
+        stage="issue_request",
+        issue_number=41,
+        status="completed",
+        metadata={"title": "Restart me", "body": "Original body"},
+    )
+    stale_followup = JobRecord(
+        repo_full_name="acme/demo",
+        stage="issue_followup",
+        issue_number=41,
+        status="failed",
+        metadata={"omx_session_id": "omx-stale", "title": "Restart me", "body": "Original body"},
+    )
+    untouched = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=99, status="completed")
+    service.storage.create_job(stale_request)
+    service.storage.create_job(stale_followup)
+    service.storage.create_job(untouched)
+    github.issue_comment_map[("acme/demo", 41)] = [
+        {"body": "Earlier user context", "user": {"login": "human"}},
+        {"body": "Earlier dani reply", "user": {"login": "dani"}},
+    ]
+
+    new_job = service.restart_issue("acme/demo", 41)
+
+    refreshed_request = service.storage.get_job(stale_request.id)
+    refreshed_followup = service.storage.get_job(stale_followup.id)
+    untouched_job = service.storage.get_job(untouched.id)
+    assert refreshed_request is not None and refreshed_request.status == "superseded"
+    assert refreshed_followup is not None and refreshed_followup.status == "superseded"
+    assert untouched_job is not None and untouched_job.status == "completed"
+    assert new_job.stage == "issue_request"
+    assert new_job.status == "queued"
+    assert new_job.issue_number == 41
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    prompt = service._build_prompt(repo, new_job)
+    assert "Earlier user context" in prompt
+    assert "Earlier dani reply" in prompt
 
 
 def test_approve_comment_queues_implementation(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -884,7 +884,14 @@ def test_final_verdict_transient_failure_allows_redelivery(tmp_path: Path) -> No
 
     service, github, _omx_runner = make_service(tmp_path)
     service.storage.create_job(
-        JobRecord(repo_full_name="acme/demo", stage="review_round", issue_number=5, pr_number=77, review_round=1, status="completed")
+        JobRecord(
+            repo_full_name="acme/demo",
+            stage="review_round",
+            issue_number=5,
+            pr_number=77,
+            review_round=1,
+            status="completed",
+        )
     )
     github.add_pull_request(
         "acme/demo",


### PR DESCRIPTION
<!-- dani:stage=implementation;job=2bf9a89c793b4ee0913d4099b2d6c22e;issue=23 -->

## Summary
- fail issue follow-up jobs honestly when OMX resume loses its rollout/session and post a deduped recovery warning
- add `dani restart-issue <repo> <num>` to supersede stale issue jobs and enqueue a fresh issue request with prior issue discussion in prompt context
- harden exact issue signature verification and release queue locks when superseded jobs are skipped

## Verification
- `uv run pytest`
- `uv run ruff check .`
- `uv run ty check`
- manual `restart_issue` service verification for `['superseded', 'superseded', 'queued']`
