### PR TITLE
Feature/#21

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,4 +139,4 @@ For PRs opened by external contributors, `dani` follows a lighter event-driven r
    - once all remaining automated review passes are already queued or running, extra PR-activity events are coalesced until one of those passes finishes
 4. The merge bar stays the same as the existing verdict session: requirements must be met, real verification must pass, and the PR must be approveable.
 5. Only completed automated review passes count toward escalation, but queued/running passes still reserve the remaining review budget.
-6. If automated review reaches 10 completed passes without approval, `dani` escalates the PR to a human maintainer for a manual decision.
+6. If automated review reaches 10 completed passes without approval, `dani` immediately escalates the PR to a human maintainer for a manual decision.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,5 +136,7 @@ For PRs opened by external contributors, `dani` follows a lighter event-driven r
    - a renewed review request
    - another PR-open style re-entry event (`reopened`, `ready_for_review`)
    - duplicate webhook deliveries are ignored, using the GitHub delivery id when available and a PR activity fallback key otherwise
+   - once all remaining automated review passes are already queued or running, extra PR-activity events are coalesced until one of those passes finishes
 4. The merge bar stays the same as the existing verdict session: requirements must be met, real verification must pass, and the PR must be approveable.
-5. If automated review reaches 10 passes without approval, `dani` escalates the PR to a human maintainer for a manual decision.
+5. Only completed automated review passes count toward escalation, but queued/running passes still reserve the remaining review budget.
+6. If automated review reaches 10 completed passes without approval, `dani` escalates the PR to a human maintainer for a manual decision.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,3 +124,16 @@ Before you submit a pull request, check that it meets these guidelines:
 
 2. If the pull request adds functionality, the docs should be updated.
    Put your new functionality into a function with a docstring, and add the feature to the list in `README.md`.
+
+## External contribution PR review process
+
+For PRs opened by external contributors, `dani` follows a lighter event-driven review loop:
+
+1. A maintainer review runs when the PR is opened.
+2. If changes are requested, the contributor owns the follow-up implementation.
+3. `dani` reviews again only when the PR changes meaningfully, such as:
+   - a new commit (`synchronize`)
+   - a renewed review request
+   - another PR-open style re-entry event (`reopened`, `ready_for_review`)
+4. The merge bar stays the same as the existing verdict session: requirements must be met, real verification must pass, and the PR must be approveable.
+5. If automated review reaches 10 passes without approval, `dani` escalates the PR to a human maintainer for a manual decision.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,5 +135,6 @@ For PRs opened by external contributors, `dani` follows a lighter event-driven r
    - a new commit (`synchronize`)
    - a renewed review request
    - another PR-open style re-entry event (`reopened`, `ready_for_review`)
+   - duplicate webhook deliveries are ignored, using the GitHub delivery id when available and a PR activity fallback key otherwise
 4. The merge bar stays the same as the existing verdict session: requirements must be met, real verification must pass, and the PR must be approveable.
 5. If automated review reaches 10 passes without approval, `dani` escalates the PR to a human maintainer for a manual decision.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Simple GitHub webhook -> OMX automation loop.
   - issue request report
   - `/approve` implementation
   - 3 review rounds for agent-authored PRs
-  - event-driven re-review for external contributor PRs
+  - event-driven, duplicate-delivery-safe re-review for external contributor PRs
   - final verdict + auto-merge on APPROVE
 
 ## Environment

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Simple GitHub webhook -> OMX automation loop.
 - Workflows for:
   - issue request report
   - `/approve` implementation
-  - 3 review rounds for PRs
+  - 3 review rounds for agent-authored PRs
+  - event-driven re-review for external contributor PRs
   - final verdict + auto-merge on APPROVE
 
 ## Environment

--- a/dani/models.py
+++ b/dani/models.py
@@ -92,6 +92,7 @@ class DaniConfig:
     host: str = "127.0.0.1"
     port: int = 8787
     review_rounds: int = 3
+    external_review_limit: int = 10
 
     @property
     def registry_path(self) -> Path:

--- a/dani/models.py
+++ b/dani/models.py
@@ -80,6 +80,7 @@ class NormalizedEvent:
     title: str | None = None
     base_branch: str | None = None
     head_branch: str | None = None
