### PR TITLE
Feature/#22

### DIFF
--- a/dani/github.py
+++ b/dani/github.py
@@ -84,7 +84,11 @@ class GitHubCLI:
         comments = (
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
-        return [comment for comment in comments if signature_fragment in (comment.get("body") or "")]
+        return [
+            comment
+            for comment in comments
+            if not is_opt_out_comment(comment.get("body", "")) and signature_fragment in (comment.get("body") or "")
+        ]
 
     def create_issue_comment(self, repo_full_name: str, issue_number: int, body: str) -> dict[str, Any]:
         issue = self._repo(repo_full_name).get_issue(issue_number)

--- a/dani/github.py
+++ b/dani/github.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from github import Auth, Github
 
-from dani.signatures import parse_signature
+from dani.signatures import is_opt_out_comment, parse_agent_signature
 
 TOKEN_ENV_VARS = ("DANI_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT")
 
@@ -71,7 +71,9 @@ class GitHubCLI:
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
         for comment in reversed(comments):
-            parsed = parse_signature(comment.get("body", ""))
+            if is_opt_out_comment(comment.get("body", "")):
+                continue
+            parsed = parse_agent_signature(comment.get("body", ""))
             if parsed is not None:
                 return comment, parsed
         return None

--- a/dani/service.py
+++ b/dani/service.py
@@ -10,7 +10,7 @@ from dani.models import DaniConfig, JobRecord, NormalizedEvent, RepoConfig, Sess
 from dani.omx_runner import OmxRunner
 from dani.prompts import render_prompt
 from dani.queue import RepoQueueManager
-from dani.signatures import build_signature, parse_signature
+from dani.signatures import build_signature, is_opt_out_comment, parse_signature
 from dani.storage import JsonStorage
 
 ISSUE_REF_PATTERN = re.compile(r"#(?P<number>\d+)")
@@ -85,6 +85,9 @@ class DaniService:
         repo = self.storage.get_repo(event.repo_full_name)
         if repo is None or not repo.enabled:
             return {"status": "ignored", "reason": "unregistered_repo"}
+
+        if event.kind in {"issue_comment", "pull_request_comment"} and is_opt_out_comment(event.body):
+            return {"status": "ignored", "reason": "comment_opt_out"}
 
         signature = parse_signature(event.body or "")
         if signature and event.kind != "pull_request_opened":

--- a/dani/signatures.py
+++ b/dani/signatures.py
@@ -3,6 +3,18 @@ from __future__ import annotations
 import re
 
 SIGNATURE_PATTERN = re.compile(r"<!--\s*(?:dani|DANI):\s*(?P<body>[^>]+)\s*-->")
+IGNORE_COMMAND_PATTERN = re.compile(r"(?mi)(?:^|\s)/dani\s+ignore(?:\s|$)")
+
+
+def _parse_signature_body(raw_body: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    parts = raw_body.split(";") if ";" in raw_body else raw_body.split()
+    for item in parts:
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        fields[key.strip()] = value.strip()
+    return fields
 
 
 def build_signature(**fields: object) -> str:
@@ -21,16 +33,30 @@ def parse_signature(text: str | None) -> dict[str, str] | None:
     match = SIGNATURE_PATTERN.search(text)
     if not match:
         return None
-    fields: dict[str, str] = {}
-    raw_body = match.group("body")
-    parts = raw_body.split(";") if ";" in raw_body else raw_body.split()
-    for item in parts:
-        if "=" not in item:
-            continue
-        key, value = item.split("=", 1)
-        fields[key.strip()] = value.strip()
+    fields = _parse_signature_body(match.group("body"))
     return fields or None
 
 
+def parse_agent_signature(text: str | None) -> dict[str, str] | None:
+    fields = parse_signature(text)
+    if fields is None or fields.get("stage", "").lower() == "ignore":
+        return None
+    return fields
+
+
 def has_agent_signature(text: str | None) -> bool:
-    return parse_signature(text) is not None
+    return parse_agent_signature(text) is not None
+
+
+def has_ignore_signature(text: str | None) -> bool:
+    if not text:
+        return False
+    for match in SIGNATURE_PATTERN.finditer(text):
+        fields = _parse_signature_body(match.group("body"))
+        if fields.get("stage", "").lower() == "ignore":
+            return True
+    return False
+
+
+def is_opt_out_comment(text: str | None) -> bool:
+    return has_ignore_signature(text) or bool(text and IGNORE_COMMAND_PATTERN.search(text))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,7 +6,7 @@ from typing import Any, TypedDict
 
 from dani.git_sync import DevSyncConflictError, DevSyncContext, DevSyncOutcome
 from dani.models import JobRecord, SessionRecord
-from dani.signatures import build_signature, parse_signature
+from dani.signatures import build_signature, is_opt_out_comment, parse_agent_signature, parse_signature
 
 
 class FakeGitHubCLI:
@@ -42,7 +42,9 @@ class FakeGitHubCLI:
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
         for comment in reversed(comments):
-            parsed = parse_signature(comment.get("body", ""))
+            if is_opt_out_comment(comment.get("body", "")):
+                continue
+            parsed = parse_agent_signature(comment.get("body", ""))
             if parsed is not None:
                 return comment, parsed
         return None

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -55,7 +55,11 @@ class FakeGitHubCLI:
         comments = (
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
-        return [comment for comment in comments if signature_fragment in (comment.get("body") or "")]
+        return [
+            comment
+            for comment in comments
+            if not is_opt_out_comment(comment.get("body", "")) and signature_fragment in (comment.get("body") or "")
+        ]
 
     def merge_pull_request(self, repo_full_name: str, pr_number: int) -> None:
         self.merged.append((repo_full_name, pr_number))

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -131,6 +131,32 @@ def test_create_issue_and_pr_comments_use_repository_objects(fake_repo: FakeRepo
     assert fake_repo.pulls[7].created_issue_comments == ["hello pr"]
 
 
+def test_latest_signature_comment_ignores_opt_out_marker(fake_repo: FakeRepo) -> None:
+    fake_repo.issues[5] = FakeIssue([
+        "<!-- dani:stage=issue_request;job=job-1;issue=5 -->",
+        "<!-- dani:stage=ignore -->",
+    ])
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    latest = github.latest_signature_comment("acme/demo", 5, kind="issue")
+
+    assert latest is not None
+    assert latest[1]["stage"] == "issue_request"
+
+
+def test_latest_signature_comment_skips_dani_ignore_command_even_with_embedded_signature(fake_repo: FakeRepo) -> None:
+    fake_repo.issues[5] = FakeIssue([
+        "<!-- dani:stage=issue_request;job=job-1;issue=5 -->",
+        "/dani ignore\nQuoted marker <!-- dani:stage=review_round;job=job-2;pr=7;round=1 -->",
+    ])
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    latest = github.latest_signature_comment("acme/demo", 5, kind="issue")
+
+    assert latest is not None
+    assert latest[1]["stage"] == "issue_request"
+
+
 def test_ensure_pull_request_updates_existing_open_pull_request(fake_repo: FakeRepo) -> None:
     github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -157,6 +157,16 @@ def test_latest_signature_comment_skips_dani_ignore_command_even_with_embedded_s
     assert latest[1]["stage"] == "issue_request"
 
 
+def test_find_comments_by_signature_skips_opt_out_comment_that_quotes_exact_signature(fake_repo: FakeRepo) -> None:
+    signature = "<!-- dani:stage=review_round;job=job-2;pr=7;round=1 -->"
+    fake_repo.pulls[7] = FakePullRequest(number=7, body="body", comments=[f"/dani ignore\nQuoted marker {signature}"])
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    matching_comments = github.find_comments_by_signature("acme/demo", 7, kind="pr", signature_fragment=signature)
+
+    assert matching_comments == []
+
+
 def test_ensure_pull_request_updates_existing_open_pull_request(fake_repo: FakeRepo) -> None:
     github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
@@ -382,6 +383,41 @@ def test_review_round_verification_rejects_stale_signed_comment(tmp_path: Path) 
     github.add_pr_signature("acme/demo", 77, build_signature(stage="review_round", job="stale-job", pr=77, round=1))
 
     with pytest.raises(RuntimeError, match="review-comment-missing"):
+        service._verify_side_effect(repo, job)
+
+
+@pytest.mark.parametrize(
+    ("job", "signature", "expected_error"),
+    [
+        (
+            JobRecord(repo_full_name="acme/demo", stage="review_round", pr_number=77, review_round=2),
+            lambda job: build_signature(stage="review_round", job=job.id, pr=77, round=2),
+            "review-comment-missing",
+        ),
+        (
+            JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=5, pr_number=77),
+            lambda job: build_signature(stage="implementation", job=job.id, issue=5, pr=77),
+            "implementation-comment-missing",
+        ),
+        (
+            JobRecord(repo_full_name="acme/demo", stage="final_verdict", pr_number=77),
+            lambda job: build_signature(stage="final_verdict", job=job.id, pr=77, verdict="APPROVE"),
+            "final-verdict-comment-missing",
+        ),
+    ],
+)
+def test_pr_side_effect_verification_rejects_opt_out_comment_quoting_exact_signature(
+    tmp_path: Path,
+    job: JobRecord,
+    signature: Callable[[JobRecord], str],
+    expected_error: str,
+) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    github.pr_comment_map[("acme/demo", 77)] = [{"body": f"/dani ignore\nQuoted marker {signature(job)}"}]
+
+    with pytest.raises(RuntimeError, match=expected_error):
         service._verify_side_effect(repo, job)
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -136,6 +136,63 @@ def test_general_issue_comment_without_existing_issue_session_is_ignored(tmp_pat
     assert omx_runner.resumes == []
 
 
+def test_issue_comment_with_ignore_signature_is_ignored_before_followup(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=36,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=36,
+            actor_login="human",
+            payload={"issue": {"body": "Need automation"}},
+            body="Please ignore this.\n<!-- dani:stage=ignore -->",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "comment_opt_out"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=36) == []
+    assert omx_runner.resumes == []
+
+
+def test_issue_comment_with_ignore_command_overrides_approve(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=37,
+            actor_login="human",
+            payload={"issue": {"body": "context"}},
+            body="/approve\n/dani ignore",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "comment_opt_out"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", issue_number=37) == []
+    assert omx_runner.launches == []
+
+
 def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
     service, _, omx_runner = make_service(tmp_path)
     event = NormalizedEvent(
@@ -355,6 +412,33 @@ def test_duplicate_review_round_event_is_ignored(tmp_path: Path) -> None:
     assert omx_runner.launches[-1]["job"].pr_number == 77
 
 
+def test_pull_request_comment_with_ignore_signature_skips_agent_transition(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=77,
+            actor_login="human",
+            payload={},
+            body=(
+                "Please do not trigger this.\n"
+                "<!-- dani:stage=ignore -->\n"
+                f"{build_signature(stage='review_round', job='job-1', pr=77, round=1)}"
+            ),
+            title="Feature/#5",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "comment_opt_out"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=77) == []
+    assert omx_runner.launches == []
+
+
 def test_implementation_followup_verification_requires_exact_signature(tmp_path: Path) -> None:
     service, github, _ = make_service(tmp_path)
     repo = service.storage.get_repo("acme/demo")
@@ -440,6 +524,42 @@ def test_bootstrap_repo_skips_issues_with_existing_issue_request_signature(tmp_p
     assert isinstance(only_job, JobRecord)
     assert only_job.issue_number == 6
     assert only_job.stage == "issue_request"
+
+
+def test_bootstrap_repo_still_skips_issue_request_when_ignore_comment_is_latest(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.open_issues["acme/demo"] = [{"number": 5, "title": "Already handled", "body": "Need sync"}]
+    github.add_issue_signature(
+        "acme/demo",
+        5,
+        build_signature(stage="issue_request", job="existing-job", issue=5),
+    )
+    github.issue_comment_map[("acme/demo", 5)].append({"body": "<!-- dani:stage=ignore -->"})
+
+    count = service.bootstrap_repo("acme/demo")
+    service.wait_for_idle()
+
+    assert count == 0
+    assert omx_runner.launches == []
+
+
+def test_bootstrap_repo_skips_opt_out_comment_that_quotes_agent_signature(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.open_issues["acme/demo"] = [{"number": 5, "title": "Already handled", "body": "Need sync"}]
+    github.add_issue_signature(
+        "acme/demo",
+        5,
+        build_signature(stage="issue_request", job="existing-job", issue=5),
+    )
+    github.issue_comment_map[("acme/demo", 5)].append({
+        "body": "/dani ignore\nQuoted marker <!-- dani:stage=review_round;job=job-2;pr=7;round=1 -->"
+    })
+
+    count = service.bootstrap_repo("acme/demo")
+    service.wait_for_idle()
+
+    assert count == 0
+    assert omx_runner.launches == []
 
 
 def test_pull_request_opened_to_main_is_ignored(tmp_path: Path) -> None:

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -1,4 +1,10 @@
-from dani.signatures import build_signature, parse_signature
+from dani.signatures import (
+    build_signature,
+    has_ignore_signature,
+    is_opt_out_comment,
+    parse_agent_signature,
+    parse_signature,
+)
 
 
 def test_signature_round_trip() -> None:
@@ -9,3 +15,17 @@ def test_signature_round_trip() -> None:
         "pr": "7",
         "round": "2",
     }
+
+
+def test_has_ignore_signature_detects_ignore_stage_across_multiple_markers() -> None:
+    text = f"{build_signature(stage='review_round', job='job123', pr=7, round=2)}\n<!-- dani:stage=ignore -->"
+
+    assert has_ignore_signature(text) is True
+
+
+def test_is_opt_out_comment_accepts_dani_ignore_command() -> None:
+    assert is_opt_out_comment("Heads up\n/dani ignore") is True
+
+
+def test_parse_agent_signature_excludes_ignore_stage() -> None:
+    assert parse_agent_signature("<!-- dani:stage=ignore -->") is None


### PR DESCRIPTION
## Summary
- ignore issue and PR comments that explicitly opt out with `<!-- dani:stage=ignore -->`
- ignore `/dani ignore` comments before approval/follow-up routing and signature processing
- keep bootstrap/latest-signature discovery stable even when opt-out comments quote Dani signatures

## Verification
- uv run ruff check .
- uv run ty check
- uv run pytest
- uv run python manual service script for `/dani ignore` and bootstrap replay

<!-- dani:stage=implementation;job=d0662afdc8ce4e95b2175914d54580d6;issue=22 -->
