### PR TITLE
Detach codex subprocess from parent TTY to prevent stdin deadlock

### DIFF
--- a/dani/omx_runner.py
+++ b/dani/omx_runner.py
@@ -44,7 +44,13 @@ class OmxRunner:
         script_path.chmod(0o755)
         stdout_file = stdout_path.open("w", encoding="utf-8")
         stderr_file = stderr_path.open("w", encoding="utf-8")
-        process = subprocess.Popen([str(script_path)], stdout=stdout_file, stderr=stderr_file)  # noqa: S603
+        process = subprocess.Popen(  # noqa: S603
+            [str(script_path)],
+            stdin=subprocess.DEVNULL,
+            stdout=stdout_file,
+            stderr=stderr_file,
+            start_new_session=True,
+        )
         with self._lock:
             self._processes[process_handle] = (process, stdout_file, stderr_file)
         omx_session_id = None
@@ -83,7 +89,13 @@ class OmxRunner:
         script_path.chmod(0o755)
         stdout_file = stdout_path.open("w", encoding="utf-8")
         stderr_file = stderr_path.open("w", encoding="utf-8")
-        process = subprocess.Popen([str(script_path)], stdout=stdout_file, stderr=stderr_file)  # noqa: S603
+        process = subprocess.Popen(  # noqa: S603
+            [str(script_path)],
+            stdin=subprocess.DEVNULL,
+            stdout=stdout_file,
+            stderr=stderr_file,
+            start_new_session=True,
+        )
         with self._lock:
             self._processes[process_handle] = (process, stdout_file, stderr_file)
         return SessionRecord(


### PR DESCRIPTION
## Summary

`OmxRunner.launch` / `OmxRunner.resume` spawned the `omx` / `codex` child with default stdio inheritance. The child inherited fd 0 from whatever launched `dani serve`, and **both common deployment shapes produced a reproducible hang**:

- **Under tmux (controlling TTY inherited):** codex took TTY-affirmative init paths that held the pane's TTY in the foreground and eventually wedged in an async deadlock downstream. Zombie codex processes stayed pinned to the tmux pane's `/dev/ttys*` even after `dani`'s 30-minute wait timeout, because `close_session` sent `SIGTERM` only to the direct shell parent and the reparented descendants survived.
- **Under pm2 (fd 0 = unix-socket IPC from pm2 God Daemon):** `codex exec`'s `read_prompt_from_stdin(OptionalAppend)` (`codex-rs/exec/src/lib.rs:1631-1676`) sees `is_terminal() == false`, enters the fallthrough branch, and blocks indefinitely inside `std::io::stdin().read_to_end(...)` because the pm2 IPC socket never closes its write end. This hang is **deterministic** — it fires on every invocation, not just some.

Both modes collapse to a single fix: give the child a benign stdin and break the TTY inheritance chain.

## Change

In `dani/omx_runner.py`, both `subprocess.Popen` calls now pass:

- `stdin=subprocess.DEVNULL` — codex's `read_to_end` sees immediate EOF, returns an empty prompt addition, and `OptionalAppend` moves on cleanly.
- `start_new_session=True` — child runs in a new POSIX session with no controlling TTY regardless of how `dani serve` is launched (tmux, pm2, launchd, plain shell).

## Evidence

Investigation summary on the original stalled PR:

- `sample` on the hung native codex showed main thread + every `tokio-runtime-worker` blocked in `pthread_cond_wait` → `__psynch_cvwait`. Zero busy threads.
- `lsof` on the hung process showed **no network sockets open** (ruled out the "stuck streaming API read" theory).
- fd 0 = `/dev/ttys004` inherited from the tmux pane running `dani serve`.
- An audit of `openai/codex` (HEAD ~ \`3f7222ec\`) confirmed the only stdin-read in the exec crate is `read_prompt_from_stdin` in \`codex-rs/exec/src/lib.rs:1631-1676\`, gated only on \`is_terminal()\` — i.e. pm2-mode triggers the hang path, not TTY-mode.
- Empirical repro of the pm2-side failure before the fix:
  \`\`\`
  timeout 5 bash -c '{ sleep 30; } | codex exec \"hello\" 2>&1'
  # → prints \"Reading additional input from stdin...\" then blocks until timeout
  \`\`\`
  With \`</dev/null\` the same invocation exits immediately.

## Verification

- \`uv run pytest tests/test_omx_runner.py\` — 5/5 passed
- Repro disappears with the patched \`Popen\` under both tmux and pm2 parents
- Reinstalled locally via \`uv tool install --from /Users/jeffrey/Projects/dani dani\`, restarted \`dani serve\` under pm2 (fd 0 = unix socket in parent), \`curl localhost:8000/\` responds normally

## Follow-ups (separate from this hotfix)

- \`OmxRunner.close_session\` still calls \`process.terminate()\` on the direct PID; it should kill the process group (\`os.killpg(os.getpgid(process.pid), SIGTERM)\`) so timeout-failed sessions reap their descendants. With this PR's \`start_new_session=True\`, process-group kill is now well-defined.
- The downstream \`tokio::select!\` wedge observed in codex \`lib.rs:787-812\` (\`interrupt_rx.recv()\` + \`client.next_event()\`) is unrelated to stdin and lives upstream in \`openai/codex\`. This hotfix does not address that class of hang but makes it bound by dani's 30-minute wait instead of a deterministic first-request deadlock.