+    delivery_id: str | None = None
     ref: str | None = None
     commit_sha: str | None = None
     is_pull_request: bool = False

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -90,7 +90,7 @@ After creating or updating the PR, exit.
     "review_round": Template(
         """
 You are reviewing PR #$pr_number in $repo.
-Round: $round_number / 3
+Round: $round_number / $round_total
 PR title: $pr_title
 PR body:
 $pr_body
@@ -98,6 +98,7 @@ $pr_body
 Recent discussion:
 $discussion
 
+$review_mode_note
 Use the code locally and run $$code-review before writing the review comment.
 Do real verification, not only static inspection.
 Checklist:
@@ -116,6 +117,7 @@ After posting the PR comment, exit.
     "final_verdict": Template(
         """
 You are deciding the final verdict for PR #$pr_number in $repo.
+$review_cycle
 PR title: $pr_title
 PR body:
 $pr_body
@@ -123,17 +125,40 @@ $pr_body
 Review history:
 $discussion
 
-Leave exactly one final GitHub PR comment.
+Leave exactly one GitHub PR comment for this review pass.
 Checklist:
 - [ ] Verdict: APPROVE or REJECT
 - [ ] Short reason
 - [ ] Real Result from actual verification
 - [ ] Include concrete evidence appropriate for what you verified
+- [ ] If REJECT, make the next contributor action clear
 - [ ] If APPROVE, include: $approve_signature
 - [ ] If REJECT, include: $reject_signature
 
 Post it with gh:
 gh pr comment $pr_number --repo $repo --body-file <final-verdict.md>
+
+After posting the PR comment, exit.
+        """.strip()
+    ),
+    "human_escalation": Template(
+        """
+You are escalating PR #$pr_number in $repo to a human maintainer.
+Review limit reached: $review_limit
+PR title: $pr_title
+PR body:
+$pr_body
+
+Recent review history:
+$discussion
+
+Leave exactly one GitHub PR comment that:
+- [ ] States automated review stopped after $review_limit review passes
+- [ ] Asks a human maintainer to take over triage / scope / merge judgment
+- [ ] Includes this exact signature: $signature
+
+Post it with gh:
+gh pr comment $pr_number --repo $repo --body-file <human-escalation.md>
 
 After posting the PR comment, exit.
         """.strip()
@@ -170,6 +195,9 @@ After the push succeeds, exit.
 def render_prompt(template_name: str, context: dict[str, Any]) -> str:
     template = TEMPLATES[template_name]
     context = dict(context)
+    context.setdefault("review_cycle", "")
+    context.setdefault("round_total", "3")
+    context.setdefault("review_mode_note", "")
     if template_name != "final_verdict" and "signature" not in context:
         context = {
             **context,

--- a/dani/server.py
+++ b/dani/server.py
@@ -23,7 +23,7 @@ def create_app(service: DaniService) -> FastAPI:
         if event_name is None:
             raise HTTPException(status_code=400, detail="missing event name")
         payload = parse_body(body)
-        event = normalize_event(event_name, payload)
+        event = normalize_event(event_name, payload, delivery_id=request.headers.get("x-github-delivery"))
         if event is None:
             return {"status": "ignored", "reason": "unsupported_event"}
         return service.handle_event(event)

--- a/dani/service.py
+++ b/dani/service.py
@@ -79,6 +79,7 @@ class DaniService:
             "title": event.title,
             "base_branch": event.base_branch,
             "head_branch": event.head_branch,
+            "delivery_id": event.delivery_id,
             "ref": event.ref,
             "commit_sha": event.commit_sha,
         })
@@ -761,6 +762,10 @@ class DaniService:
             )
             return {"status": "queued", "job_id": job.id, "stage": job.stage}
 
+        event_key = self._external_pull_request_event_key(event)
+        if not self.storage.record_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_external_pr_event"}
+
         if self._has_human_escalation(event.repo_full_name, event.number):
             return {"status": "ignored", "reason": "human_review_required"}
 
@@ -809,6 +814,33 @@ class DaniService:
                 value = str(default_pr)
             if value:
                 fields.append((key, value))
+        return ";".join(f"{key}={value}" for key, value in fields)
+
+    def _external_pull_request_event_key(self, event: NormalizedEvent) -> str:
+        if event.delivery_id:
+            return f"external_pr_event;delivery={event.delivery_id}"
+
+        fields = [
+            ("repo", event.repo_full_name),
+            ("kind", event.kind),
+            ("pr", str(event.number)),
+            ("action", event.action),
+        ]
+        if event.commit_sha:
+            fields.append(("head_sha", event.commit_sha))
+        elif event.head_branch:
+            fields.append(("head_branch", event.head_branch))
+        requested_reviewer = event.payload.get("requested_reviewer") or {}
+        reviewer_login = requested_reviewer.get("login")
+        if reviewer_login:
+            fields.append(("reviewer", str(reviewer_login)))
+        requested_team = event.payload.get("requested_team") or {}
+        team_slug = requested_team.get("slug") or requested_team.get("name")
+        if team_slug:
+            fields.append(("team", str(team_slug)))
+        updated_at = (event.payload.get("pull_request") or {}).get("updated_at")
+        if updated_at:
+            fields.append(("updated_at", str(updated_at)))
         return ";".join(f"{key}={value}" for key, value in fields)
 
     def _latest_review_round(self, repo_full_name: str, pr_number: int) -> int:

--- a/dani/service.py
+++ b/dani/service.py
@@ -173,6 +173,7 @@ class DaniService:
             return self._handle_external_review_round_event(
                 repo,
                 event,
+                source_job=source_job,
                 pr_metadata=pr_metadata,
                 issue_number=issue_number,
                 pr_number=pr_number,
@@ -198,6 +199,7 @@ class DaniService:
         repo: RepoConfig,
         event: NormalizedEvent,
         *,
+        source_job: JobRecord,
         pr_metadata: dict[str, str],
         issue_number: int | None,
         pr_number: int,
@@ -217,6 +219,24 @@ class DaniService:
                 },
             )
             return {"status": "queued", "job_id": verdict_job.id, "stage": verdict_job.stage}
+
+        completed_reviews = self._completed_external_review_count(event.repo_full_name, pr_number)
+        if source_job.status != "completed":
+            completed_reviews += 1
+        if completed_reviews >= self.config.external_review_limit and not self._has_human_escalation(
+            event.repo_full_name, pr_number
+        ):
+            escalation_job = self._enqueue_external_human_escalation(
+                repo,
+                issue_number=issue_number,
+                pr_number=pr_number,
+                metadata={
+                    **pr_metadata,
+                    "title": (pr_metadata.get("title") or event.title or ""),
+                    "external_contribution": True,
+                },
+            )
+            return {"status": "queued", "job_id": escalation_job.id, "stage": escalation_job.stage}
         return {"status": "updated", "stage": "review_round"}
 
     def _enqueue_job(
@@ -785,9 +805,8 @@ class DaniService:
         completed_reviews = self._completed_external_review_count(event.repo_full_name, event.number)
         consumed_review_rounds = self._consumed_external_review_rounds(event.repo_full_name, event.number)
         if completed_reviews >= self.config.external_review_limit:
-            escalation_job = self._enqueue_job(
+            escalation_job = self._enqueue_external_human_escalation(
                 repo,
-                stage="human_escalation",
                 issue_number=issue_number,
                 pr_number=event.number,
                 metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
@@ -807,6 +826,22 @@ class DaniService:
             metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
         )
         return {"status": "queued", "job_id": job.id, "stage": job.stage}
+
+    def _enqueue_external_human_escalation(
+        self,
+        repo: RepoConfig,
+        *,
+        issue_number: int | None,
+        pr_number: int,
+        metadata: dict[str, Any],
+    ) -> JobRecord:
+        return self._enqueue_job(
+            repo,
+            stage="human_escalation",
+            issue_number=issue_number,
+            pr_number=pr_number,
+            metadata=metadata,
+        )
 
     def _latest_resumable_session(
         self,

--- a/dani/service.py
+++ b/dani/service.py
@@ -110,30 +110,7 @@ class DaniService:
     def _handle_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         stage = signature.get("stage")
         if stage == "review_round":
-            event_key = self._agent_event_key(signature, default_pr=event.number if event.is_pull_request else None)
-            if not self.storage.record_processed_event(event_key):
-                return {"status": "ignored", "reason": "duplicate_agent_event"}
-            review_round = int(signature["round"])
-            pr_number = int(signature["pr"])
-            issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
-            repo = self.storage.get_repo(event.repo_full_name)
-            if repo is None:
-                return {"status": "ignored", "reason": "missing_repo"}
-            pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
-            next_job = self._enqueue_job(
-                repo,
-                stage="implementation",
-                issue_number=issue_number,
-                pr_number=pr_number,
-                review_round=review_round,
-                metadata={
-                    **pr_metadata,
-                    "title": (pr_metadata.get("title") or event.title or ""),
-                    "review_comment_body": event.body or "",
-                    "triggering_review_round": review_round,
-                },
-            )
-            return {"status": "queued", "job_id": next_job.id, "stage": next_job.stage}
+            return self._handle_review_round_event(event, signature)
 
         if stage == "implementation" and event.kind == "pull_request_comment":
             pr_number = int(signature.get("pr") or event.number)
@@ -178,6 +155,68 @@ class DaniService:
             return {"status": "merged", "pr_number": int(signature["pr"])}
 
         return {"status": "updated", "stage": stage}
+
+    def _handle_review_round_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
+        event_key = self._agent_event_key(signature, default_pr=event.number if event.is_pull_request else None)
+        if not self.storage.record_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_agent_event"}
+        review_round = int(signature["round"])
+        pr_number = int(signature["pr"])
+        issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
+        source_job = self.storage.get_job(signature.get("job", ""))
+        repo = self.storage.get_repo(event.repo_full_name)
+        if repo is None:
+            return {"status": "ignored", "reason": "missing_repo"}
+        pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
+        if bool(source_job and source_job.metadata.get("external_contribution")):
+            return self._handle_external_review_round_event(
+                repo,
+                event,
+                pr_metadata=pr_metadata,
+                issue_number=issue_number,
+                pr_number=pr_number,
+                review_round=review_round,
+            )
+        next_job = self._enqueue_job(
+            repo,
+            stage="implementation",
+            issue_number=issue_number,
+            pr_number=pr_number,
+            review_round=review_round,
+            metadata={
+                **pr_metadata,
+                "title": (pr_metadata.get("title") or event.title or ""),
+                "review_comment_body": event.body or "",
+                "triggering_review_round": review_round,
+            },
+        )
+        return {"status": "queued", "job_id": next_job.id, "stage": next_job.stage}
+
+    def _handle_external_review_round_event(
+        self,
+        repo: RepoConfig,
+        event: NormalizedEvent,
+        *,
+        pr_metadata: dict[str, str],
+        issue_number: int | None,
+        pr_number: int,
+        review_round: int,
+    ) -> dict[str, Any]:
+        if self._is_approve_comment(event.body):
+            verdict_job = self._enqueue_job(
+                repo,
+                stage="final_verdict",
+                issue_number=issue_number,
+                pr_number=pr_number,
+                review_round=review_round,
+                metadata={
+                    **pr_metadata,
+                    "title": (pr_metadata.get("title") or event.title or ""),
+                    "external_contribution": True,
+                },
+            )
+            return {"status": "queued", "job_id": verdict_job.id, "stage": verdict_job.stage}
+        return {"status": "updated", "stage": "review_round"}
 
     def _enqueue_job(
         self,
@@ -316,6 +355,9 @@ class DaniService:
         if job.stage == "review_round":
             return self._build_review_round_prompt(repo, job, issue_number, pr_number, pr_title, pr_body)
 
+        if job.stage == "human_escalation":
+            return self._build_human_escalation_prompt(repo, job, issue_number, pr_number, pr_title, pr_body)
+
         return self._build_final_verdict_prompt(job, issue_number, pr_number, pr_title, pr_body)
 
     def _verify_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
@@ -330,6 +372,9 @@ class DaniService:
             return
         if job.stage == "review_round":
             self._verify_review_round_side_effect(repo, job)
+            return
+        if job.stage == "human_escalation":
+            self._verify_human_escalation_side_effect(repo, job)
             return
         if job.stage == "final_verdict":
             self._verify_final_verdict_side_effect(repo, job)
@@ -460,6 +505,7 @@ class DaniService:
         pr_discussion = self._render_pr_discussion(repo.full_name, pr_number)
         if pr_discussion:
             discussion_parts.append(pr_discussion)
+        is_external_review = bool(job.metadata.get("external_contribution"))
         return render_prompt(
             "review_round",
             {
@@ -469,6 +515,13 @@ class DaniService:
                 "pr_body": pr_body,
                 "discussion": "\n\n".join(discussion_parts),
                 "round_number": job.review_round or 1,
+                "round_total": self.config.external_review_limit if is_external_review else self.config.review_rounds,
+                "review_mode_note": (
+                    "This is an external contribution PR. The contributor owns any follow-up implementation. "
+                    "If the PR is ready to merge, include /approve in your review comment so dani can run the final verdict pass."
+                    if is_external_review
+                    else ""
+                ),
                 "signature": build_signature(**signature_fields),
             },
         )
@@ -495,10 +548,43 @@ class DaniService:
                 "pr_title": pr_title,
                 "pr_body": pr_body,
                 "discussion": "\n\n".join(discussion_parts),
+                "review_cycle": (
+                    f"Review pass: {job.review_round} / {self.config.external_review_limit}"
+                    if job.review_round and job.metadata.get("external_contribution")
+                    else ""
+                ),
                 "approve_signature": build_signature(
                     stage="final_verdict", job=job.id, pr=pr_number, verdict="APPROVE"
                 ),
                 "reject_signature": build_signature(stage="final_verdict", job=job.id, pr=pr_number, verdict="REJECT"),
+            },
+        )
+
+    def _build_human_escalation_prompt(
+        self,
+        repo: RepoConfig,
+        job: JobRecord,
+        issue_number: int,
+        pr_number: int,
+        pr_title: str,
+        pr_body: str,
+    ) -> str:
+        discussion_parts = []
+        if issue_number:
+            discussion_parts.append(f"Related issue: #{issue_number}")
+        pr_discussion = self._render_pr_discussion(repo.full_name, pr_number)
+        if pr_discussion:
+            discussion_parts.append(pr_discussion)
+        return render_prompt(
+            "human_escalation",
+            {
+                "repo": repo.full_name,
+                "pr_number": pr_number,
+                "pr_title": pr_title,
+                "pr_body": pr_body,
+                "discussion": "\n\n".join(discussion_parts),
+                "review_limit": self.config.external_review_limit,
+                "signature": build_signature(stage="human_escalation", job=job.id, pr=pr_number),
             },
         )
 
@@ -559,6 +645,11 @@ class DaniService:
             or self._has_exact_pr_signature(repo.full_name, int(job.pr_number or 0), reject_signature)
         ):
             raise RuntimeError("final-verdict-comment-missing")
+
+    def _verify_human_escalation_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
+        signature = build_signature(stage="human_escalation", job=job.id, pr=int(job.pr_number or 0))
+        if not self._has_exact_pr_signature(repo.full_name, int(job.pr_number or 0), signature):
+            raise RuntimeError("human-escalation-comment-missing")
 
     def _has_exact_pr_signature(self, repo_full_name: str, pr_number: int, signature: str) -> bool:
         return bool(
@@ -656,13 +747,41 @@ class DaniService:
                 self.storage.update_job(signature["job"], status="completed", pr_number=event.number)
         if issue_number is None:
             issue_number = self._extract_issue_number(event.body)
+        is_agent_managed_pr = bool(signature and signature.get("stage") == "implementation")
+        if is_agent_managed_pr:
+            if event.action != "opened":
+                return {"status": "ignored", "reason": "agent_managed_pr_followup"}
+            job = self._enqueue_job(
+                repo,
+                stage="review_round",
+                issue_number=issue_number,
+                pr_number=event.number,
+                review_round=1,
+                metadata={"title": event.title or "", "body": event.body or ""},
+            )
+            return {"status": "queued", "job_id": job.id, "stage": job.stage}
+
+        if self._has_human_escalation(event.repo_full_name, event.number):
+            return {"status": "ignored", "reason": "human_review_required"}
+
+        completed_reviews = self._external_review_count(event.repo_full_name, event.number)
+        if completed_reviews >= self.config.external_review_limit:
+            escalation_job = self._enqueue_job(
+                repo,
+                stage="human_escalation",
+                issue_number=issue_number,
+                pr_number=event.number,
+                metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
+            )
+            return {"status": "queued", "job_id": escalation_job.id, "stage": escalation_job.stage}
+
         job = self._enqueue_job(
             repo,
             stage="review_round",
             issue_number=issue_number,
             pr_number=event.number,
-            review_round=1,
-            metadata={"title": event.title or "", "body": event.body or ""},
+            review_round=completed_reviews + 1,
+            metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
         )
         return {"status": "queued", "job_id": job.id, "stage": job.stage}
 
@@ -698,6 +817,18 @@ class DaniService:
             for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
         ]
         return max(rounds, default=0)
+
+    def _external_review_count(self, repo_full_name: str, pr_number: int) -> int:
+        return sum(
+            1
+            for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
+            if job.metadata.get("external_contribution")
+        )
+
+    def _has_human_escalation(self, repo_full_name: str, pr_number: int) -> bool:
+        return bool(
+            self.storage.find_jobs(repo_full_name=repo_full_name, stage="human_escalation", pr_number=pr_number)
+        )
 
     def _issue_number_for_signature_event(
         self,

--- a/dani/service.py
+++ b/dani/service.py
@@ -762,6 +762,19 @@ class DaniService:
             )
             return {"status": "queued", "job_id": job.id, "stage": job.stage}
 
+        return self._queue_external_pull_request_review(
+            repo,
+            event,
+            issue_number=issue_number,
+        )
+
+    def _queue_external_pull_request_review(
+        self,
+        repo: RepoConfig,
+        event: NormalizedEvent,
+        *,
+        issue_number: int | None,
+    ) -> dict[str, Any]:
         event_key = self._external_pull_request_event_key(event)
         if not self.storage.record_processed_event(event_key):
             return {"status": "ignored", "reason": "duplicate_external_pr_event"}
@@ -769,7 +782,8 @@ class DaniService:
         if self._has_human_escalation(event.repo_full_name, event.number):
             return {"status": "ignored", "reason": "human_review_required"}
 
-        completed_reviews = self._external_review_count(event.repo_full_name, event.number)
+        completed_reviews = self._completed_external_review_count(event.repo_full_name, event.number)
+        consumed_review_rounds = self._consumed_external_review_rounds(event.repo_full_name, event.number)
         if completed_reviews >= self.config.external_review_limit:
             escalation_job = self._enqueue_job(
                 repo,
@@ -780,12 +794,16 @@ class DaniService:
             )
             return {"status": "queued", "job_id": escalation_job.id, "stage": escalation_job.stage}
 
+        if len(consumed_review_rounds) >= self.config.external_review_limit:
+            return {"status": "ignored", "reason": "external_review_limit_pending"}
+
+        next_review_round = max(consumed_review_rounds, default=0) + 1
         job = self._enqueue_job(
             repo,
             stage="review_round",
             issue_number=issue_number,
             pr_number=event.number,
-            review_round=completed_reviews + 1,
+            review_round=next_review_round,
             metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
         )
         return {"status": "queued", "job_id": job.id, "stage": job.stage}
@@ -850,12 +868,23 @@ class DaniService:
         ]
         return max(rounds, default=0)
 
-    def _external_review_count(self, repo_full_name: str, pr_number: int) -> int:
+    def _completed_external_review_count(self, repo_full_name: str, pr_number: int) -> int:
         return sum(
             1
             for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
-            if job.metadata.get("external_contribution")
+            if job.metadata.get("external_contribution") and job.status == "completed"
         )
+
+    def _consumed_external_review_rounds(self, repo_full_name: str, pr_number: int) -> set[int]:
+        return {
+            int(job.review_round)
+            for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
+            if (
+                job.metadata.get("external_contribution")
+                and job.review_round is not None
+                and job.status in {"queued", "launched", "completed"}
+            )
+        }
 
     def _has_human_escalation(self, repo_full_name: str, pr_number: int) -> bool:
         return bool(

--- a/dani/webhook.py
+++ b/dani/webhook.py
@@ -66,7 +66,13 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             commit_sha=commit_sha,
         )
 
-    if event_name == "pull_request" and action == "opened":
+    if event_name == "pull_request" and action in {
+        "opened",
+        "synchronize",
+        "reopened",
+        "ready_for_review",
+        "review_requested",
+    }:
         pull_request = payload["pull_request"]
         return NormalizedEvent(
             kind="pull_request_opened",

--- a/dani/webhook.py
+++ b/dani/webhook.py
@@ -15,7 +15,9 @@ def verify_github_signature(secret: str, body: bytes, signature_header: str | No
     return hmac.compare_digest(expected, signature_header)
 
 
-def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent | None:
+def normalize_event(
+    event_name: str, payload: dict[str, Any], *, delivery_id: str | None = None
+) -> NormalizedEvent | None:
     repo = payload.get("repository") or {}
     repo_full_name = repo.get("full_name")
     if not repo_full_name:
@@ -33,6 +35,7 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             payload=payload,
             body=issue.get("body"),
             title=issue.get("title"),
+            delivery_id=delivery_id,
         )
 
     if event_name == "issue_comment" and action == "created":
@@ -47,6 +50,7 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             payload=payload,
             body=payload["comment"].get("body"),
             title=issue.get("title"),
+            delivery_id=delivery_id,
             is_pull_request=is_pr,
         )
 
@@ -62,6 +66,7 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             number=0,
             actor_login=payload["sender"]["login"],
             payload=payload,
+            delivery_id=delivery_id,
             ref=ref,
             commit_sha=commit_sha,
         )
@@ -85,6 +90,8 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             title=pull_request.get("title"),
             base_branch=pull_request["base"]["ref"],
             head_branch=pull_request["head"]["ref"],
+            delivery_id=delivery_id,
+            commit_sha=pull_request["head"].get("sha"),
             is_pull_request=True,
         )
 
@@ -101,6 +108,8 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             title=pull_request.get("title"),
             base_branch=pull_request["base"]["ref"],
             head_branch=pull_request["head"]["ref"],
+            delivery_id=delivery_id,
+            commit_sha=pull_request["head"].get("sha"),
             is_pull_request=True,
         )
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -125,6 +125,13 @@ class FakeOmxRunner:
                 pr_number,
                 build_signature(stage="review_round", job=job.id, pr=pr_number, round=job.review_round or 1),
             )
+        elif job.stage == "human_escalation":
+            pr_number = int((signature or {}).get("pr", job.pr_number or 0))
+            self.github.add_pr_signature(
+                repo_full_name,
+                pr_number,
+                build_signature(stage="human_escalation", job=job.id, pr=pr_number),
+            )
         elif job.stage == "dev_sync":
             pass
         else:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -122,6 +122,30 @@ def test_review_round_prompt_requires_code_review_and_verification() -> None:
     assert "gh pr comment 5 --repo acme/demo --body-file <review-comment.md>" in prompt
 
 
+def test_review_round_prompt_for_external_contribution_mentions_contributor_ownership() -> None:
+    prompt = render_prompt(
+        "review_round",
+        {
+            "repo": "acme/demo",
+            "pr_number": 5,
+            "pr_title": "Feature",
+            "pr_body": "Body",
+            "discussion": "history",
+            "round_number": 2,
+            "round_total": 10,
+            "review_mode_note": (
+                "This is an external contribution PR. The contributor owns any follow-up implementation. "
+                "If the PR is ready to merge, include /approve in your review comment so dani can run the final verdict pass."
+            ),
+            "signature": "<!-- dani:stage=review_round;job=abc;pr=5;round=2 -->",
+        },
+    )
+
+    assert "2 / 10" in prompt
+    assert "external contribution pr" in prompt.lower()
+    assert "/approve" in prompt
+
+
 def test_final_verdict_prompt_contains_both_signatures() -> None:
     prompt = render_prompt(
         "final_verdict",
@@ -160,3 +184,23 @@ def test_final_verdict_prompt_requires_general_real_result_evidence() -> None:
     assert "web:" not in prompt.lower()
     assert "cli:" not in prompt.lower()
     assert "backend:" not in prompt.lower()
+
+
+def test_human_escalation_prompt_mentions_review_limit_and_signature() -> None:
+    prompt = render_prompt(
+        "human_escalation",
+        {
+            "repo": "acme/demo",
+            "pr_number": 5,
+            "pr_title": "Feature",
+            "pr_body": "Body",
+            "discussion": "history",
+            "review_limit": 10,
+            "signature": "<!-- dani:stage=human_escalation;job=abc;pr=5 -->",
+        },
+    )
+
+    assert "10" in prompt
+    assert "human maintainer" in prompt.lower()
+    assert "gh pr comment 5 --repo acme/demo --body-file <human-escalation.md>" in prompt
+    assert "stage=human_escalation" in prompt

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -92,3 +92,43 @@ def test_github_webhook_endpoint_queues_dev_sync_on_main_push(tmp_path: Path) ->
 
     assert response.status_code == 200
     assert response.json()["stage"] == "dev_sync"
+
+
+def test_github_webhook_endpoint_dedupes_duplicate_external_pr_delivery(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    github = FakeGitHubCLI()
+    omx_runner = FakeOmxRunner(github)
+    service = DaniService(
+        config, storage=JsonStorage(config), github=cast(GitHubCLI, github), omx_runner=cast(OmxRunner, omx_runner)
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+    client = TestClient(create_app(service))
+    payload = {
+        "action": "synchronize",
+        "repository": {"full_name": "acme/demo"},
+        "sender": {"login": "contributor"},
+        "pull_request": {
+            "number": 21,
+            "title": "Feature/#21",
+            "body": "Implements #21",
+            "base": {"ref": "dev"},
+            "head": {"ref": "feature/#21", "sha": "sha-21-2"},
+        },
+    }
+    body = json.dumps(payload).encode("utf-8")
+    headers = {
+        "x-github-event": "pull_request",
+        "x-github-delivery": "delivery-21",
+        "x-hub-signature-256": _signature(TEST_SECRET, body),
+    }
+
+    first = client.post("/webhook", content=body, headers=headers)
+    second = client.post("/webhook", content=body, headers=headers)
+    service.wait_for_idle()
+
+    assert first.status_code == 200
+    assert first.json()["stage"] == "review_round"
+    assert second.status_code == 200
+    assert second.json() == {"status": "ignored", "reason": "duplicate_external_pr_event"}
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=21)
+    assert [job.review_round for job in review_jobs] == [1]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -32,6 +32,42 @@ def make_service(
     return service, github, omx_runner
 
 
+def make_pr_event(
+    *,
+    pr_number: int,
+    action: str,
+    body: str,
+    actor_login: str = "contributor",
+) -> NormalizedEvent:
+    return NormalizedEvent(
+        kind="pull_request_opened",
+        repo_full_name="acme/demo",
+        action=action,
+        number=pr_number,
+        actor_login=actor_login,
+        payload={},
+        body=body,
+        title=f"Feature/#{pr_number}",
+        base_branch="dev",
+        head_branch=f"feature/#{pr_number}",
+        is_pull_request=True,
+    )
+
+
+def make_pr_comment_event(*, pr_number: int, body: str, actor_login: str = "agent") -> NormalizedEvent:
+    return NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=pr_number,
+        actor_login=actor_login,
+        payload={},
+        body=body,
+        title=f"Feature/#{pr_number}",
+        is_pull_request=True,
+    )
+
+
 def test_issue_request_persists_omx_session_id(tmp_path: Path) -> None:
     service, _, _ = make_service(tmp_path)
 
@@ -210,6 +246,123 @@ def test_pr_opened_from_implementation_signature_queues_review_round(tmp_path: P
     assert result["stage"] == "review_round"
     assert review_jobs[0].review_round == 1
     assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_external_pr_opened_queues_review_round(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == [1]
+    assert review_jobs[0].metadata["external_contribution"] is True
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_external_pr_new_commit_queues_another_review_round(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+
+    result = service.handle_event(make_pr_event(pr_number=88, action="synchronize", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == [1, 2]
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_external_pr_review_requested_queues_review_round(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(make_pr_event(pr_number=91, action="review_requested", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_external_review_comment_does_not_queue_implementation(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+    review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
+
+    result = service.handle_event(
+        make_pr_comment_event(
+            pr_number=88,
+            body=build_signature(stage="review_round", job=review_job.id, pr=88, round=1),
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "updated", "stage": "review_round"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
+    assert len(omx_runner.launches) == 1
+    assert github.merged == []
+
+
+def test_external_review_approve_comment_queues_final_verdict(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+    review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
+
+    result = service.handle_event(
+        make_pr_comment_event(
+            pr_number=88,
+            body=f"/approve\n{build_signature(stage='review_round', job=review_job.id, pr=88, round=1)}",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result["stage"] == "final_verdict"
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
+    assert len(service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=88)) == 1
+    assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+    assert github.merged == []
+
+
+def test_external_final_verdict_approve_merges_without_implementation_job(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        make_pr_comment_event(
+            pr_number=88,
+            body=build_signature(stage="final_verdict", job="verdict-1", pr=88, verdict="APPROVE"),
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "merged", "pr_number": 88}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
+    assert omx_runner.launches == []
+    assert github.merged == [("acme/demo", 88)]
+
+
+def test_external_pr_escalates_after_ten_review_passes(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    for _ in range(10):
+        service.storage.create_job(
+            JobRecord(
+                repo_full_name="acme/demo",
+                stage="review_round",
+                pr_number=88,
+                metadata={"external_contribution": True},
+            )
+        )
+
+    result = service.handle_event(make_pr_event(pr_number=88, action="synchronize", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "human_escalation"
+    escalation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)
+    assert len(escalation_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "human_escalation"
 
 
 def test_review_chain_reaches_verdict_and_merges_on_approve(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,3 +1,4 @@
+import threading
 from pathlib import Path
 from typing import cast
 
@@ -14,13 +15,36 @@ from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI, FakeOmxRunner
 TEST_SECRET = "unit-test-secret"
 
 
+def add_exact_review_signature(github: FakeGitHubCLI, job: JobRecord) -> None:
+    signature_fields: dict[str, str | int] = {
+        "stage": "review_round",
+        "job": job.id,
+        "pr": int(job.pr_number or 0),
+        "round": job.review_round or 1,
+    }
+    if job.issue_number is not None:
+        signature_fields["issue"] = int(job.issue_number)
+    github.add_pr_signature(
+        job.repo_full_name,
+        int(job.pr_number or 0),
+        build_signature(**signature_fields),
+    )
+
+
 def make_service(
     tmp_path: Path, *, dev_syncer: FakeGitDevSyncer | None = None
 ) -> tuple[DaniService, FakeGitHubCLI, FakeOmxRunner]:
+    class ExactReviewSignatureOmxRunner(FakeOmxRunner):
+        def launch(self, repo_path: Path, job: JobRecord, prompt: str):
+            session = super().launch(repo_path, job, prompt)
+            if job.stage == "review_round" and job.issue_number is not None:
+                add_exact_review_signature(self.github, job)
+            return session
+
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
-    omx_runner = FakeOmxRunner(github)
+    omx_runner = ExactReviewSignatureOmxRunner(github)
     service = DaniService(
         config,
         storage=storage,
@@ -313,6 +337,7 @@ def test_duplicate_external_pr_activity_does_not_consume_review_limit(tmp_path: 
                 pr_number=88,
                 review_round=round_number,
                 metadata={"external_contribution": True},
+                status="completed",
             )
         )
 
@@ -459,6 +484,7 @@ def test_external_pr_escalates_after_ten_review_passes(tmp_path: Path) -> None:
                 stage="review_round",
                 pr_number=88,
                 metadata={"external_contribution": True},
+                status="completed",
             )
         )
 
@@ -469,6 +495,86 @@ def test_external_pr_escalates_after_ten_review_passes(tmp_path: Path) -> None:
     escalation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)
     assert len(escalation_jobs) == 1
     assert omx_runner.launches[-1]["job"].stage == "human_escalation"
+
+
+def test_external_pr_unique_activity_never_queues_an_eleventh_automated_review(tmp_path: Path) -> None:
+    class BlockingOmxRunner(FakeOmxRunner):
+        def __init__(self, github: FakeGitHubCLI) -> None:
+            super().__init__(github)
+            self.review_started = threading.Event()
+            self.release_review = threading.Event()
+
+        def launch(self, repo_path: Path, job: JobRecord, prompt: str):
+            session = super().launch(repo_path, job, prompt)
+            if job.stage == "review_round":
+                add_exact_review_signature(self.github, job)
+            return session
+
+        def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
+            if (
+                runtime_handle.startswith("runtime-")
+                and self.launches
+                and self.launches[-1]["job"].stage == "review_round"
+            ):
+                self.review_started.set()
+                self.release_review.wait(timeout=timeout_seconds)
+
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    github = FakeGitHubCLI()
+    omx_runner = BlockingOmxRunner(github)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github),
+        omx_runner=cast(OmxRunner, omx_runner),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    opened = service.handle_event(
+        make_pr_event(pr_number=88, action="opened", body="Implements #21", commit_sha="sha-1")
+    )
+    assert opened["stage"] == "review_round"
+    assert omx_runner.review_started.wait(timeout=1)
+
+    results = []
+    for round_number in range(2, 12):
+        results.append(
+            service.handle_event(
+                make_pr_event(
+                    pr_number=88,
+                    action="synchronize",
+                    body="Implements #21",
+                    commit_sha=f"sha-{round_number}",
+                )
+            )
+        )
+
+    assert all(result["stage"] == "review_round" for result in results[:9])
+    assert results[9] == {"status": "ignored", "reason": "external_review_limit_pending"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
+
+    omx_runner.release_review.set()
+    service.wait_for_idle()
+
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == list(range(1, 11))
+    assert all(job.status == "completed" for job in review_jobs)
+
+    post_limit = service.handle_event(
+        make_pr_event(
+            pr_number=88,
+            action="synchronize",
+            body="Implements #21",
+            commit_sha="sha-12",
+        )
+    )
+    service.wait_for_idle()
+
+    assert post_limit["stage"] == "human_escalation"
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88) == review_jobs
+    assert [job.review_round for job in review_jobs] == list(range(1, 11))
 
 
 def test_review_chain_reaches_verdict_and_merges_on_approve(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -38,19 +38,24 @@ def make_pr_event(
     action: str,
     body: str,
     actor_login: str = "contributor",
+    commit_sha: str | None = None,
+    delivery_id: str | None = None,
 ) -> NormalizedEvent:
+    head_sha = commit_sha or f"sha-{pr_number}-{action}"
     return NormalizedEvent(
         kind="pull_request_opened",
         repo_full_name="acme/demo",
         action=action,
         number=pr_number,
         actor_login=actor_login,
-        payload={},
+        payload={"pull_request": {"head": {"sha": head_sha}}},
         body=body,
         title=f"Feature/#{pr_number}",
         base_branch="dev",
         head_branch=f"feature/#{pr_number}",
+        commit_sha=head_sha,
         is_pull_request=True,
+        delivery_id=delivery_id,
     )
 
 
@@ -274,6 +279,107 @@ def test_external_pr_new_commit_queues_another_review_round(tmp_path: Path) -> N
     review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
     assert [job.review_round for job in review_jobs] == [1, 2]
     assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_duplicate_external_pr_activity_event_is_ignored(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21", commit_sha="sha-1"))
+    service.wait_for_idle()
+
+    first = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-2")
+    )
+    service.wait_for_idle()
+    duplicate = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-2")
+    )
+    service.wait_for_idle()
+
+    assert first["stage"] == "review_round"
+    assert duplicate == {"status": "ignored", "reason": "duplicate_external_pr_event"}
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == [1, 2]
+    assert len(omx_runner.launches) == 2
+
+
+def test_duplicate_external_pr_activity_does_not_consume_review_limit(tmp_path: Path) -> None:
+    service, _, _ = make_service(tmp_path)
+    for round_number in range(1, 10):
+        service.storage.create_job(
+            JobRecord(
+                repo_full_name="acme/demo",
+                stage="review_round",
+                pr_number=88,
+                review_round=round_number,
+                metadata={"external_contribution": True},
+            )
+        )
+
+    first = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-10")
+    )
+    service.wait_for_idle()
+    duplicate = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-10")
+    )
+    service.wait_for_idle()
+
+    assert first["stage"] == "review_round"
+    assert duplicate == {"status": "ignored", "reason": "duplicate_external_pr_event"}
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs if job.metadata.get("external_contribution")] == list(range(1, 11))
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
+
+
+def test_external_pr_fallback_dedupe_key_is_repo_scoped(tmp_path: Path) -> None:
+    service, _, _ = make_service(tmp_path)
+    service.register_repo("acme/other", str(tmp_path))
+
+    first = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="synchronize",
+            number=88,
+            actor_login="contributor",
+            payload={"pull_request": {"head": {"sha": "shared-sha"}}},
+            body="Implements #21",
+            title="Feature/#21",
+            base_branch="dev",
+            head_branch="feature/#21",
+            commit_sha="shared-sha",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    second = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/other",
+            action="synchronize",
+            number=88,
+            actor_login="contributor",
+            payload={"pull_request": {"head": {"sha": "shared-sha"}}},
+            body="Implements #21",
+            title="Feature/#21",
+            base_branch="dev",
+            head_branch="feature/#21",
+            commit_sha="shared-sha",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    assert first["stage"] == "review_round"
+    assert second["stage"] == "review_round"
+    assert [
+        job.review_round for job in service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round")
+    ] == [1]
+    assert [
+        job.review_round for job in service.storage.find_jobs(repo_full_name="acme/other", stage="review_round")
+    ] == [1]
 
 
 def test_external_pr_review_requested_queues_review_round(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -497,6 +497,56 @@ def test_external_pr_escalates_after_ten_review_passes(tmp_path: Path) -> None:
     assert omx_runner.launches[-1]["job"].stage == "human_escalation"
 
 
+def test_external_review_comment_queues_human_escalation_on_tenth_completed_pass(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    for round_number in range(1, 11):
+        action = "opened" if round_number == 1 else "synchronize"
+        result = service.handle_event(
+            make_pr_event(pr_number=88, action=action, body="Implements #21", commit_sha=f"sha-{round_number}")
+        )
+        service.wait_for_idle()
+
+        assert result["stage"] == "review_round"
+        review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
+        comment_result = service.handle_event(
+            make_pr_comment_event(
+                pr_number=88,
+                body=build_signature(stage="review_round", job=review_job.id, pr=88, round=round_number),
+            )
+        )
+        service.wait_for_idle()
+
+        if round_number < 10:
+            assert comment_result == {"status": "updated", "stage": "review_round"}
+            assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
+            continue
+
+        assert comment_result["stage"] == "human_escalation"
+
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == list(range(1, 11))
+    assert all(job.status == "completed" for job in review_jobs)
+
+    escalation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)
+    assert len(escalation_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "human_escalation"
+
+    post_limit = service.handle_event(
+        make_pr_event(
+            pr_number=88,
+            action="synchronize",
+            body="Implements #21",
+            commit_sha="sha-11",
+        )
+    )
+    service.wait_for_idle()
+
+    assert post_limit == {"status": "ignored", "reason": "human_review_required"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88) == review_jobs
+    assert len(service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)) == 1
+
+
 def test_external_pr_unique_activity_never_queues_an_eleventh_automated_review(tmp_path: Path) -> None:
     class BlockingOmxRunner(FakeOmxRunner):
         def __init__(self, github: FakeGitHubCLI) -> None:
@@ -561,18 +611,6 @@ def test_external_pr_unique_activity_never_queues_an_eleventh_automated_review(t
     review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
     assert [job.review_round for job in review_jobs] == list(range(1, 11))
     assert all(job.status == "completed" for job in review_jobs)
-
-    post_limit = service.handle_event(
-        make_pr_event(
-            pr_number=88,
-            action="synchronize",
-            body="Implements #21",
-            commit_sha="sha-12",
-        )
-    )
-    service.wait_for_idle()
-
-    assert post_limit["stage"] == "human_escalation"
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88) == review_jobs
     assert [job.review_round for job in review_jobs] == list(range(1, 11))
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -13,9 +13,10 @@ def test_normalize_pull_request_synchronize_event() -> None:
                 "title": "Feature/#21",
                 "body": "Implements #21",
                 "base": {"ref": "dev"},
-                "head": {"ref": "feature/#21"},
+                "head": {"ref": "feature/#21", "sha": "abc123"},
             },
         },
+        delivery_id="delivery-1",
     )
 
     assert event is not None
@@ -23,6 +24,8 @@ def test_normalize_pull_request_synchronize_event() -> None:
     assert event.number == 21
     assert event.base_branch == "dev"
     assert event.head_branch == "feature/#21"
+    assert event.commit_sha == "abc123"
+    assert event.delivery_id == "delivery-1"
     assert event.is_pull_request is True
 
 
@@ -38,8 +41,9 @@ def test_normalize_pull_request_review_requested_event() -> None:
                 "title": "Feature/#21",
                 "body": "Implements #21",
                 "base": {"ref": "dev"},
-                "head": {"ref": "feature/#21"},
+                "head": {"ref": "feature/#21", "sha": "def456"},
             },
+            "requested_reviewer": {"login": "maintainer"},
         },
     )
 
@@ -48,4 +52,5 @@ def test_normalize_pull_request_review_requested_event() -> None:
     assert event.number == 21
     assert event.base_branch == "dev"
     assert event.head_branch == "feature/#21"
+    assert event.commit_sha == "def456"
     assert event.is_pull_request is True

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,51 @@
+from dani.webhook import normalize_event
+
+
+def test_normalize_pull_request_synchronize_event() -> None:
+    event = normalize_event(
+        "pull_request",
+        {
+            "action": "synchronize",
+            "repository": {"full_name": "acme/demo"},
+            "sender": {"login": "contributor"},
+            "pull_request": {
+                "number": 21,
+                "title": "Feature/#21",
+                "body": "Implements #21",
+                "base": {"ref": "dev"},
+                "head": {"ref": "feature/#21"},
+            },
+        },
+    )
+
+    assert event is not None
+    assert event.kind == "pull_request_opened"
+    assert event.number == 21
+    assert event.base_branch == "dev"
+    assert event.head_branch == "feature/#21"
+    assert event.is_pull_request is True
+
+
+def test_normalize_pull_request_review_requested_event() -> None:
+    event = normalize_event(
+        "pull_request",
+        {
+            "action": "review_requested",
+            "repository": {"full_name": "acme/demo"},
+            "sender": {"login": "contributor"},
+            "pull_request": {
+                "number": 21,
+                "title": "Feature/#21",
+                "body": "Implements #21",
+                "base": {"ref": "dev"},
+                "head": {"ref": "feature/#21"},
+            },
+        },
+    )
+
+    assert event is not None
+    assert event.kind == "pull_request_opened"
+    assert event.number == 21
+    assert event.base_branch == "dev"
+    assert event.head_branch == "feature/#21"
+    assert event.is_pull_request is True


### PR DESCRIPTION
## Summary
- route external contributor PRs through event-driven re-review on PR activity
- keep the signed internal implementation PR loop intact and escalate external PRs after 10 completed review passes
- prevent duplicate or burst external PR activity from queueing beyond the 10-pass automated review budget
- document the external contribution review process and add coverage for webhook + service routing

## Verification
- make check
- uv run pytest -q
- uv run ty check
- uv run python smoke script for external contributor PR review -> /approve -> final verdict merge flow

<!-- dani:stage=implementation;job=81fd42a7576a4998a93cc1b5caff2719;issue=21 -->
