### PR TITLE
Merge dev into main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,4 +139,4 @@ For PRs opened by external contributors, `dani` follows a lighter event-driven r
    - once all remaining automated review passes are already queued or running, extra PR-activity events are coalesced until one of those passes finishes
 4. The merge bar stays the same as the existing verdict session: requirements must be met, real verification must pass, and the PR must be approveable.
 5. Only completed automated review passes count toward escalation, but queued/running passes still reserve the remaining review budget.
-6. If automated review reaches 10 completed passes without approval, `dani` escalates the PR to a human maintainer for a manual decision.
+6. If automated review reaches 10 completed passes without approval, `dani` immediately escalates the PR to a human maintainer for a manual decision.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,5 +136,7 @@ For PRs opened by external contributors, `dani` follows a lighter event-driven r
    - a renewed review request
    - another PR-open style re-entry event (`reopened`, `ready_for_review`)
    - duplicate webhook deliveries are ignored, using the GitHub delivery id when available and a PR activity fallback key otherwise
+   - once all remaining automated review passes are already queued or running, extra PR-activity events are coalesced until one of those passes finishes
 4. The merge bar stays the same as the existing verdict session: requirements must be met, real verification must pass, and the PR must be approveable.
-5. If automated review reaches 10 passes without approval, `dani` escalates the PR to a human maintainer for a manual decision.
+5. Only completed automated review passes count toward escalation, but queued/running passes still reserve the remaining review budget.
+6. If automated review reaches 10 completed passes without approval, `dani` escalates the PR to a human maintainer for a manual decision.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,3 +124,16 @@ Before you submit a pull request, check that it meets these guidelines:
 
 2. If the pull request adds functionality, the docs should be updated.
    Put your new functionality into a function with a docstring, and add the feature to the list in `README.md`.
+
+## External contribution PR review process
+
+For PRs opened by external contributors, `dani` follows a lighter event-driven review loop:
+
+1. A maintainer review runs when the PR is opened.
+2. If changes are requested, the contributor owns the follow-up implementation.
+3. `dani` reviews again only when the PR changes meaningfully, such as:
+   - a new commit (`synchronize`)
+   - a renewed review request
+   - another PR-open style re-entry event (`reopened`, `ready_for_review`)
+4. The merge bar stays the same as the existing verdict session: requirements must be met, real verification must pass, and the PR must be approveable.
+5. If automated review reaches 10 passes without approval, `dani` escalates the PR to a human maintainer for a manual decision.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,5 +135,6 @@ For PRs opened by external contributors, `dani` follows a lighter event-driven r
    - a new commit (`synchronize`)
    - a renewed review request
    - another PR-open style re-entry event (`reopened`, `ready_for_review`)
+   - duplicate webhook deliveries are ignored, using the GitHub delivery id when available and a PR activity fallback key otherwise
 4. The merge bar stays the same as the existing verdict session: requirements must be met, real verification must pass, and the PR must be approveable.
 5. If automated review reaches 10 passes without approval, `dani` escalates the PR to a human maintainer for a manual decision.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Simple GitHub webhook -> OMX automation loop.
   - issue request report
   - `/approve` implementation
   - 3 review rounds for agent-authored PRs
-  - event-driven re-review for external contributor PRs
+  - event-driven, duplicate-delivery-safe re-review for external contributor PRs
   - final verdict + auto-merge on APPROVE
 
 ## Environment

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Simple GitHub webhook -> OMX automation loop.
 - Workflows for:
   - issue request report
   - `/approve` implementation
-  - 3 review rounds for PRs
+  - 3 review rounds for agent-authored PRs
+  - event-driven re-review for external contributor PRs
   - final verdict + auto-merge on APPROVE
 
 ## Environment

--- a/dani/cli.py
+++ b/dani/cli.py
@@ -78,3 +78,16 @@ def show_state(data_dir: Path = DATA_DIR_OPTION) -> None:
     """Print current dani state."""
     service = build_service(data_dir=data_dir)
     typer.echo(json.dumps(service.state_snapshot(), ensure_ascii=False, indent=2))
+
+
+@app.command("restart-issue")
+def restart_issue(
+    repo_full_name: str = FULL_NAME_ARGUMENT,
+    issue_number: int = typer.Argument(..., help="Issue number"),
+    data_dir: Path = DATA_DIR_OPTION,
+) -> None:
+    """Supersede stale issue jobs, run a fresh issue_request, and wait for completion."""
+    service = build_service(data_dir=data_dir)
+    job = service.restart_issue(repo_full_name, issue_number)
+    service.wait_for_idle()
+    typer.echo(json.dumps(job.to_dict(), ensure_ascii=False, indent=2))

--- a/dani/errors.py
+++ b/dani/errors.py
@@ -7,9 +7,22 @@ TRANSIENT_CAPACITY_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"model is currently overloaded", re.IGNORECASE),
 ]
 
+ROLLOUT_MISSING_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"thread/resume failed", re.IGNORECASE),
+    re.compile(r"no rollout found", re.IGNORECASE),
+]
+
 
 class TransientCapacityError(Exception):
     """Raised when an OMX session fails due to a transient model-capacity issue."""
+
+    def __init__(self, message: str, pattern: str) -> None:
+        super().__init__(message)
+        self.pattern = pattern
+
+
+class RolloutMissingError(Exception):
+    """Raised when a resume target rollout/session can no longer be found."""
 
     def __init__(self, message: str, pattern: str) -> None:
         super().__init__(message)
@@ -22,3 +35,11 @@ def check_transient_capacity_error(stderr_text: str) -> None:
         match = pattern.search(stderr_text)
         if match:
             raise TransientCapacityError(match.group(0), pattern.pattern)
+
+
+def check_rollout_missing_error(stderr_text: str) -> None:
+    """Raise ``RolloutMissingError`` if *stderr_text* matches known missing-rollout patterns."""
+    for pattern in ROLLOUT_MISSING_PATTERNS:
+        match = pattern.search(stderr_text)
+        if match:
+            raise RolloutMissingError(stderr_text.strip() or match.group(0), pattern.pattern)

--- a/dani/github.py
+++ b/dani/github.py
@@ -8,7 +8,7 @@ from typing import Any
 from github import Auth, Github
 from github.GithubException import GithubException
 
-from dani.signatures import parse_signature
+from dani.signatures import is_opt_out_comment, parse_agent_signature
 
 TOKEN_ENV_VARS = ("DANI_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT")
 LOGGER = logging.getLogger(__name__)
@@ -88,7 +88,9 @@ class GitHubCLI:
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
         for comment in reversed(comments):
-            parsed = parse_signature(comment.get("body", ""))
+            if is_opt_out_comment(comment.get("body", "")):
+                continue
+            parsed = parse_agent_signature(comment.get("body", ""))
             if parsed is not None:
                 return comment, parsed
         return None
@@ -99,7 +101,11 @@ class GitHubCLI:
         comments = (
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
-        return [comment for comment in comments if signature_fragment in (comment.get("body") or "")]
+        return [
+            comment
+            for comment in comments
+            if not is_opt_out_comment(comment.get("body", "")) and signature_fragment in (comment.get("body") or "")
+        ]
 
     def create_issue_comment(self, repo_full_name: str, issue_number: int, body: str) -> dict[str, Any]:
         issue = self._repo(repo_full_name).get_issue(issue_number)

--- a/dani/github.py
+++ b/dani/github.py
@@ -12,6 +12,7 @@ from dani.signatures import is_opt_out_comment, parse_agent_signature
 
 TOKEN_ENV_VARS = ("DANI_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT")
 LOGGER = logging.getLogger(__name__)
+MERGE_CONFLICT_STATUSES = frozenset({405, 409, 422})
 
 
 class MergeConflictError(RuntimeError):
@@ -138,7 +139,9 @@ class GitHubCLI:
         try:
             merge_status = pull_request.merge(merge_method="merge", delete_branch=False)
         except GithubException as exc:
-            raise MergeConflictError(repo_full_name, pr_number, status=exc.status, message=str(exc)) from exc
+            if exc.status in MERGE_CONFLICT_STATUSES:
+                raise MergeConflictError(repo_full_name, pr_number, status=exc.status, message=str(exc)) from exc
+            raise
         if not merge_status.merged:
             raise MergeConflictError(repo_full_name, pr_number, message=merge_status.message)
         try:

--- a/dani/models.py
+++ b/dani/models.py
@@ -92,6 +92,7 @@ class DaniConfig:
     host: str = "127.0.0.1"
     port: int = 8787
     review_rounds: int = 3
+    external_review_limit: int = 10
 
     @property
     def registry_path(self) -> Path:

--- a/dani/models.py
+++ b/dani/models.py
@@ -80,6 +80,7 @@ class NormalizedEvent:
     title: str | None = None
     base_branch: str | None = None
     head_branch: str | None = None
+    delivery_id: str | None = None
     ref: str | None = None
     commit_sha: str | None = None
     is_pull_request: bool = False

--- a/dani/omx_runner.py
+++ b/dani/omx_runner.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Protocol, TextIO
 from uuid import uuid4
 
-from dani.errors import check_transient_capacity_error
+from dani.errors import check_rollout_missing_error, check_transient_capacity_error
 from dani.models import JobRecord, SessionRecord
 
 
@@ -155,6 +155,7 @@ class OmxRunner:
         if not stderr_path.exists():
             return
         stderr_text = stderr_path.read_text(encoding="utf-8", errors="replace")
+        check_rollout_missing_error(stderr_text)
         check_transient_capacity_error(stderr_text)
 
     def close_session(self, runtime_handle: str) -> None:

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -15,6 +15,9 @@ Task: review GitHub issue #$issue_number titled "$issue_title".
 Issue body:
 $issue_body
 
+Existing issue discussion history:
+$discussion
+
 Write one GitHub issue comment.
 Checklist:
 - [ ] AI-understood issue summary

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -90,7 +90,7 @@ After creating or updating the PR, exit.
     "review_round": Template(
         """
 You are reviewing PR #$pr_number in $repo.
-Round: $round_number / 3
+Round: $round_number / $round_total
 PR title: $pr_title
 PR body:
 $pr_body
@@ -98,6 +98,7 @@ $pr_body
 Recent discussion:
 $discussion
 
+$review_mode_note
 Use the code locally and run $$code-review before writing the review comment.
 Do real verification, not only static inspection.
 Checklist:
@@ -116,6 +117,7 @@ After posting the PR comment, exit.
     "final_verdict": Template(
         """
 You are deciding the final verdict for PR #$pr_number in $repo.
+$review_cycle
 PR title: $pr_title
 PR body:
 $pr_body
@@ -123,17 +125,40 @@ $pr_body
 Review history:
 $discussion
 
-Leave exactly one final GitHub PR comment.
+Leave exactly one GitHub PR comment for this review pass.
 Checklist:
 - [ ] Verdict: APPROVE or REJECT
 - [ ] Short reason
 - [ ] Real Result from actual verification
 - [ ] Include concrete evidence appropriate for what you verified
+- [ ] If REJECT, make the next contributor action clear
 - [ ] If APPROVE, include: $approve_signature
 - [ ] If REJECT, include: $reject_signature
 
 Post it with gh:
 gh pr comment $pr_number --repo $repo --body-file <final-verdict.md>
+
+After posting the PR comment, exit.
+        """.strip()
+    ),
+    "human_escalation": Template(
+        """
+You are escalating PR #$pr_number in $repo to a human maintainer.
+Review limit reached: $review_limit
+PR title: $pr_title
+PR body:
+$pr_body
+
+Recent review history:
+$discussion
+
+Leave exactly one GitHub PR comment that:
+- [ ] States automated review stopped after $review_limit review passes
+- [ ] Asks a human maintainer to take over triage / scope / merge judgment
+- [ ] Includes this exact signature: $signature
+
+Post it with gh:
+gh pr comment $pr_number --repo $repo --body-file <human-escalation.md>
 
 After posting the PR comment, exit.
         """.strip()
@@ -170,6 +195,9 @@ After the push succeeds, exit.
 def render_prompt(template_name: str, context: dict[str, Any]) -> str:
     template = TEMPLATES[template_name]
     context = dict(context)
+    context.setdefault("review_cycle", "")
+    context.setdefault("round_total", "3")
+    context.setdefault("review_mode_note", "")
     if template_name != "final_verdict" and "signature" not in context:
         context = {
             **context,

--- a/dani/queue.py
+++ b/dani/queue.py
@@ -85,7 +85,7 @@ class RepoQueueManager:
     def _after_job(self, repo: str, job: JobRecord) -> None:
         if not self._needs_issue_lock(job):
             return
-        if job.stage in _TERMINAL_STAGES or job.status == "failed":
+        if job.stage in _TERMINAL_STAGES or job.status in {"failed", "superseded"}:
             self._flush_deferred(repo)
 
     def _flush_deferred(self, repo: str) -> None:

--- a/dani/server.py
+++ b/dani/server.py
@@ -23,7 +23,7 @@ def create_app(service: DaniService) -> FastAPI:
         if event_name is None:
             raise HTTPException(status_code=400, detail="missing event name")
         payload = parse_body(body)
-        event = normalize_event(event_name, payload)
+        event = normalize_event(event_name, payload, delivery_id=request.headers.get("x-github-delivery"))
         if event is None:
             return {"status": "ignored", "reason": "unsupported_event"}
         return service.handle_event(event)

--- a/dani/service.py
+++ b/dani/service.py
@@ -79,6 +79,7 @@ class DaniService:
             "title": event.title,
             "base_branch": event.base_branch,
             "head_branch": event.head_branch,
+            "delivery_id": event.delivery_id,
             "ref": event.ref,
             "commit_sha": event.commit_sha,
         })
@@ -761,6 +762,10 @@ class DaniService:
             )
             return {"status": "queued", "job_id": job.id, "stage": job.stage}
 
+        event_key = self._external_pull_request_event_key(event)
+        if not self.storage.record_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_external_pr_event"}
+
         if self._has_human_escalation(event.repo_full_name, event.number):
             return {"status": "ignored", "reason": "human_review_required"}
 
@@ -809,6 +814,33 @@ class DaniService:
                 value = str(default_pr)
             if value:
                 fields.append((key, value))
+        return ";".join(f"{key}={value}" for key, value in fields)
+
+    def _external_pull_request_event_key(self, event: NormalizedEvent) -> str:
+        if event.delivery_id:
+            return f"external_pr_event;delivery={event.delivery_id}"
+
+        fields = [
+            ("repo", event.repo_full_name),
+            ("kind", event.kind),
+            ("pr", str(event.number)),
+            ("action", event.action),
+        ]
+        if event.commit_sha:
+            fields.append(("head_sha", event.commit_sha))
+        elif event.head_branch:
+            fields.append(("head_branch", event.head_branch))
+        requested_reviewer = event.payload.get("requested_reviewer") or {}
+        reviewer_login = requested_reviewer.get("login")
+        if reviewer_login:
+            fields.append(("reviewer", str(reviewer_login)))
+        requested_team = event.payload.get("requested_team") or {}
+        team_slug = requested_team.get("slug") or requested_team.get("name")
+        if team_slug:
+            fields.append(("team", str(team_slug)))
+        updated_at = (event.payload.get("pull_request") or {}).get("updated_at")
+        if updated_at:
+            fields.append(("updated_at", str(updated_at)))
         return ";".join(f"{key}={value}" for key, value in fields)
 
     def _latest_review_round(self, repo_full_name: str, pr_number: int) -> int:

--- a/dani/service.py
+++ b/dani/service.py
@@ -173,6 +173,7 @@ class DaniService:
             return self._handle_external_review_round_event(
                 repo,
                 event,
+                source_job=source_job,
                 pr_metadata=pr_metadata,
                 issue_number=issue_number,
                 pr_number=pr_number,
@@ -198,6 +199,7 @@ class DaniService:
         repo: RepoConfig,
         event: NormalizedEvent,
         *,
+        source_job: JobRecord,
         pr_metadata: dict[str, str],
         issue_number: int | None,
         pr_number: int,
@@ -217,6 +219,24 @@ class DaniService:
                 },
             )
             return {"status": "queued", "job_id": verdict_job.id, "stage": verdict_job.stage}
+
+        completed_reviews = self._completed_external_review_count(event.repo_full_name, pr_number)
+        if source_job.status != "completed":
+            completed_reviews += 1
+        if completed_reviews >= self.config.external_review_limit and not self._has_human_escalation(
+            event.repo_full_name, pr_number
+        ):
+            escalation_job = self._enqueue_external_human_escalation(
+                repo,
+                issue_number=issue_number,
+                pr_number=pr_number,
+                metadata={
+                    **pr_metadata,
+                    "title": (pr_metadata.get("title") or event.title or ""),
+                    "external_contribution": True,
+                },
+            )
+            return {"status": "queued", "job_id": escalation_job.id, "stage": escalation_job.stage}
         return {"status": "updated", "stage": "review_round"}
 
     def _enqueue_job(
@@ -785,9 +805,8 @@ class DaniService:
         completed_reviews = self._completed_external_review_count(event.repo_full_name, event.number)
         consumed_review_rounds = self._consumed_external_review_rounds(event.repo_full_name, event.number)
         if completed_reviews >= self.config.external_review_limit:
-            escalation_job = self._enqueue_job(
+            escalation_job = self._enqueue_external_human_escalation(
                 repo,
-                stage="human_escalation",
                 issue_number=issue_number,
                 pr_number=event.number,
                 metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
@@ -807,6 +826,22 @@ class DaniService:
             metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
         )
         return {"status": "queued", "job_id": job.id, "stage": job.stage}
+
+    def _enqueue_external_human_escalation(
+        self,
+        repo: RepoConfig,
+        *,
+        issue_number: int | None,
+        pr_number: int,
+        metadata: dict[str, Any],
+    ) -> JobRecord:
+        return self._enqueue_job(
+            repo,
+            stage="human_escalation",
+            issue_number=issue_number,
+            pr_number=pr_number,
+            metadata=metadata,
+        )
 
     def _latest_resumable_session(
         self,

--- a/dani/service.py
+++ b/dani/service.py
@@ -110,30 +110,7 @@ class DaniService:
     def _handle_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         stage = signature.get("stage")
         if stage == "review_round":
-            event_key = self._agent_event_key(signature, default_pr=event.number if event.is_pull_request else None)
-            if not self.storage.record_processed_event(event_key):
-                return {"status": "ignored", "reason": "duplicate_agent_event"}
-            review_round = int(signature["round"])
-            pr_number = int(signature["pr"])
-            issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
-            repo = self.storage.get_repo(event.repo_full_name)
-            if repo is None:
-                return {"status": "ignored", "reason": "missing_repo"}
-            pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
-            next_job = self._enqueue_job(
-                repo,
-                stage="implementation",
-                issue_number=issue_number,
-                pr_number=pr_number,
-                review_round=review_round,
-                metadata={
-                    **pr_metadata,
-                    "title": (pr_metadata.get("title") or event.title or ""),
-                    "review_comment_body": event.body or "",
-                    "triggering_review_round": review_round,
-                },
-            )
-            return {"status": "queued", "job_id": next_job.id, "stage": next_job.stage}
+            return self._handle_review_round_event(event, signature)
 
         if stage == "implementation" and event.kind == "pull_request_comment":
             pr_number = int(signature.get("pr") or event.number)
@@ -178,6 +155,68 @@ class DaniService:
             return {"status": "merged", "pr_number": int(signature["pr"])}
 
         return {"status": "updated", "stage": stage}
+
+    def _handle_review_round_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
+        event_key = self._agent_event_key(signature, default_pr=event.number if event.is_pull_request else None)
+        if not self.storage.record_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_agent_event"}
+        review_round = int(signature["round"])
+        pr_number = int(signature["pr"])
+        issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
+        source_job = self.storage.get_job(signature.get("job", ""))
+        repo = self.storage.get_repo(event.repo_full_name)
+        if repo is None:
+            return {"status": "ignored", "reason": "missing_repo"}
+        pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
+        if bool(source_job and source_job.metadata.get("external_contribution")):
+            return self._handle_external_review_round_event(
+                repo,
+                event,
+                pr_metadata=pr_metadata,
+                issue_number=issue_number,
+                pr_number=pr_number,
+                review_round=review_round,
+            )
+        next_job = self._enqueue_job(
+            repo,
+            stage="implementation",
+            issue_number=issue_number,
+            pr_number=pr_number,
+            review_round=review_round,
+            metadata={
+                **pr_metadata,
+                "title": (pr_metadata.get("title") or event.title or ""),
+                "review_comment_body": event.body or "",
+                "triggering_review_round": review_round,
+            },
+        )
+        return {"status": "queued", "job_id": next_job.id, "stage": next_job.stage}
+
+    def _handle_external_review_round_event(
+        self,
+        repo: RepoConfig,
+        event: NormalizedEvent,
+        *,
+        pr_metadata: dict[str, str],
+        issue_number: int | None,
+        pr_number: int,
+        review_round: int,
+    ) -> dict[str, Any]:
+        if self._is_approve_comment(event.body):
+            verdict_job = self._enqueue_job(
+                repo,
+                stage="final_verdict",
+                issue_number=issue_number,
+                pr_number=pr_number,
+                review_round=review_round,
+                metadata={
+                    **pr_metadata,
+                    "title": (pr_metadata.get("title") or event.title or ""),
+                    "external_contribution": True,
+                },
+            )
+            return {"status": "queued", "job_id": verdict_job.id, "stage": verdict_job.stage}
+        return {"status": "updated", "stage": "review_round"}
 
     def _enqueue_job(
         self,
@@ -316,6 +355,9 @@ class DaniService:
         if job.stage == "review_round":
             return self._build_review_round_prompt(repo, job, issue_number, pr_number, pr_title, pr_body)
 
+        if job.stage == "human_escalation":
+            return self._build_human_escalation_prompt(repo, job, issue_number, pr_number, pr_title, pr_body)
+
         return self._build_final_verdict_prompt(job, issue_number, pr_number, pr_title, pr_body)
 
     def _verify_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
@@ -330,6 +372,9 @@ class DaniService:
             return
         if job.stage == "review_round":
             self._verify_review_round_side_effect(repo, job)
+            return
+        if job.stage == "human_escalation":
+            self._verify_human_escalation_side_effect(repo, job)
             return
         if job.stage == "final_verdict":
             self._verify_final_verdict_side_effect(repo, job)
@@ -460,6 +505,7 @@ class DaniService:
         pr_discussion = self._render_pr_discussion(repo.full_name, pr_number)
         if pr_discussion:
             discussion_parts.append(pr_discussion)
+        is_external_review = bool(job.metadata.get("external_contribution"))
         return render_prompt(
             "review_round",
             {
@@ -469,6 +515,13 @@ class DaniService:
                 "pr_body": pr_body,
                 "discussion": "\n\n".join(discussion_parts),
                 "round_number": job.review_round or 1,
+                "round_total": self.config.external_review_limit if is_external_review else self.config.review_rounds,
+                "review_mode_note": (
+                    "This is an external contribution PR. The contributor owns any follow-up implementation. "
+                    "If the PR is ready to merge, include /approve in your review comment so dani can run the final verdict pass."
+                    if is_external_review
+                    else ""
+                ),
                 "signature": build_signature(**signature_fields),
             },
         )
@@ -495,10 +548,43 @@ class DaniService:
                 "pr_title": pr_title,
                 "pr_body": pr_body,
                 "discussion": "\n\n".join(discussion_parts),
+                "review_cycle": (
+                    f"Review pass: {job.review_round} / {self.config.external_review_limit}"
+                    if job.review_round and job.metadata.get("external_contribution")
+                    else ""
+                ),
                 "approve_signature": build_signature(
                     stage="final_verdict", job=job.id, pr=pr_number, verdict="APPROVE"
                 ),
                 "reject_signature": build_signature(stage="final_verdict", job=job.id, pr=pr_number, verdict="REJECT"),
+            },
+        )
+
+    def _build_human_escalation_prompt(
+        self,
+        repo: RepoConfig,
+        job: JobRecord,
+        issue_number: int,
+        pr_number: int,
+        pr_title: str,
+        pr_body: str,
+    ) -> str:
+        discussion_parts = []
+        if issue_number:
+            discussion_parts.append(f"Related issue: #{issue_number}")
+        pr_discussion = self._render_pr_discussion(repo.full_name, pr_number)
+        if pr_discussion:
+            discussion_parts.append(pr_discussion)
+        return render_prompt(
+            "human_escalation",
+            {
+                "repo": repo.full_name,
+                "pr_number": pr_number,
+                "pr_title": pr_title,
+                "pr_body": pr_body,
+                "discussion": "\n\n".join(discussion_parts),
+                "review_limit": self.config.external_review_limit,
+                "signature": build_signature(stage="human_escalation", job=job.id, pr=pr_number),
             },
         )
 
@@ -559,6 +645,11 @@ class DaniService:
             or self._has_exact_pr_signature(repo.full_name, int(job.pr_number or 0), reject_signature)
         ):
             raise RuntimeError("final-verdict-comment-missing")
+
+    def _verify_human_escalation_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
+        signature = build_signature(stage="human_escalation", job=job.id, pr=int(job.pr_number or 0))
+        if not self._has_exact_pr_signature(repo.full_name, int(job.pr_number or 0), signature):
+            raise RuntimeError("human-escalation-comment-missing")
 
     def _has_exact_pr_signature(self, repo_full_name: str, pr_number: int, signature: str) -> bool:
         return bool(
@@ -656,13 +747,41 @@ class DaniService:
                 self.storage.update_job(signature["job"], status="completed", pr_number=event.number)
         if issue_number is None:
             issue_number = self._extract_issue_number(event.body)
+        is_agent_managed_pr = bool(signature and signature.get("stage") == "implementation")
+        if is_agent_managed_pr:
+            if event.action != "opened":
+                return {"status": "ignored", "reason": "agent_managed_pr_followup"}
+            job = self._enqueue_job(
+                repo,
+                stage="review_round",
+                issue_number=issue_number,
+                pr_number=event.number,
+                review_round=1,
+                metadata={"title": event.title or "", "body": event.body or ""},
+            )
+            return {"status": "queued", "job_id": job.id, "stage": job.stage}
+
+        if self._has_human_escalation(event.repo_full_name, event.number):
+            return {"status": "ignored", "reason": "human_review_required"}
+
+        completed_reviews = self._external_review_count(event.repo_full_name, event.number)
+        if completed_reviews >= self.config.external_review_limit:
+            escalation_job = self._enqueue_job(
+                repo,
+                stage="human_escalation",
+                issue_number=issue_number,
+                pr_number=event.number,
+                metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
+            )
+            return {"status": "queued", "job_id": escalation_job.id, "stage": escalation_job.stage}
+
         job = self._enqueue_job(
             repo,
             stage="review_round",
             issue_number=issue_number,
             pr_number=event.number,
-            review_round=1,
-            metadata={"title": event.title or "", "body": event.body or ""},
+            review_round=completed_reviews + 1,
+            metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
         )
         return {"status": "queued", "job_id": job.id, "stage": job.stage}
 
@@ -698,6 +817,18 @@ class DaniService:
             for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
         ]
         return max(rounds, default=0)
+
+    def _external_review_count(self, repo_full_name: str, pr_number: int) -> int:
+        return sum(
+            1
+            for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
+            if job.metadata.get("external_contribution")
+        )
+
+    def _has_human_escalation(self, repo_full_name: str, pr_number: int) -> bool:
+        return bool(
+            self.storage.find_jobs(repo_full_name=repo_full_name, stage="human_escalation", pr_number=pr_number)
+        )
 
     def _issue_number_for_signature_event(
         self,

--- a/dani/service.py
+++ b/dani/service.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from dani.errors import TransientCapacityError
+from dani.errors import ROLLOUT_MISSING_PATTERNS, RolloutMissingError, TransientCapacityError
 from dani.git_sync import DevSyncConflictError, GitDevSyncer
 from dani.github import GitHubCLI, MergeConflictError
 from dani.models import DaniConfig, JobRecord, NormalizedEvent, RepoConfig, SessionRecord, utc_now
@@ -76,6 +76,26 @@ class DaniService:
     def state_snapshot(self) -> dict[str, Any]:
         return self.storage.snapshot()
 
+    def restart_issue(self, repo_full_name: str, issue_number: int) -> JobRecord:
+        repo = self.storage.get_repo(repo_full_name)
+        if repo is None:
+            msg = f"missing_repo: {repo_full_name}"
+            raise RuntimeError(msg)
+
+        for job in self.storage.find_jobs(repo_full_name=repo_full_name, issue_number=issue_number):
+            self.storage.update_job(job.id, status="superseded")
+
+        issue_metadata = self._issue_metadata(repo_full_name, issue_number)
+        return self._enqueue_job(
+            repo,
+            stage="issue_request",
+            issue_number=issue_number,
+            metadata={
+                "title": issue_metadata.get("title", f"Issue #{issue_number}"),
+                "body": issue_metadata.get("body", ""),
+            },
+        )
+
     def handle_event(self, event: NormalizedEvent) -> dict[str, Any]:
         self.storage.append_event({
             "repo_full_name": event.repo_full_name,
@@ -135,36 +155,6 @@ class DaniService:
 
         return {"status": "updated", "stage": stage}
 
-    def _handle_review_round_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
-        event_key = self._agent_event_key(signature, default_pr=event.number if event.is_pull_request else None)
-        if not self.storage.record_processed_event(event_key):
-            return {"status": "ignored", "reason": "duplicate_agent_event"}
-        review_round = int(signature["round"])
-        pr_number = int(signature["pr"])
-        issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
-        if issue_number is None:
-            return {"status": "ignored", "reason": "untracked_pr"}
-        repo = self.storage.get_repo(event.repo_full_name)
-        if repo is None:
-            return {"status": "ignored", "reason": "missing_repo"}
-        if not self._is_pr_open(event.repo_full_name, pr_number):
-            return {"status": "ignored", "reason": "pr_not_open"}
-        pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
-        next_job = self._enqueue_job(
-            repo,
-            stage="implementation",
-            issue_number=issue_number,
-            pr_number=pr_number,
-            review_round=review_round,
-            metadata={
-                **pr_metadata,
-                "title": (pr_metadata.get("title") or event.title or ""),
-                "review_comment_body": event.body or "",
-                "triggering_review_round": review_round,
-            },
-        )
-        return {"status": "queued", "job_id": next_job.id, "stage": next_job.stage}
-
     def _handle_implementation_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         pr_number = int(signature.get("pr") or event.number)
         event_key = self._agent_event_key(signature, default_pr=pr_number)
@@ -210,10 +200,13 @@ class DaniService:
     def _handle_merge_conflict_resolution_agent_event(
         self, event: NormalizedEvent, signature: dict[str, str]
     ) -> dict[str, Any]:
+        pr_number = int(signature["pr"])
+        event_key = self._agent_event_key(signature, default_pr=pr_number)
+        if not self.storage.record_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_agent_event"}
         repo = self.storage.get_repo(event.repo_full_name)
         if repo is None:
             return {"status": "ignored", "reason": "missing_repo"}
-        pr_number = int(signature["pr"])
         if not self._is_pr_open(event.repo_full_name, pr_number):
             return {"status": "ignored", "reason": "pr_not_open"}
         pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
@@ -234,6 +227,9 @@ class DaniService:
 
     def _handle_final_verdict_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         pr_number = int(signature["pr"])
+        event_key = self._agent_event_key(signature, default_pr=pr_number)
+        if self.storage.has_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_agent_event"}
         if not self._is_pr_open(event.repo_full_name, pr_number):
             return {"status": "ignored", "reason": "pr_not_open"}
         try:
@@ -243,10 +239,13 @@ class DaniService:
             if repo is None:
                 return {"status": "ignored", "reason": "missing_repo"}
             pull_request = self.github.get_pull_request(event.repo_full_name, pr_number)
+            issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
+            if issue_number is None:
+                issue_number = self._extract_issue_number(pull_request.get("body"))
             merge_conflict_job = self._enqueue_job(
                 repo,
                 stage="merge_conflict_resolution",
-                issue_number=self._extract_issue_number(pull_request.get("body")),
+                issue_number=issue_number,
                 pr_number=pr_number,
                 metadata={
                     "title": pull_request.get("title") or event.title or f"PR #{pr_number}",
@@ -256,7 +255,9 @@ class DaniService:
                     "conflict_reason": str(exc),
                 },
             )
+            self.storage.record_processed_event(event_key)
             return {"status": "queued", "job_id": merge_conflict_job.id, "stage": merge_conflict_job.stage}
+        self.storage.record_processed_event(event_key)
         return {"status": "merged", "pr_number": pr_number}
 
     def _handle_review_round_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
@@ -285,6 +286,10 @@ class DaniService:
                 pr_number=pr_number,
                 review_round=review_round,
             )
+        if issue_number is None:
+            return {"status": "ignored", "reason": "untracked_pr"}
+        if not self._is_pr_open(event.repo_full_name, pr_number):
+            return {"status": "ignored", "reason": "pr_not_open"}
         next_job = self._enqueue_job(
             repo,
             stage="implementation",
@@ -368,6 +373,11 @@ class DaniService:
         return job
 
     def _run_job(self, job: JobRecord) -> None:
+        stored_job = self.storage.get_job(job.id)
+        if stored_job is not None and stored_job.status == "superseded":
+            job.status = "superseded"
+            return
+
         repo = self.storage.get_repo(job.repo_full_name)
         if repo is None:
             self.storage.update_job(job.id, status="failed", metadata={**job.metadata, "error": "missing repo"})
@@ -483,16 +493,18 @@ class DaniService:
         attempt: int,
         retry_history: list[dict[str, str]],
     ) -> None:
-        self.storage.update_job(
-            job.id,
-            status="failed",
-            metadata={
-                **job.metadata,
-                "error": str(exc),
-                "retry_attempts": attempt - 1,
-                "retry_history": retry_history,
-            },
-        )
+        metadata = {
+            **job.metadata,
+            "error": str(exc),
+            "retry_attempts": attempt - 1,
+            "retry_history": retry_history,
+        }
+        if self._is_rollout_missing_error(exc):
+            metadata["error"] = "rollout_missing"
+            metadata["error_detail"] = str(exc)
+            with contextlib.suppress(Exception):
+                self._post_session_lost_warning(job)
+        self.storage.update_job(job.id, status="failed", metadata=metadata)
 
     def _run_dev_sync_job(self, repo: RepoConfig, job: JobRecord) -> None:
         session = None
@@ -627,6 +639,7 @@ class DaniService:
                 "issue_number": issue_number,
                 "issue_title": issue_title,
                 "issue_body": issue_body,
+                "discussion": self._render_issue_discussion(repo.full_name, issue_number),
                 "signature": build_signature(stage="issue_request", job=job.id, issue=issue_number),
             },
         )
@@ -846,12 +859,13 @@ class DaniService:
         )
 
     def _verify_issue_request_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
-        if self.github.latest_signature_comment(repo.full_name, int(job.issue_number or 0), kind="issue") is None:
+        signature = build_signature(stage="issue_request", job=job.id, issue=int(job.issue_number or 0))
+        if not self._has_exact_issue_signature(repo.full_name, int(job.issue_number or 0), signature):
             raise RuntimeError("issue-request-comment-missing")
 
     def _verify_issue_followup_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
-        latest_comment = self.github.latest_signature_comment(repo.full_name, int(job.issue_number or 0), kind="issue")
-        if latest_comment is None or latest_comment[1].get("stage") != "issue_followup":
+        signature = build_signature(stage="issue_followup", job=job.id, issue=int(job.issue_number or 0))
+        if not self._has_exact_issue_signature(repo.full_name, int(job.issue_number or 0), signature):
             raise RuntimeError("issue-followup-comment-missing")
 
     def _verify_implementation_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
@@ -916,6 +930,13 @@ class DaniService:
     def _has_exact_pr_signature(self, repo_full_name: str, pr_number: int, signature: str) -> bool:
         return bool(
             self.github.find_comments_by_signature(repo_full_name, pr_number, kind="pr", signature_fragment=signature)
+        )
+
+    def _has_exact_issue_signature(self, repo_full_name: str, issue_number: int, signature: str) -> bool:
+        return bool(
+            self.github.find_comments_by_signature(
+                repo_full_name, issue_number, kind="issue", signature_fragment=signature
+            )
         )
 
     def _is_approve_comment(self, body: str | None) -> bool:
@@ -1230,3 +1251,44 @@ class DaniService:
             author = comment.get("user", {}).get("login") or comment.get("author", {}).get("login") or "unknown"
             rendered.append(f"[{author}]\n{body}")
         return "\n\n".join(rendered)
+
+    def _render_issue_discussion(self, repo_full_name: str, issue_number: int, *, limit: int = 8) -> str:
+        comments = self.github.issue_comments(repo_full_name, issue_number)
+        rendered: list[str] = []
+        for comment in comments[-limit:]:
+            body = str(comment.get("body") or "").strip()
+            if not body:
+                continue
+            author = comment.get("user", {}).get("login") or comment.get("author", {}).get("login") or "unknown"
+            rendered.append(f"[{author}]\n{body}")
+        return "\n\n".join(rendered)
+
+    def _is_rollout_missing_error(self, exc: Exception) -> bool:
+        if isinstance(exc, RolloutMissingError):
+            return True
+        error_text = str(exc)
+        return any(pattern.search(error_text) for pattern in ROLLOUT_MISSING_PATTERNS)
+
+    def _post_session_lost_warning(self, job: JobRecord) -> None:
+        if job.stage != "issue_followup" or job.issue_number is None:
+            return
+        event_key = f"repo={job.repo_full_name};stage=session_lost;issue={job.issue_number}"
+        signature = build_signature(stage="session_lost", issue=job.issue_number)
+        if self.github.find_comments_by_signature(
+            job.repo_full_name,
+            job.issue_number,
+            kind="issue",
+            signature_fragment=signature,
+        ):
+            if not self.storage.has_processed_event(event_key):
+                self.storage.record_processed_event(event_key)
+            return
+        if self.storage.has_processed_event(event_key):
+            return
+        body = (
+            "⚠️ dani 세션 기록이 유실되어 이전 대화를 이어갈 수 없습니다. "
+            f"`dani restart-issue {job.repo_full_name} {job.issue_number}` 로 새 세션을 시작해 주세요.\n\n"
+            f"{signature}"
+        )
+        self.github.create_issue_comment(job.repo_full_name, job.issue_number, body)
+        self.storage.record_processed_event(event_key)

--- a/dani/service.py
+++ b/dani/service.py
@@ -762,6 +762,19 @@ class DaniService:
             )
             return {"status": "queued", "job_id": job.id, "stage": job.stage}
 
+        return self._queue_external_pull_request_review(
+            repo,
+            event,
+            issue_number=issue_number,
+        )
+
+    def _queue_external_pull_request_review(
+        self,
+        repo: RepoConfig,
+        event: NormalizedEvent,
+        *,
+        issue_number: int | None,
+    ) -> dict[str, Any]:
         event_key = self._external_pull_request_event_key(event)
         if not self.storage.record_processed_event(event_key):
             return {"status": "ignored", "reason": "duplicate_external_pr_event"}
@@ -769,7 +782,8 @@ class DaniService:
         if self._has_human_escalation(event.repo_full_name, event.number):
             return {"status": "ignored", "reason": "human_review_required"}
 
-        completed_reviews = self._external_review_count(event.repo_full_name, event.number)
+        completed_reviews = self._completed_external_review_count(event.repo_full_name, event.number)
+        consumed_review_rounds = self._consumed_external_review_rounds(event.repo_full_name, event.number)
         if completed_reviews >= self.config.external_review_limit:
             escalation_job = self._enqueue_job(
                 repo,
@@ -780,12 +794,16 @@ class DaniService:
             )
             return {"status": "queued", "job_id": escalation_job.id, "stage": escalation_job.stage}
 
+        if len(consumed_review_rounds) >= self.config.external_review_limit:
+            return {"status": "ignored", "reason": "external_review_limit_pending"}
+
+        next_review_round = max(consumed_review_rounds, default=0) + 1
         job = self._enqueue_job(
             repo,
             stage="review_round",
             issue_number=issue_number,
             pr_number=event.number,
-            review_round=completed_reviews + 1,
+            review_round=next_review_round,
             metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
         )
         return {"status": "queued", "job_id": job.id, "stage": job.stage}
@@ -850,12 +868,23 @@ class DaniService:
         ]
         return max(rounds, default=0)
 
-    def _external_review_count(self, repo_full_name: str, pr_number: int) -> int:
+    def _completed_external_review_count(self, repo_full_name: str, pr_number: int) -> int:
         return sum(
             1
             for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
-            if job.metadata.get("external_contribution")
+            if job.metadata.get("external_contribution") and job.status == "completed"
         )
+
+    def _consumed_external_review_rounds(self, repo_full_name: str, pr_number: int) -> set[int]:
+        return {
+            int(job.review_round)
+            for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
+            if (
+                job.metadata.get("external_contribution")
+                and job.review_round is not None
+                and job.status in {"queued", "launched", "completed"}
+            )
+        }
 
     def _has_human_escalation(self, repo_full_name: str, pr_number: int) -> bool:
         return bool(

--- a/dani/service.py
+++ b/dani/service.py
@@ -14,7 +14,7 @@ from dani.models import DaniConfig, JobRecord, NormalizedEvent, RepoConfig, Sess
 from dani.omx_runner import OmxRunner
 from dani.prompts import render_prompt
 from dani.queue import RepoQueueManager
-from dani.signatures import build_signature, parse_signature
+from dani.signatures import build_signature, is_opt_out_comment, parse_signature
 from dani.storage import JsonStorage
 
 ISSUE_REF_PATTERN = re.compile(r"#(?P<number>\d+)")
@@ -94,6 +94,9 @@ class DaniService:
         repo = self.storage.get_repo(event.repo_full_name)
         if repo is None or not repo.enabled:
             return {"status": "ignored", "reason": "unregistered_repo"}
+
+        if event.kind in {"issue_comment", "pull_request_comment"} and is_opt_out_comment(event.body):
+            return {"status": "ignored", "reason": "comment_opt_out"}
 
         signature = parse_signature(event.body or "")
         if signature and event.kind != "pull_request_opened":

--- a/dani/signatures.py
+++ b/dani/signatures.py
@@ -3,6 +3,18 @@ from __future__ import annotations
 import re
 
 SIGNATURE_PATTERN = re.compile(r"<!--\s*(?:dani|DANI):\s*(?P<body>[^>]+)\s*-->")
+IGNORE_COMMAND_PATTERN = re.compile(r"(?mi)(?:^|\s)/dani\s+ignore(?:\s|$)")
+
+
+def _parse_signature_body(raw_body: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    parts = raw_body.split(";") if ";" in raw_body else raw_body.split()
+    for item in parts:
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        fields[key.strip()] = value.strip()
+    return fields
 
 
 def build_signature(**fields: object) -> str:
@@ -21,16 +33,30 @@ def parse_signature(text: str | None) -> dict[str, str] | None:
     match = SIGNATURE_PATTERN.search(text)
     if not match:
         return None
-    fields: dict[str, str] = {}
-    raw_body = match.group("body")
-    parts = raw_body.split(";") if ";" in raw_body else raw_body.split()
-    for item in parts:
-        if "=" not in item:
-            continue
-        key, value = item.split("=", 1)
-        fields[key.strip()] = value.strip()
+    fields = _parse_signature_body(match.group("body"))
     return fields or None
 
 
+def parse_agent_signature(text: str | None) -> dict[str, str] | None:
+    fields = parse_signature(text)
+    if fields is None or fields.get("stage", "").lower() == "ignore":
+        return None
+    return fields
+
+
 def has_agent_signature(text: str | None) -> bool:
-    return parse_signature(text) is not None
+    return parse_agent_signature(text) is not None
+
+
+def has_ignore_signature(text: str | None) -> bool:
+    if not text:
+        return False
+    for match in SIGNATURE_PATTERN.finditer(text):
+        fields = _parse_signature_body(match.group("body"))
+        if fields.get("stage", "").lower() == "ignore":
+            return True
+    return False
+
+
+def is_opt_out_comment(text: str | None) -> bool:
+    return has_ignore_signature(text) or bool(text and IGNORE_COMMAND_PATTERN.search(text))

--- a/dani/webhook.py
+++ b/dani/webhook.py
@@ -66,7 +66,13 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             commit_sha=commit_sha,
         )
 
-    if event_name == "pull_request" and action == "opened":
+    if event_name == "pull_request" and action in {
+        "opened",
+        "synchronize",
+        "reopened",
+        "ready_for_review",
+        "review_requested",
+    }:
         pull_request = payload["pull_request"]
         return NormalizedEvent(
             kind="pull_request_opened",

--- a/dani/webhook.py
+++ b/dani/webhook.py
@@ -15,7 +15,9 @@ def verify_github_signature(secret: str, body: bytes, signature_header: str | No
     return hmac.compare_digest(expected, signature_header)
 
 
-def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent | None:
+def normalize_event(
+    event_name: str, payload: dict[str, Any], *, delivery_id: str | None = None
+) -> NormalizedEvent | None:
     repo = payload.get("repository") or {}
     repo_full_name = repo.get("full_name")
     if not repo_full_name:
@@ -33,6 +35,7 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             payload=payload,
             body=issue.get("body"),
             title=issue.get("title"),
+            delivery_id=delivery_id,
         )
 
     if event_name == "issue_comment" and action == "created":
@@ -47,6 +50,7 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             payload=payload,
             body=payload["comment"].get("body"),
             title=issue.get("title"),
+            delivery_id=delivery_id,
             is_pull_request=is_pr,
         )
 
@@ -62,6 +66,7 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             number=0,
             actor_login=payload["sender"]["login"],
             payload=payload,
+            delivery_id=delivery_id,
             ref=ref,
             commit_sha=commit_sha,
         )
@@ -85,6 +90,8 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             title=pull_request.get("title"),
             base_branch=pull_request["base"]["ref"],
             head_branch=pull_request["head"]["ref"],
+            delivery_id=delivery_id,
+            commit_sha=pull_request["head"].get("sha"),
             is_pull_request=True,
         )
 
@@ -101,6 +108,8 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             title=pull_request.get("title"),
             base_branch=pull_request["base"]["ref"],
             head_branch=pull_request["head"]["ref"],
+            delivery_id=delivery_id,
+            commit_sha=pull_request["head"].get("sha"),
             is_pull_request=True,
         )
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -125,6 +125,13 @@ class FakeOmxRunner:
                 pr_number,
                 build_signature(stage="review_round", job=job.id, pr=pr_number, round=job.review_round or 1),
             )
+        elif job.stage == "human_escalation":
+            pr_number = int((signature or {}).get("pr", job.pr_number or 0))
+            self.github.add_pr_signature(
+                repo_full_name,
+                pr_number,
+                build_signature(stage="human_escalation", job=job.id, pr=pr_number),
+            )
         elif job.stage == "dev_sync":
             pass
         else:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -90,6 +90,16 @@ class FakeGitHubCLI:
     def add_pr_signature(self, repo_full_name: str, pr_number: int, signature: str) -> None:
         self.pr_comment_map.setdefault((repo_full_name, pr_number), []).append({"body": signature})
 
+    def create_issue_comment(self, repo_full_name: str, issue_number: int, body: str) -> dict[str, Any]:
+        comment = {"body": body}
+        self.issue_comment_map.setdefault((repo_full_name, issue_number), []).append(comment)
+        return comment
+
+    def create_pr_comment(self, repo_full_name: str, pr_number: int, body: str) -> dict[str, Any]:
+        comment = {"body": body}
+        self.pr_comment_map.setdefault((repo_full_name, pr_number), []).append(comment)
+        return comment
+
     def add_pull_request(
         self,
         repo_full_name: str,
@@ -136,10 +146,14 @@ class FakeOmxRunner:
         self.resumes: list[ResumeRecord] = []
         self.closed_sessions: list[str] = []
         self._transient_failures_remaining: int = 0
+        self.resume_error: Exception | None = None
 
     def set_transient_failures(self, count: int) -> None:
         """Configure the runner to raise TransientCapacityError for the next *count* wait() calls."""
         self._transient_failures_remaining = count
+
+    def set_resume_failure(self, exc: Exception) -> None:
+        self.resume_error = exc
 
     def launch(self, repo_path: Path, job: JobRecord, prompt: str) -> SessionRecord:
         repo_full_name = job.repo_full_name
@@ -199,6 +213,13 @@ class FakeOmxRunner:
                 pr_number,
                 build_signature(stage="merge_conflict_resolution", job=job.id, pr=pr_number),
             )
+        elif job.stage == "human_escalation":
+            pr_number = int((signature or {}).get("pr", job.pr_number or 0))
+            self.github.add_pr_signature(
+                repo_full_name,
+                pr_number,
+                build_signature(stage="human_escalation", job=job.id, pr=pr_number),
+            )
         elif job.stage != "dev_sync":
             self.github.add_pr_signature(
                 repo_full_name,
@@ -207,6 +228,8 @@ class FakeOmxRunner:
             )
 
     def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
+        if self.resume_error is not None:
+            raise self.resume_error
         issue_number = job.issue_number or 0
         self.github.add_issue_signature(
             job.repo_full_name,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,7 +8,7 @@ from dani.errors import TransientCapacityError
 from dani.git_sync import DevSyncConflictError, DevSyncContext, DevSyncOutcome
 from dani.github import MergeConflictError
 from dani.models import JobRecord, SessionRecord
-from dani.signatures import build_signature, parse_signature
+from dani.signatures import build_signature, is_opt_out_comment, parse_agent_signature, parse_signature
 
 _CAPACITY_MSG = "capacity"
 
@@ -60,7 +60,9 @@ class FakeGitHubCLI:
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
         for comment in reversed(comments):
-            parsed = parse_signature(comment.get("body", ""))
+            if is_opt_out_comment(comment.get("body", "")):
+                continue
+            parsed = parse_agent_signature(comment.get("body", ""))
             if parsed is not None:
                 return comment, parsed
         return None
@@ -71,7 +73,11 @@ class FakeGitHubCLI:
         comments = (
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
-        return [comment for comment in comments if signature_fragment in (comment.get("body") or "")]
+        return [
+            comment
+            for comment in comments
+            if not is_opt_out_comment(comment.get("body", "")) and signature_fragment in (comment.get("body") or "")
+        ]
 
     def merge_pull_request(self, repo_full_name: str, pr_number: int) -> None:
         if (repo_full_name, pr_number) in self.merge_conflicts:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from typer.testing import CliRunner
 
 import dani.cli as cli_module
 from dani.cli import app
+from dani.models import JobRecord
 
 
 class FakeBootstrapService:
@@ -15,6 +16,18 @@ class FakeBootstrapService:
     def bootstrap_repo(self, repo_full_name: str) -> int:
         self.calls.append(("bootstrap_repo", repo_full_name))
         return self.count
+
+    def wait_for_idle(self) -> None:
+        self.calls.append(("wait_for_idle", None))
+
+
+class FakeRestartService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, int] | tuple[str, None]] = []
+
+    def restart_issue(self, repo_full_name: str, issue_number: int) -> JobRecord:
+        self.calls.append(("restart_issue", repo_full_name, issue_number))
+        return JobRecord(repo_full_name=repo_full_name, stage="issue_request", issue_number=issue_number, id="job-123")
 
     def wait_for_idle(self) -> None:
         self.calls.append(("wait_for_idle", None))
@@ -44,3 +57,19 @@ def test_bootstrap_waits_for_idle_before_exiting(tmp_path: Path, monkeypatch) ->
     assert result.exit_code == 0
     assert fake_service.calls == [("bootstrap_repo", "acme/demo"), ("wait_for_idle", None)]
     assert result.stdout.strip() == "processed 2 issues"
+
+
+def test_restart_issue_invokes_service_waits_for_idle_and_prints_job(tmp_path: Path, monkeypatch) -> None:
+    runner = CliRunner()
+    data_dir = tmp_path / ".dani"
+    fake_service = FakeRestartService()
+    monkeypatch.setattr(cli_module, "build_service", lambda data_dir: fake_service)
+
+    result = runner.invoke(app, ["restart-issue", "acme/demo", "41", "--data-dir", str(data_dir)])
+
+    assert result.exit_code == 0
+    assert fake_service.calls == [("restart_issue", "acme/demo", 41), ("wait_for_idle", None)]
+    payload = json.loads(result.stdout)
+    assert payload["id"] == "job-123"
+    assert payload["stage"] == "issue_request"
+    assert payload["issue_number"] == 41

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -254,6 +254,16 @@ def test_merge_pull_request_raises_merge_conflict_error_for_merge_api_failures(
     assert exc_info.value.status == status
 
 
+def test_merge_pull_request_reraises_non_conflict_github_failures(fake_repo: FakeRepo) -> None:
+    fake_repo.pulls[7].merge_exception = GithubException(500, {"message": "GitHub outage"}, {})
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    with pytest.raises(GithubException) as exc_info:
+        github.merge_pull_request("acme/demo", 7)
+
+    assert exc_info.value.status == 500
+
+
 def test_merge_pull_request_raises_merge_conflict_error_when_merge_status_is_false(fake_repo: FakeRepo) -> None:
     fake_repo.pulls[7].merge_status = FakeMergeStatus(merged=False, message="Pull Request is not mergeable")
     github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -175,6 +175,42 @@ def test_create_issue_and_pr_comments_use_repository_objects(fake_repo: FakeRepo
     assert fake_repo.pulls[7].created_issue_comments == ["hello pr"]
 
 
+def test_latest_signature_comment_ignores_opt_out_marker(fake_repo: FakeRepo) -> None:
+    fake_repo.issues[5] = FakeIssue([
+        "<!-- dani:stage=issue_request;job=job-1;issue=5 -->",
+        "<!-- dani:stage=ignore -->",
+    ])
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    latest = github.latest_signature_comment("acme/demo", 5, kind="issue")
+
+    assert latest is not None
+    assert latest[1]["stage"] == "issue_request"
+
+
+def test_latest_signature_comment_skips_dani_ignore_command_even_with_embedded_signature(fake_repo: FakeRepo) -> None:
+    fake_repo.issues[5] = FakeIssue([
+        "<!-- dani:stage=issue_request;job=job-1;issue=5 -->",
+        "/dani ignore\nQuoted marker <!-- dani:stage=review_round;job=job-2;pr=7;round=1 -->",
+    ])
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    latest = github.latest_signature_comment("acme/demo", 5, kind="issue")
+
+    assert latest is not None
+    assert latest[1]["stage"] == "issue_request"
+
+
+def test_find_comments_by_signature_skips_opt_out_comment_that_quotes_exact_signature(fake_repo: FakeRepo) -> None:
+    signature = "<!-- dani:stage=review_round;job=job-2;pr=7;round=1 -->"
+    fake_repo.pulls[7] = FakePullRequest(number=7, body="body", comments=[f"/dani ignore\nQuoted marker {signature}"])
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    matching_comments = github.find_comments_by_signature("acme/demo", 7, kind="pr", signature_fragment=signature)
+
+    assert matching_comments == []
+
+
 def test_ensure_pull_request_updates_existing_open_pull_request(fake_repo: FakeRepo) -> None:
     github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
 

--- a/tests/test_omx_runner.py
+++ b/tests/test_omx_runner.py
@@ -4,6 +4,9 @@ import json
 import time
 from pathlib import Path
 
+import pytest
+
+from dani.errors import RolloutMissingError
 from dani.omx_runner import OmxRunner
 from dani.signatures import build_signature
 
@@ -102,3 +105,37 @@ def test_build_resume_script_uses_omx_exec_resume(tmp_path: Path) -> None:
     )
 
     assert "omx exec resume session-123 --dangerously-bypass-approvals-and-sandbox" in script
+
+
+def test_wait_raises_rollout_missing_error_when_resume_stderr_mentions_no_rollout_found(tmp_path: Path) -> None:
+    runner = OmxRunner(run_dir=tmp_path / "runs")
+    runtime_handle = "runtime-123"
+    runtime_dir = runner.run_dir / runtime_handle
+    runtime_dir.mkdir(parents=True)
+    stdout_path = tmp_path / "stdout.log"
+    stderr_path = runtime_dir / "stderr.log"
+    stdout_path.write_text("", encoding="utf-8")
+    stderr_path.write_text(
+        "Error: thread/resume failed: no rollout found for thread id 019d6829",
+        encoding="utf-8",
+    )
+    stdout_file = stdout_path.open("w", encoding="utf-8")
+    stderr_file = stderr_path.open("a", encoding="utf-8")
+    process = type(
+        "Process",
+        (),
+        {
+            "poll": lambda self: 1,
+            "terminate": lambda self: None,
+            "wait": lambda self, timeout=None: 1,
+            "kill": lambda self: None,
+        },
+    )()
+    runner._processes[runtime_handle] = (process, stdout_file, stderr_file)
+
+    try:
+        with pytest.raises(RolloutMissingError, match="no rollout found"):
+            runner.wait(runtime_handle)
+    finally:
+        stdout_file.close()
+        stderr_file.close()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -122,6 +122,30 @@ def test_review_round_prompt_requires_code_review_and_verification() -> None:
     assert "gh pr comment 5 --repo acme/demo --body-file <review-comment.md>" in prompt
 
 
+def test_review_round_prompt_for_external_contribution_mentions_contributor_ownership() -> None:
+    prompt = render_prompt(
+        "review_round",
+        {
+            "repo": "acme/demo",
+            "pr_number": 5,
+            "pr_title": "Feature",
+            "pr_body": "Body",
+            "discussion": "history",
+            "round_number": 2,
+            "round_total": 10,
+            "review_mode_note": (
+                "This is an external contribution PR. The contributor owns any follow-up implementation. "
+                "If the PR is ready to merge, include /approve in your review comment so dani can run the final verdict pass."
+            ),
+            "signature": "<!-- dani:stage=review_round;job=abc;pr=5;round=2 -->",
+        },
+    )
+
+    assert "2 / 10" in prompt
+    assert "external contribution pr" in prompt.lower()
+    assert "/approve" in prompt
+
+
 def test_final_verdict_prompt_contains_both_signatures() -> None:
     prompt = render_prompt(
         "final_verdict",
@@ -160,3 +184,23 @@ def test_final_verdict_prompt_requires_general_real_result_evidence() -> None:
     assert "web:" not in prompt.lower()
     assert "cli:" not in prompt.lower()
     assert "backend:" not in prompt.lower()
+
+
+def test_human_escalation_prompt_mentions_review_limit_and_signature() -> None:
+    prompt = render_prompt(
+        "human_escalation",
+        {
+            "repo": "acme/demo",
+            "pr_number": 5,
+            "pr_title": "Feature",
+            "pr_body": "Body",
+            "discussion": "history",
+            "review_limit": 10,
+            "signature": "<!-- dani:stage=human_escalation;job=abc;pr=5 -->",
+        },
+    )
+
+    assert "10" in prompt
+    assert "human maintainer" in prompt.lower()
+    assert "gh pr comment 5 --repo acme/demo --body-file <human-escalation.md>" in prompt
+    assert "stage=human_escalation" in prompt

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -77,6 +77,7 @@ def test_issue_request_prompt_uses_gh_instructions() -> None:
             "issue_number": 7,
             "issue_title": "Need a bot",
             "issue_body": "Implement it",
+            "discussion": "",
             "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
         },
     )
@@ -94,12 +95,31 @@ def test_issue_request_prompt_requires_ai_summary_and_expected_outcome() -> None
             "issue_number": 7,
             "issue_title": "Need a bot",
             "issue_body": "Implement it",
+            "discussion": "",
             "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
         },
     )
 
     assert "AI-understood issue summary" in prompt
     assert "Expected Outcome" in prompt
+
+
+def test_issue_request_prompt_includes_existing_discussion_history() -> None:
+    prompt = render_prompt(
+        "issue_request",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "[human]\nEarlier context",
+            "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
+        },
+    )
+
+    assert "Existing issue discussion history" in prompt
+    assert "Earlier context" in prompt
 
 
 def test_review_round_prompt_requires_code_review_and_verification() -> None:
@@ -186,26 +206,6 @@ def test_final_verdict_prompt_requires_general_real_result_evidence() -> None:
     assert "backend:" not in prompt.lower()
 
 
-def test_human_escalation_prompt_mentions_review_limit_and_signature() -> None:
-    prompt = render_prompt(
-        "human_escalation",
-        {
-            "repo": "acme/demo",
-            "pr_number": 5,
-            "pr_title": "Feature",
-            "pr_body": "Body",
-            "discussion": "history",
-            "review_limit": 10,
-            "signature": "<!-- dani:stage=human_escalation;job=abc;pr=5 -->",
-        },
-    )
-
-    assert "10" in prompt
-    assert "human maintainer" in prompt.lower()
-    assert "gh pr comment 5 --repo acme/demo --body-file <human-escalation.md>" in prompt
-    assert "stage=human_escalation" in prompt
-
-
 def test_merge_conflict_resolution_prompt_requires_recheck_without_direct_merge() -> None:
     prompt = render_prompt(
         "merge_conflict_resolution",
@@ -227,3 +227,23 @@ def test_merge_conflict_resolution_prompt_requires_recheck_without_direct_merge(
     assert "Do not merge the PR yourself" in prompt
     assert "stage=merge_conflict_resolution" in prompt
     assert "gh pr comment 5 --repo acme/demo --body-file <merge-conflict-comment.md>" in prompt
+
+
+def test_human_escalation_prompt_mentions_review_limit_and_signature() -> None:
+    prompt = render_prompt(
+        "human_escalation",
+        {
+            "repo": "acme/demo",
+            "pr_number": 5,
+            "pr_title": "Feature",
+            "pr_body": "Body",
+            "discussion": "history",
+            "review_limit": 10,
+            "signature": "<!-- dani:stage=human_escalation;job=abc;pr=5 -->",
+        },
+    )
+
+    assert "10" in prompt
+    assert "human maintainer" in prompt.lower()
+    assert "gh pr comment 5 --repo acme/demo --body-file <human-escalation.md>" in prompt
+    assert "stage=human_escalation" in prompt

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -154,6 +154,28 @@ def test_failed_job_releases_lock() -> None:
     ]
 
 
+def test_superseded_job_releases_lock() -> None:
+    """A superseded locked job releases the issue lock so other issues can proceed."""
+    execution_order: list[tuple[int, str, str]] = []
+    lock = threading.Lock()
+
+    def handler(job: JobRecord) -> None:
+        with lock:
+            execution_order.append((job.issue_number, job.stage, job.status))  # type: ignore[arg-type]
+        if job.issue_number == 1:
+            job.status = "superseded"
+
+    manager = RepoQueueManager(handler)
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=1))
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=2))
+    manager.join_all()
+
+    assert execution_order == [
+        (1, "implementation", "queued"),
+        (2, "implementation", "queued"),
+    ]
+
+
 def test_handler_exception_releases_lock() -> None:
     """If the handler raises an unhandled exception, the issue lock is still released."""
     execution_order: list[tuple[int, str]] = []

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -187,3 +187,33 @@ def test_transient_error_with_side_effect_already_posted_completes(mock_sleep: o
     assert job.metadata.get("note") == "side_effect_already_posted"
     # Should NOT have retried — only 1 launch
     assert len(omx_runner.launches) == 1
+
+
+@patch("dani.service.time.sleep")
+def test_restart_issue_request_with_stale_signed_comments_does_not_false_complete_on_transient(
+    mock_sleep: object, tmp_path: Path
+) -> None:
+    service, github, _ = make_service(tmp_path)
+    stale_signature = "<!-- dani:stage=issue_request;job=stale-job;issue=11 -->"
+    github.add_issue_signature("acme/demo", 11, stale_signature)
+
+    original_launch = service.omx_runner.launch
+
+    def launch_without_new_side_effect(repo_path: Path, job, prompt: str):
+        session = original_launch(repo_path, job, prompt)
+        github.issue_comment_map[("acme/demo", 11)] = [{"body": stale_signature}]
+        return session
+
+    service.omx_runner.launch = launch_without_new_side_effect  # type: ignore[assignment]
+
+    def wait_that_always_fails(runtime_handle: str, **kwargs: object) -> None:
+        raise TransientCapacityError(_CAPACITY_MSG, _CAPACITY_MSG)
+
+    service.omx_runner.wait = wait_that_always_fails  # type: ignore[assignment]
+
+    service.handle_event(_issue_event())
+    service.wait_for_idle()
+
+    job = service.storage.list_jobs()[0]
+    assert job.status == "failed"
+    assert job.metadata.get("note") != "side_effect_already_posted"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -92,3 +92,43 @@ def test_github_webhook_endpoint_queues_dev_sync_on_main_push(tmp_path: Path) ->
 
     assert response.status_code == 200
     assert response.json()["stage"] == "dev_sync"
+
+
+def test_github_webhook_endpoint_dedupes_duplicate_external_pr_delivery(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    github = FakeGitHubCLI()
+    omx_runner = FakeOmxRunner(github)
+    service = DaniService(
+        config, storage=JsonStorage(config), github=cast(GitHubCLI, github), omx_runner=cast(OmxRunner, omx_runner)
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+    client = TestClient(create_app(service))
+    payload = {
+        "action": "synchronize",
+        "repository": {"full_name": "acme/demo"},
+        "sender": {"login": "contributor"},
+        "pull_request": {
+            "number": 21,
+            "title": "Feature/#21",
+            "body": "Implements #21",
+            "base": {"ref": "dev"},
+            "head": {"ref": "feature/#21", "sha": "sha-21-2"},
+        },
+    }
+    body = json.dumps(payload).encode("utf-8")
+    headers = {
+        "x-github-event": "pull_request",
+        "x-github-delivery": "delivery-21",
+        "x-hub-signature-256": _signature(TEST_SECRET, body),
+    }
+
+    first = client.post("/webhook", content=body, headers=headers)
+    second = client.post("/webhook", content=body, headers=headers)
+    service.wait_for_idle()
+
+    assert first.status_code == 200
+    assert first.json()["stage"] == "review_round"
+    assert second.status_code == 200
+    assert second.json() == {"status": "ignored", "reason": "duplicate_external_pr_event"}
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=21)
+    assert [job.review_round for job in review_jobs] == [1]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,10 +1,10 @@
 import threading
-from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
 import pytest
 
+from dani.errors import RolloutMissingError
 from dani.github import GitHubCLI
 from dani.models import DaniConfig, JobRecord, NormalizedEvent
 from dani.omx_runner import OmxRunner
@@ -119,6 +119,29 @@ def test_issue_request_persists_omx_session_id(tmp_path: Path) -> None:
     assert session.omx_session_id == "omx-" + session.job_id
 
 
+def test_issue_request_verification_requires_exact_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_request", issue_number=21)
+    expected_signature = build_signature(stage="issue_request", job=job.id, issue=21)
+    github.add_issue_signature("acme/demo", 21, build_signature(stage="issue_request", job="stale-job", issue=21))
+    github.add_issue_signature("acme/demo", 21, expected_signature)
+
+    service._verify_side_effect(repo, job)
+
+
+def test_issue_request_verification_rejects_stale_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_request", issue_number=21)
+    github.add_issue_signature("acme/demo", 21, build_signature(stage="issue_request", job="stale-job", issue=21))
+
+    with pytest.raises(RuntimeError, match="issue-request-comment-missing"):
+        service._verify_side_effect(repo, job)
+
+
 def test_issue_opened_queues_issue_request(tmp_path: Path) -> None:
     service, _, omx_runner = make_service(tmp_path)
     event = NormalizedEvent(
@@ -202,6 +225,250 @@ def test_general_issue_comment_without_existing_issue_session_is_ignored(tmp_pat
     assert omx_runner.resumes == []
 
 
+def test_issue_followup_verification_requires_exact_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_followup", issue_number=31)
+    expected_signature = build_signature(stage="issue_followup", job=job.id, issue=31)
+    github.add_issue_signature("acme/demo", 31, build_signature(stage="issue_followup", job="stale-job", issue=31))
+    github.add_issue_signature("acme/demo", 31, expected_signature)
+
+    service._verify_side_effect(repo, job)
+
+
+def test_issue_followup_verification_rejects_stale_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_followup", issue_number=31)
+    github.add_issue_signature("acme/demo", 31, build_signature(stage="issue_followup", job="stale-job", issue=31))
+
+    with pytest.raises(RuntimeError, match="issue-followup-comment-missing"):
+        service._verify_side_effect(repo, job)
+
+
+def test_issue_followup_rollout_missing_marks_job_failed_and_posts_restart_warning(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=33,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    omx_runner.set_resume_failure(
+        RolloutMissingError(
+            "thread/resume failed: no rollout found for thread id 019d6829",
+            "no rollout found",
+        )
+    )
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=33,
+            actor_login="human",
+            payload={"issue": {"body": "Need automation"}},
+            body="Please continue.",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    job = service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=33)[0]
+    assert job.status == "failed"
+    assert job.metadata["error"] == "rollout_missing"
+    assert "thread/resume failed" in job.metadata["error_detail"]
+
+    warning_signature = build_signature(stage="session_lost", issue=33)
+    warning_comments = github.find_comments_by_signature(
+        "acme/demo", 33, kind="issue", signature_fragment=warning_signature
+    )
+    assert len(warning_comments) == 1
+    assert "dani restart-issue acme/demo 33" in warning_comments[0]["body"]
+    latest_comment = github.latest_signature_comment("acme/demo", 33, kind="issue")
+    assert latest_comment is not None
+    assert latest_comment[1]["stage"] == "session_lost"
+    assert latest_comment[1]["issue"] == "33"
+
+
+def test_issue_followup_rollout_missing_warning_comment_is_posted_only_once(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=34,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+    omx_runner.set_resume_failure(
+        RolloutMissingError(
+            "thread/resume failed: no rollout found for thread id 019d6829",
+            "no rollout found",
+        )
+    )
+
+    event = NormalizedEvent(
+        kind="issue_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=34,
+        actor_login="human",
+        payload={"issue": {"body": "Need automation"}},
+        body="Please continue.",
+        title="Need automation",
+    )
+
+    service.handle_event(event)
+    service.wait_for_idle()
+    service.handle_event(event)
+    service.wait_for_idle()
+
+    warning_comments = github.find_comments_by_signature(
+        "acme/demo",
+        34,
+        kind="issue",
+        signature_fragment=build_signature(stage="session_lost", issue=34),
+    )
+    assert len(warning_comments) == 1
+    matching_keys = [
+        key
+        for key in service.storage.snapshot()["processed_events"]["keys"]
+        if "stage=session_lost" in key and "issue=34" in key
+    ]
+    assert len(matching_keys) == 1
+    failed_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=34)
+    assert len(failed_jobs) == 2
+    assert all(job.status == "failed" for job in failed_jobs)
+
+
+def test_issue_followup_rollout_missing_retries_warning_after_comment_post_failure(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=35,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+    omx_runner.set_resume_failure(
+        RolloutMissingError(
+            "thread/resume failed: no rollout found for thread id 019d6829",
+            "no rollout found",
+        )
+    )
+
+    original_create_issue_comment = github.create_issue_comment
+    attempts = 0
+
+    def flaky_create_issue_comment(repo_full_name: str, issue_number: int, body: str) -> dict[str, object]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            msg = "temporary GitHub failure"
+            raise RuntimeError(msg)
+        return original_create_issue_comment(repo_full_name, issue_number, body)
+
+    github.create_issue_comment = flaky_create_issue_comment  # type: ignore[assignment]
+
+    event = NormalizedEvent(
+        kind="issue_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=35,
+        actor_login="human",
+        payload={"issue": {"body": "Need automation"}},
+        body="Please continue.",
+        title="Need automation",
+    )
+
+    service.handle_event(event)
+    service.wait_for_idle()
+    service.handle_event(event)
+    service.wait_for_idle()
+
+    warning_comments = github.find_comments_by_signature(
+        "acme/demo",
+        35,
+        kind="issue",
+        signature_fragment=build_signature(stage="session_lost", issue=35),
+    )
+    assert attempts == 2
+    assert len(warning_comments) == 1
+    matching_keys = [
+        key
+        for key in service.storage.snapshot()["processed_events"]["keys"]
+        if "stage=session_lost" in key and "issue=35" in key
+    ]
+    assert len(matching_keys) == 1
+
+
+def test_restart_issue_supersedes_existing_jobs_and_enqueues_new_issue_request(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    service.queue_manager.submit = lambda job: None  # type: ignore[assignment]
+    stale_request = JobRecord(
+        repo_full_name="acme/demo",
+        stage="issue_request",
+        issue_number=41,
+        status="completed",
+        metadata={"title": "Restart me", "body": "Original body"},
+    )
+    stale_followup = JobRecord(
+        repo_full_name="acme/demo",
+        stage="issue_followup",
+        issue_number=41,
+        status="failed",
+        metadata={"omx_session_id": "omx-stale", "title": "Restart me", "body": "Original body"},
+    )
+    untouched = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=99, status="completed")
+    service.storage.create_job(stale_request)
+    service.storage.create_job(stale_followup)
+    service.storage.create_job(untouched)
+    github.issue_comment_map[("acme/demo", 41)] = [
+        {"body": "Earlier user context", "user": {"login": "human"}},
+        {"body": "Earlier dani reply", "user": {"login": "dani"}},
+    ]
+
+    new_job = service.restart_issue("acme/demo", 41)
+
+    refreshed_request = service.storage.get_job(stale_request.id)
+    refreshed_followup = service.storage.get_job(stale_followup.id)
+    untouched_job = service.storage.get_job(untouched.id)
+    assert refreshed_request is not None and refreshed_request.status == "superseded"
+    assert refreshed_followup is not None and refreshed_followup.status == "superseded"
+    assert untouched_job is not None and untouched_job.status == "completed"
+    assert new_job.stage == "issue_request"
+    assert new_job.status == "queued"
+    assert new_job.issue_number == 41
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    prompt = service._build_prompt(repo, new_job)
+    assert "Earlier user context" in prompt
+    assert "Earlier dani reply" in prompt
+
+
 def test_issue_comment_with_ignore_signature_is_ignored_before_followup(tmp_path: Path) -> None:
     service, _, omx_runner = make_service(tmp_path)
     service.handle_event(
@@ -257,6 +524,7 @@ def test_issue_comment_with_ignore_command_overrides_approve(tmp_path: Path) -> 
     assert result == {"status": "ignored", "reason": "comment_opt_out"}
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", issue_number=37) == []
     assert omx_runner.launches == []
+
 
 
 def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
@@ -804,6 +1072,53 @@ def test_approve_verdict_with_merge_conflict_queues_resolution_job(tmp_path: Pat
     assert github.merged == []
 
 
+def test_approve_verdict_with_merge_conflict_reuses_tracked_issue_number_without_pr_body_reference(
+    tmp_path: Path,
+) -> None:
+    service, github, _ = make_service(tmp_path)
+    github.merge_conflicts.add(("acme/demo", 77))
+    service.storage.create_job(
+        JobRecord(
+            repo_full_name="acme/demo",
+            stage="review_round",
+            issue_number=5,
+            pr_number=77,
+            review_round=1,
+            status="completed",
+        )
+    )
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "No issue reference in body",
+        title="Feature without issue in body",
+        head_branch="feature/no-issue",
+        base_branch="dev",
+    )
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=77,
+            actor_login="agent",
+            payload={},
+            body=build_signature(stage="final_verdict", job="verdict-1", pr=77, verdict="APPROVE"),
+            title="Feature without issue in body",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    resolution_jobs = service.storage.find_jobs(
+        repo_full_name="acme/demo", stage="merge_conflict_resolution", pr_number=77
+    )
+    assert result["stage"] == "merge_conflict_resolution"
+    assert resolution_jobs[0].issue_number == 5
+    assert resolution_jobs[0].metadata["head_branch"] == "feature/no-issue"
+
+
 def test_merge_conflict_resolution_comment_queues_final_verdict_retry(tmp_path: Path) -> None:
     service, github, omx_runner = make_service(tmp_path)
     pr_body = "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->"
@@ -838,6 +1153,41 @@ def test_merge_conflict_resolution_comment_queues_final_verdict_retry(tmp_path: 
     assert verdict_jobs[0].metadata["title"] == "Feature/#5"
     assert verdict_jobs[0].metadata["body"] == pr_body
     assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+
+
+def test_duplicate_merge_conflict_resolution_event_is_ignored(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->",
+        title="Feature/#5",
+        head_branch="Feature/#5",
+        base_branch="dev",
+    )
+    event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="merge_conflict_resolution", job="resolve-1", pr=77),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+
+    first = service.handle_event(event)
+    service.wait_for_idle()
+    second = service.handle_event(event)
+    service.wait_for_idle()
+
+    verdict_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=77)
+    assert first["status"] == "queued"
+    assert second == {"status": "ignored", "reason": "duplicate_agent_event"}
+    assert len(verdict_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+    assert omx_runner.launches[-1]["job"].pr_number == 77
 
 
 def test_merge_conflict_resolution_requires_its_own_signed_comment(tmp_path: Path) -> None:
@@ -878,41 +1228,6 @@ def test_review_round_verification_rejects_stale_signed_comment(tmp_path: Path) 
         service._verify_side_effect(repo, job)
 
 
-@pytest.mark.parametrize(
-    ("job", "signature", "expected_error"),
-    [
-        (
-            JobRecord(repo_full_name="acme/demo", stage="review_round", pr_number=77, review_round=2),
-            lambda job: build_signature(stage="review_round", job=job.id, pr=77, round=2),
-            "review-comment-missing",
-        ),
-        (
-            JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=5, pr_number=77),
-            lambda job: build_signature(stage="implementation", job=job.id, issue=5, pr=77),
-            "implementation-comment-missing",
-        ),
-        (
-            JobRecord(repo_full_name="acme/demo", stage="final_verdict", pr_number=77),
-            lambda job: build_signature(stage="final_verdict", job=job.id, pr=77, verdict="APPROVE"),
-            "final-verdict-comment-missing",
-        ),
-    ],
-)
-def test_pr_side_effect_verification_rejects_opt_out_comment_quoting_exact_signature(
-    tmp_path: Path,
-    job: JobRecord,
-    signature: Callable[[JobRecord], str],
-    expected_error: str,
-) -> None:
-    service, github, _ = make_service(tmp_path)
-    repo = service.storage.get_repo("acme/demo")
-    assert repo is not None
-    github.pr_comment_map[("acme/demo", 77)] = [{"body": f"/dani ignore\nQuoted marker {signature(job)}"}]
-
-    with pytest.raises(RuntimeError, match=expected_error):
-        service._verify_side_effect(repo, job)
-
-
 def test_duplicate_review_round_event_is_ignored(tmp_path: Path) -> None:
     service, _, omx_runner = make_service(tmp_path)
     event = NormalizedEvent(
@@ -938,33 +1253,6 @@ def test_duplicate_review_round_event_is_ignored(tmp_path: Path) -> None:
     assert len(implementation_jobs) == 1
     assert omx_runner.launches[-1]["job"].stage == "implementation"
     assert omx_runner.launches[-1]["job"].pr_number == 77
-
-
-def test_pull_request_comment_with_ignore_signature_skips_agent_transition(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
-
-    result = service.handle_event(
-        NormalizedEvent(
-            kind="pull_request_comment",
-            repo_full_name="acme/demo",
-            action="created",
-            number=77,
-            actor_login="human",
-            payload={},
-            body=(
-                "Please do not trigger this.\n"
-                "<!-- dani:stage=ignore -->\n"
-                f"{build_signature(stage='review_round', job='job-1', pr=77, round=1)}"
-            ),
-            title="Feature/#5",
-            is_pull_request=True,
-        )
-    )
-    service.wait_for_idle()
-
-    assert result == {"status": "ignored", "reason": "comment_opt_out"}
-    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=77) == []
-    assert omx_runner.launches == []
 
 
 def test_implementation_followup_verification_requires_exact_signature(tmp_path: Path) -> None:
@@ -1013,6 +1301,95 @@ def test_final_verdict_verification_rejects_unrelated_signed_comment(tmp_path: P
         service._verify_side_effect(repo, job)
 
 
+def test_duplicate_final_verdict_event_is_ignored(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.merge_conflicts.add(("acme/demo", 77))
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->",
+        title="Feature/#5",
+        head_branch="Feature/#5",
+        base_branch="dev",
+    )
+    event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="final_verdict", job="verdict-1", pr=77, verdict="APPROVE"),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+
+    first = service.handle_event(event)
+    service.wait_for_idle()
+    second = service.handle_event(event)
+    service.wait_for_idle()
+
+    resolution_jobs = service.storage.find_jobs(
+        repo_full_name="acme/demo", stage="merge_conflict_resolution", pr_number=77
+    )
+    assert first["status"] == "queued"
+    assert second == {"status": "ignored", "reason": "duplicate_agent_event"}
+    assert len(resolution_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "merge_conflict_resolution"
+    assert omx_runner.launches[-1]["job"].pr_number == 77
+
+
+def test_final_verdict_transient_failure_allows_redelivery(tmp_path: Path) -> None:
+    """A transient merge failure must not poison redelivery — the retry must succeed."""
+    from github.GithubException import GithubException
+
+    service, github, _omx_runner = make_service(tmp_path)
+    service.storage.create_job(
+        JobRecord(
+            repo_full_name="acme/demo",
+            stage="review_round",
+            issue_number=5,
+            pr_number=77,
+            review_round=1,
+            status="completed",
+        )
+    )
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->",
+        title="Feature/#5",
+        head_branch="feature/5",
+        base_branch="dev",
+    )
+    original_merge = github.merge_pull_request
+
+    def boom(repo_full_name: str, pr_number: int) -> None:
+        raise GithubException(500, {"message": "GitHub outage"}, {})
+
+    github.merge_pull_request = boom  # type: ignore[assignment]
+    event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="final_verdict", job="verdict-1", pr=77, verdict="APPROVE"),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+
+    with pytest.raises(GithubException):
+        service.handle_event(event)
+
+    # Restore normal merge and redeliver the same event
+    github.merge_pull_request = original_merge  # type: ignore[assignment]
+    result = service.handle_event(event)
+    assert result["status"] == "merged"
+    assert ("acme/demo", 77) in github.merged
+
+
 def test_bootstrap_repo_queues_existing_open_issues(tmp_path: Path) -> None:
     service, github, omx_runner = make_service(tmp_path)
     github.open_issues["acme/demo"] = [
@@ -1052,42 +1429,6 @@ def test_bootstrap_repo_skips_issues_with_existing_issue_request_signature(tmp_p
     assert isinstance(only_job, JobRecord)
     assert only_job.issue_number == 6
     assert only_job.stage == "issue_request"
-
-
-def test_bootstrap_repo_still_skips_issue_request_when_ignore_comment_is_latest(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
-    github.open_issues["acme/demo"] = [{"number": 5, "title": "Already handled", "body": "Need sync"}]
-    github.add_issue_signature(
-        "acme/demo",
-        5,
-        build_signature(stage="issue_request", job="existing-job", issue=5),
-    )
-    github.issue_comment_map[("acme/demo", 5)].append({"body": "<!-- dani:stage=ignore -->"})
-
-    count = service.bootstrap_repo("acme/demo")
-    service.wait_for_idle()
-
-    assert count == 0
-    assert omx_runner.launches == []
-
-
-def test_bootstrap_repo_skips_opt_out_comment_that_quotes_agent_signature(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
-    github.open_issues["acme/demo"] = [{"number": 5, "title": "Already handled", "body": "Need sync"}]
-    github.add_issue_signature(
-        "acme/demo",
-        5,
-        build_signature(stage="issue_request", job="existing-job", issue=5),
-    )
-    github.issue_comment_map[("acme/demo", 5)].append({
-        "body": "/dani ignore\nQuoted marker <!-- dani:stage=review_round;job=job-2;pr=7;round=1 -->"
-    })
-
-    count = service.bootstrap_repo("acme/demo")
-    service.wait_for_idle()
-
-    assert count == 0
-    assert omx_runner.launches == []
 
 
 def test_pull_request_opened_to_main_is_ignored(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -32,6 +32,42 @@ def make_service(
     return service, github, omx_runner
 
 
+def make_pr_event(
+    *,
+    pr_number: int,
+    action: str,
+    body: str,
+    actor_login: str = "contributor",
+) -> NormalizedEvent:
+    return NormalizedEvent(
+        kind="pull_request_opened",
+        repo_full_name="acme/demo",
+        action=action,
+        number=pr_number,
+        actor_login=actor_login,
+        payload={},
+        body=body,
+        title=f"Feature/#{pr_number}",
+        base_branch="dev",
+        head_branch=f"feature/#{pr_number}",
+        is_pull_request=True,
+    )
+
+
+def make_pr_comment_event(*, pr_number: int, body: str, actor_login: str = "agent") -> NormalizedEvent:
+    return NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=pr_number,
+        actor_login=actor_login,
+        payload={},
+        body=body,
+        title=f"Feature/#{pr_number}",
+        is_pull_request=True,
+    )
+
+
 def test_issue_request_persists_omx_session_id(tmp_path: Path) -> None:
     service, _, _ = make_service(tmp_path)
 
@@ -210,6 +246,123 @@ def test_pr_opened_from_implementation_signature_queues_review_round(tmp_path: P
     assert result["stage"] == "review_round"
     assert review_jobs[0].review_round == 1
     assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_external_pr_opened_queues_review_round(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == [1]
+    assert review_jobs[0].metadata["external_contribution"] is True
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_external_pr_new_commit_queues_another_review_round(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+
+    result = service.handle_event(make_pr_event(pr_number=88, action="synchronize", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == [1, 2]
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_external_pr_review_requested_queues_review_round(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(make_pr_event(pr_number=91, action="review_requested", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_external_review_comment_does_not_queue_implementation(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+    review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
+
+    result = service.handle_event(
+        make_pr_comment_event(
+            pr_number=88,
+            body=build_signature(stage="review_round", job=review_job.id, pr=88, round=1),
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "updated", "stage": "review_round"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
+    assert len(omx_runner.launches) == 1
+    assert github.merged == []
+
+
+def test_external_review_approve_comment_queues_final_verdict(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+    review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
+
+    result = service.handle_event(
+        make_pr_comment_event(
+            pr_number=88,
+            body=f"/approve\n{build_signature(stage='review_round', job=review_job.id, pr=88, round=1)}",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result["stage"] == "final_verdict"
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
+    assert len(service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=88)) == 1
+    assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+    assert github.merged == []
+
+
+def test_external_final_verdict_approve_merges_without_implementation_job(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        make_pr_comment_event(
+            pr_number=88,
+            body=build_signature(stage="final_verdict", job="verdict-1", pr=88, verdict="APPROVE"),
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "merged", "pr_number": 88}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
+    assert omx_runner.launches == []
+    assert github.merged == [("acme/demo", 88)]
+
+
+def test_external_pr_escalates_after_ten_review_passes(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    for _ in range(10):
+        service.storage.create_job(
+            JobRecord(
+                repo_full_name="acme/demo",
+                stage="review_round",
+                pr_number=88,
+                metadata={"external_contribution": True},
+            )
+        )
+
+    result = service.handle_event(make_pr_event(pr_number=88, action="synchronize", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "human_escalation"
+    escalation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)
+    assert len(escalation_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "human_escalation"
 
 
 def test_review_chain_reaches_verdict_and_merges_on_approve(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,4 +1,5 @@
 import threading
+from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
@@ -199,6 +200,63 @@ def test_general_issue_comment_without_existing_issue_session_is_ignored(tmp_pat
 
     assert result == {"status": "ignored", "reason": "missing_issue_session"}
     assert omx_runner.resumes == []
+
+
+def test_issue_comment_with_ignore_signature_is_ignored_before_followup(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=36,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=36,
+            actor_login="human",
+            payload={"issue": {"body": "Need automation"}},
+            body="Please ignore this.\n<!-- dani:stage=ignore -->",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "comment_opt_out"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=36) == []
+    assert omx_runner.resumes == []
+
+
+def test_issue_comment_with_ignore_command_overrides_approve(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=37,
+            actor_login="human",
+            payload={"issue": {"body": "context"}},
+            body="/approve\n/dani ignore",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "comment_opt_out"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", issue_number=37) == []
+    assert omx_runner.launches == []
 
 
 def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
@@ -820,6 +878,41 @@ def test_review_round_verification_rejects_stale_signed_comment(tmp_path: Path) 
         service._verify_side_effect(repo, job)
 
 
+@pytest.mark.parametrize(
+    ("job", "signature", "expected_error"),
+    [
+        (
+            JobRecord(repo_full_name="acme/demo", stage="review_round", pr_number=77, review_round=2),
+            lambda job: build_signature(stage="review_round", job=job.id, pr=77, round=2),
+            "review-comment-missing",
+        ),
+        (
+            JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=5, pr_number=77),
+            lambda job: build_signature(stage="implementation", job=job.id, issue=5, pr=77),
+            "implementation-comment-missing",
+        ),
+        (
+            JobRecord(repo_full_name="acme/demo", stage="final_verdict", pr_number=77),
+            lambda job: build_signature(stage="final_verdict", job=job.id, pr=77, verdict="APPROVE"),
+            "final-verdict-comment-missing",
+        ),
+    ],
+)
+def test_pr_side_effect_verification_rejects_opt_out_comment_quoting_exact_signature(
+    tmp_path: Path,
+    job: JobRecord,
+    signature: Callable[[JobRecord], str],
+    expected_error: str,
+) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    github.pr_comment_map[("acme/demo", 77)] = [{"body": f"/dani ignore\nQuoted marker {signature(job)}"}]
+
+    with pytest.raises(RuntimeError, match=expected_error):
+        service._verify_side_effect(repo, job)
+
+
 def test_duplicate_review_round_event_is_ignored(tmp_path: Path) -> None:
     service, _, omx_runner = make_service(tmp_path)
     event = NormalizedEvent(
@@ -845,6 +938,33 @@ def test_duplicate_review_round_event_is_ignored(tmp_path: Path) -> None:
     assert len(implementation_jobs) == 1
     assert omx_runner.launches[-1]["job"].stage == "implementation"
     assert omx_runner.launches[-1]["job"].pr_number == 77
+
+
+def test_pull_request_comment_with_ignore_signature_skips_agent_transition(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=77,
+            actor_login="human",
+            payload={},
+            body=(
+                "Please do not trigger this.\n"
+                "<!-- dani:stage=ignore -->\n"
+                f"{build_signature(stage='review_round', job='job-1', pr=77, round=1)}"
+            ),
+            title="Feature/#5",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "comment_opt_out"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=77) == []
+    assert omx_runner.launches == []
 
 
 def test_implementation_followup_verification_requires_exact_signature(tmp_path: Path) -> None:
@@ -932,6 +1052,42 @@ def test_bootstrap_repo_skips_issues_with_existing_issue_request_signature(tmp_p
     assert isinstance(only_job, JobRecord)
     assert only_job.issue_number == 6
     assert only_job.stage == "issue_request"
+
+
+def test_bootstrap_repo_still_skips_issue_request_when_ignore_comment_is_latest(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.open_issues["acme/demo"] = [{"number": 5, "title": "Already handled", "body": "Need sync"}]
+    github.add_issue_signature(
+        "acme/demo",
+        5,
+        build_signature(stage="issue_request", job="existing-job", issue=5),
+    )
+    github.issue_comment_map[("acme/demo", 5)].append({"body": "<!-- dani:stage=ignore -->"})
+
+    count = service.bootstrap_repo("acme/demo")
+    service.wait_for_idle()
+
+    assert count == 0
+    assert omx_runner.launches == []
+
+
+def test_bootstrap_repo_skips_opt_out_comment_that_quotes_agent_signature(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.open_issues["acme/demo"] = [{"number": 5, "title": "Already handled", "body": "Need sync"}]
+    github.add_issue_signature(
+        "acme/demo",
+        5,
+        build_signature(stage="issue_request", job="existing-job", issue=5),
+    )
+    github.issue_comment_map[("acme/demo", 5)].append({
+        "body": "/dani ignore\nQuoted marker <!-- dani:stage=review_round;job=job-2;pr=7;round=1 -->"
+    })
+
+    count = service.bootstrap_repo("acme/demo")
+    service.wait_for_idle()
+
+    assert count == 0
+    assert omx_runner.launches == []
 
 
 def test_pull_request_opened_to_main_is_ignored(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,3 +1,4 @@
+import threading
 from pathlib import Path
 from typing import cast
 
@@ -14,13 +15,36 @@ from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI, FakeOmxRunner
 TEST_SECRET = "unit-test-secret"
 
 
+def add_exact_review_signature(github: FakeGitHubCLI, job: JobRecord) -> None:
+    signature_fields: dict[str, str | int] = {
+        "stage": "review_round",
+        "job": job.id,
+        "pr": int(job.pr_number or 0),
+        "round": job.review_round or 1,
+    }
+    if job.issue_number is not None:
+        signature_fields["issue"] = int(job.issue_number)
+    github.add_pr_signature(
+        job.repo_full_name,
+        int(job.pr_number or 0),
+        build_signature(**signature_fields),
+    )
+
+
 def make_service(
     tmp_path: Path, *, dev_syncer: FakeGitDevSyncer | None = None
 ) -> tuple[DaniService, FakeGitHubCLI, FakeOmxRunner]:
+    class ExactReviewSignatureOmxRunner(FakeOmxRunner):
+        def launch(self, repo_path: Path, job: JobRecord, prompt: str):
+            session = super().launch(repo_path, job, prompt)
+            if job.stage == "review_round" and job.issue_number is not None:
+                add_exact_review_signature(self.github, job)
+            return session
+
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
-    omx_runner = FakeOmxRunner(github)
+    omx_runner = ExactReviewSignatureOmxRunner(github)
     service = DaniService(
         config,
         storage=storage,
@@ -313,6 +337,7 @@ def test_duplicate_external_pr_activity_does_not_consume_review_limit(tmp_path: 
                 pr_number=88,
                 review_round=round_number,
                 metadata={"external_contribution": True},
+                status="completed",
             )
         )
 
@@ -459,6 +484,7 @@ def test_external_pr_escalates_after_ten_review_passes(tmp_path: Path) -> None:
                 stage="review_round",
                 pr_number=88,
                 metadata={"external_contribution": True},
+                status="completed",
             )
         )
 
@@ -469,6 +495,86 @@ def test_external_pr_escalates_after_ten_review_passes(tmp_path: Path) -> None:
     escalation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)
     assert len(escalation_jobs) == 1
     assert omx_runner.launches[-1]["job"].stage == "human_escalation"
+
+
+def test_external_pr_unique_activity_never_queues_an_eleventh_automated_review(tmp_path: Path) -> None:
+    class BlockingOmxRunner(FakeOmxRunner):
+        def __init__(self, github: FakeGitHubCLI) -> None:
+            super().__init__(github)
+            self.review_started = threading.Event()
+            self.release_review = threading.Event()
+
+        def launch(self, repo_path: Path, job: JobRecord, prompt: str):
+            session = super().launch(repo_path, job, prompt)
+            if job.stage == "review_round":
+                add_exact_review_signature(self.github, job)
+            return session
+
+        def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
+            if (
+                runtime_handle.startswith("runtime-")
+                and self.launches
+                and self.launches[-1]["job"].stage == "review_round"
+            ):
+                self.review_started.set()
+                self.release_review.wait(timeout=timeout_seconds)
+
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    github = FakeGitHubCLI()
+    omx_runner = BlockingOmxRunner(github)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github),
+        omx_runner=cast(OmxRunner, omx_runner),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    opened = service.handle_event(
+        make_pr_event(pr_number=88, action="opened", body="Implements #21", commit_sha="sha-1")
+    )
+    assert opened["stage"] == "review_round"
+    assert omx_runner.review_started.wait(timeout=1)
+
+    results = []
+    for round_number in range(2, 12):
+        results.append(
+            service.handle_event(
+                make_pr_event(
+                    pr_number=88,
+                    action="synchronize",
+                    body="Implements #21",
+                    commit_sha=f"sha-{round_number}",
+                )
+            )
+        )
+
+    assert all(result["stage"] == "review_round" for result in results[:9])
+    assert results[9] == {"status": "ignored", "reason": "external_review_limit_pending"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
+
+    omx_runner.release_review.set()
+    service.wait_for_idle()
+
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == list(range(1, 11))
+    assert all(job.status == "completed" for job in review_jobs)
+
+    post_limit = service.handle_event(
+        make_pr_event(
+            pr_number=88,
+            action="synchronize",
+            body="Implements #21",
+            commit_sha="sha-12",
+        )
+    )
+    service.wait_for_idle()
+
+    assert post_limit["stage"] == "human_escalation"
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88) == review_jobs
+    assert [job.review_round for job in review_jobs] == list(range(1, 11))
 
 
 def test_review_chain_reaches_verdict_and_merges_on_approve(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -38,19 +38,24 @@ def make_pr_event(
     action: str,
     body: str,
     actor_login: str = "contributor",
+    commit_sha: str | None = None,
+    delivery_id: str | None = None,
 ) -> NormalizedEvent:
+    head_sha = commit_sha or f"sha-{pr_number}-{action}"
     return NormalizedEvent(
         kind="pull_request_opened",
         repo_full_name="acme/demo",
         action=action,
         number=pr_number,
         actor_login=actor_login,
-        payload={},
+        payload={"pull_request": {"head": {"sha": head_sha}}},
         body=body,
         title=f"Feature/#{pr_number}",
         base_branch="dev",
         head_branch=f"feature/#{pr_number}",
+        commit_sha=head_sha,
         is_pull_request=True,
+        delivery_id=delivery_id,
     )
 
 
@@ -274,6 +279,107 @@ def test_external_pr_new_commit_queues_another_review_round(tmp_path: Path) -> N
     review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
     assert [job.review_round for job in review_jobs] == [1, 2]
     assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_duplicate_external_pr_activity_event_is_ignored(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21", commit_sha="sha-1"))
+    service.wait_for_idle()
+
+    first = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-2")
+    )
+    service.wait_for_idle()
+    duplicate = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-2")
+    )
+    service.wait_for_idle()
+
+    assert first["stage"] == "review_round"
+    assert duplicate == {"status": "ignored", "reason": "duplicate_external_pr_event"}
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == [1, 2]
+    assert len(omx_runner.launches) == 2
+
+
+def test_duplicate_external_pr_activity_does_not_consume_review_limit(tmp_path: Path) -> None:
+    service, _, _ = make_service(tmp_path)
+    for round_number in range(1, 10):
+        service.storage.create_job(
+            JobRecord(
+                repo_full_name="acme/demo",
+                stage="review_round",
+                pr_number=88,
+                review_round=round_number,
+                metadata={"external_contribution": True},
+            )
+        )
+
+    first = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-10")
+    )
+    service.wait_for_idle()
+    duplicate = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-10")
+    )
+    service.wait_for_idle()
+
+    assert first["stage"] == "review_round"
+    assert duplicate == {"status": "ignored", "reason": "duplicate_external_pr_event"}
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs if job.metadata.get("external_contribution")] == list(range(1, 11))
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
+
+
+def test_external_pr_fallback_dedupe_key_is_repo_scoped(tmp_path: Path) -> None:
+    service, _, _ = make_service(tmp_path)
+    service.register_repo("acme/other", str(tmp_path))
+
+    first = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="synchronize",
+            number=88,
+            actor_login="contributor",
+            payload={"pull_request": {"head": {"sha": "shared-sha"}}},
+            body="Implements #21",
+            title="Feature/#21",
+            base_branch="dev",
+            head_branch="feature/#21",
+            commit_sha="shared-sha",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    second = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/other",
+            action="synchronize",
+            number=88,
+            actor_login="contributor",
+            payload={"pull_request": {"head": {"sha": "shared-sha"}}},
+            body="Implements #21",
+            title="Feature/#21",
+            base_branch="dev",
+            head_branch="feature/#21",
+            commit_sha="shared-sha",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    assert first["stage"] == "review_round"
+    assert second["stage"] == "review_round"
+    assert [
+        job.review_round for job in service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round")
+    ] == [1]
+    assert [
+        job.review_round for job in service.storage.find_jobs(repo_full_name="acme/other", stage="review_round")
+    ] == [1]
 
 
 def test_external_pr_review_requested_queues_review_round(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -497,6 +497,56 @@ def test_external_pr_escalates_after_ten_review_passes(tmp_path: Path) -> None:
     assert omx_runner.launches[-1]["job"].stage == "human_escalation"
 
 
+def test_external_review_comment_queues_human_escalation_on_tenth_completed_pass(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    for round_number in range(1, 11):
+        action = "opened" if round_number == 1 else "synchronize"
+        result = service.handle_event(
+            make_pr_event(pr_number=88, action=action, body="Implements #21", commit_sha=f"sha-{round_number}")
+        )
+        service.wait_for_idle()
+
+        assert result["stage"] == "review_round"
+        review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
+        comment_result = service.handle_event(
+            make_pr_comment_event(
+                pr_number=88,
+                body=build_signature(stage="review_round", job=review_job.id, pr=88, round=round_number),
+            )
+        )
+        service.wait_for_idle()
+
+        if round_number < 10:
+            assert comment_result == {"status": "updated", "stage": "review_round"}
+            assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
+            continue
+
+        assert comment_result["stage"] == "human_escalation"
+
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == list(range(1, 11))
+    assert all(job.status == "completed" for job in review_jobs)
+
+    escalation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)
+    assert len(escalation_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "human_escalation"
+
+    post_limit = service.handle_event(
+        make_pr_event(
+            pr_number=88,
+            action="synchronize",
+            body="Implements #21",
+            commit_sha="sha-11",
+        )
+    )
+    service.wait_for_idle()
+
+    assert post_limit == {"status": "ignored", "reason": "human_review_required"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88) == review_jobs
+    assert len(service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)) == 1
+
+
 def test_external_pr_unique_activity_never_queues_an_eleventh_automated_review(tmp_path: Path) -> None:
     class BlockingOmxRunner(FakeOmxRunner):
         def __init__(self, github: FakeGitHubCLI) -> None:
@@ -561,18 +611,6 @@ def test_external_pr_unique_activity_never_queues_an_eleventh_automated_review(t
     review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
     assert [job.review_round for job in review_jobs] == list(range(1, 11))
     assert all(job.status == "completed" for job in review_jobs)
-
-    post_limit = service.handle_event(
-        make_pr_event(
-            pr_number=88,
-            action="synchronize",
-            body="Implements #21",
-            commit_sha="sha-12",
-        )
-    )
-    service.wait_for_idle()
-
-    assert post_limit["stage"] == "human_escalation"
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88) == review_jobs
     assert [job.review_round for job in review_jobs] == list(range(1, 11))
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -526,7 +526,6 @@ def test_issue_comment_with_ignore_command_overrides_approve(tmp_path: Path) -> 
     assert omx_runner.launches == []
 
 
-
 def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
     service, _, omx_runner = make_service(tmp_path)
     event = NormalizedEvent(

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -1,4 +1,10 @@
-from dani.signatures import build_signature, parse_signature
+from dani.signatures import (
+    build_signature,
+    has_ignore_signature,
+    is_opt_out_comment,
+    parse_agent_signature,
+    parse_signature,
+)
 
 
 def test_signature_round_trip() -> None:
@@ -9,3 +15,17 @@ def test_signature_round_trip() -> None:
         "pr": "7",
         "round": "2",
     }
+
+
+def test_has_ignore_signature_detects_ignore_stage_across_multiple_markers() -> None:
+    text = f"{build_signature(stage='review_round', job='job123', pr=7, round=2)}\n<!-- dani:stage=ignore -->"
+
+    assert has_ignore_signature(text) is True
+
+
+def test_is_opt_out_comment_accepts_dani_ignore_command() -> None:
+    assert is_opt_out_comment("Heads up\n/dani ignore") is True
+
+
+def test_parse_agent_signature_excludes_ignore_stage() -> None:
+    assert parse_agent_signature("<!-- dani:stage=ignore -->") is None

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -13,9 +13,10 @@ def test_normalize_pull_request_synchronize_event() -> None:
                 "title": "Feature/#21",
                 "body": "Implements #21",
                 "base": {"ref": "dev"},
-                "head": {"ref": "feature/#21"},
+                "head": {"ref": "feature/#21", "sha": "abc123"},
             },
         },
+        delivery_id="delivery-1",
     )
 
     assert event is not None
@@ -23,6 +24,8 @@ def test_normalize_pull_request_synchronize_event() -> None:
     assert event.number == 21
     assert event.base_branch == "dev"
     assert event.head_branch == "feature/#21"
+    assert event.commit_sha == "abc123"
+    assert event.delivery_id == "delivery-1"
     assert event.is_pull_request is True
 
 
@@ -38,8 +41,9 @@ def test_normalize_pull_request_review_requested_event() -> None:
                 "title": "Feature/#21",
                 "body": "Implements #21",
                 "base": {"ref": "dev"},
-                "head": {"ref": "feature/#21"},
+                "head": {"ref": "feature/#21", "sha": "def456"},
             },
+            "requested_reviewer": {"login": "maintainer"},
         },
     )
 
@@ -48,4 +52,5 @@ def test_normalize_pull_request_review_requested_event() -> None:
     assert event.number == 21
     assert event.base_branch == "dev"
     assert event.head_branch == "feature/#21"
+    assert event.commit_sha == "def456"
     assert event.is_pull_request is True

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,51 @@
+from dani.webhook import normalize_event
+
+
+def test_normalize_pull_request_synchronize_event() -> None:
+    event = normalize_event(
+        "pull_request",
+        {
+            "action": "synchronize",
+            "repository": {"full_name": "acme/demo"},
+            "sender": {"login": "contributor"},
+            "pull_request": {
+                "number": 21,
+                "title": "Feature/#21",
+                "body": "Implements #21",
+                "base": {"ref": "dev"},
+                "head": {"ref": "feature/#21"},
+            },
+        },
+    )
+
+    assert event is not None
+    assert event.kind == "pull_request_opened"
+    assert event.number == 21
+    assert event.base_branch == "dev"
+    assert event.head_branch == "feature/#21"
+    assert event.is_pull_request is True
+
+
+def test_normalize_pull_request_review_requested_event() -> None:
+    event = normalize_event(
+        "pull_request",
+        {
+            "action": "review_requested",
+            "repository": {"full_name": "acme/demo"},
+            "sender": {"login": "contributor"},
+            "pull_request": {
+                "number": 21,
+                "title": "Feature/#21",
+                "body": "Implements #21",
+                "base": {"ref": "dev"},
+                "head": {"ref": "feature/#21"},
+            },
+        },
+    )
+
+    assert event is not None
+    assert event.kind == "pull_request_opened"
+    assert event.number == 21
+    assert event.base_branch == "dev"
+    assert event.head_branch == "feature/#21"
+    assert event.is_pull_request is True


### PR DESCRIPTION
## Summary

Release three issue-driven features merged into `dev` since the last `dev → main` sync (#8).

### #21 — External contributor PR review loop (PR #28)
- Route external contributor PRs through event-driven re-review triggered by PR activity (push / review comments)
- Cap the automated review budget at 10 completed passes, then escalate to human review
- Deduplicate burst webhook deliveries so a single contributor push can't burn the entire budget
- Preserve the signed internal implementation PR loop untouched

### #22 — Respect explicit opt-out markers (PR #26)
- Ignore issue/PR comments that carry a `<!-- dani:stage=ignore -->` signature
- `/dani ignore` overrides `/approve` routing and followup dispatch
- Bootstrap / latest-signature discovery stays stable even when opt-out comments quote Dani signatures

### #23 — Honest rollout-loss failure + `dani restart-issue` CLI (PR #24)
- Fail `issue_followup` jobs honestly when `omx exec resume` reports `no rollout found` / `thread/resume failed`, posting a deduped `session_lost` warning comment with restart instructions
- New `dani restart-issue <repo> <num>` command supersedes stale issue jobs and enqueues a fresh `issue_request` with prior GitHub discussion injected into the prompt
- Tighten `_verify_issue_{request,followup}_side_effect` to match each job's exact signature, preventing prior-job comments from silently passing verification
- Harden `merge_pull_request()` to only remap 405/409/422 to `MergeConflictError` (unrelated 500/auth/rate-limit failures propagate normally)
- Add processed-event dedupe to `merge_conflict_resolution` / `final_verdict` agent handlers; record `final_verdict` dedupe marker only after a durable outcome so a transient merge failure can be retried on webhook redelivery
- Release the repo queue's issue lock for `superseded` jobs so restart-issue doesn't deadlock other issues

## Merge blockers
- None. `dev` is clean-mergeable into `main` (verified with `git merge-tree`); CI `quality` formatting regression was fixed by 870225f. Will wait for CI on this PR before merging.

## Test plan
- [ ] CI `quality` job green (pre-commit / ruff format / ruff check)
- [ ] CI `tests-and-type-check` across 3.10–3.14 green
- [ ] Manual smoke: `dani restart-issue` on a lost-session issue
- [ ] Manual smoke: `/dani ignore` suppresses followup on a live issue
- [ ] Manual smoke: external contributor PR review loop escalates after 10 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)