### PR TITLE
Feature/#25

### DIFF
--- a/dani/github.py
+++ b/dani/github.py
@@ -5,10 +5,13 @@ from collections.abc import Callable
 from typing import Any
 
 from github import Auth, Github
+from github.GithubException import UnknownObjectException
 
 from dani.signatures import parse_signature
 
 TOKEN_ENV_VARS = ("DANI_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT")
+IMPLEMENTING_LABEL_COLOR = "FBCA04"
+IMPLEMENTING_LABEL_DESCRIPTION = "Implementation has started for this issue."
 
 
 class GitHubCLI:
@@ -91,6 +94,21 @@ class GitHubCLI:
     def create_pr_comment(self, repo_full_name: str, pr_number: int, body: str) -> dict[str, Any]:
         pull_request = self._repo(repo_full_name).get_pull(pr_number)
         return pull_request.create_issue_comment(body).raw_data
+
+    def ensure_issue_label(self, repo_full_name: str, issue_number: int, label: str) -> None:
+        repo = self._repo(repo_full_name)
+        try:
+            repo.get_label(label)
+        except UnknownObjectException as exc:
+            if exc.status != 404:
+                raise
+            repo.create_label(
+                name=label,
+                color=IMPLEMENTING_LABEL_COLOR,
+                description=IMPLEMENTING_LABEL_DESCRIPTION,
+            )
+        issue = repo.get_issue(issue_number)
+        issue.add_to_labels(label)
 
     def ensure_pull_request(
         self,

--- a/dani/service.py
+++ b/dani/service.py
@@ -14,6 +14,7 @@ from dani.signatures import build_signature, parse_signature
 from dani.storage import JsonStorage
 
 ISSUE_REF_PATTERN = re.compile(r"#(?P<number>\d+)")
+IMPLEMENTING_LABEL = "Implementing"
 
 
 class DaniService:
@@ -720,6 +721,7 @@ class DaniService:
         return False
 
     def _queue_implementation(self, repo: RepoConfig, event: NormalizedEvent) -> dict[str, Any]:
+        self.github.ensure_issue_label(repo.full_name, event.number, IMPLEMENTING_LABEL)
         job = self._enqueue_job(
             repo,
             stage="implementation",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -16,6 +16,7 @@ class FakeGitHubCLI:
         self.prs: dict[str, list[dict[str, Any]]] = {}
         self.open_issues: dict[str, list[dict[str, Any]]] = {}
         self.merged: list[tuple[str, int]] = []
+        self.issue_labels: dict[tuple[str, int], list[str]] = {}
 
     def list_open_issues(self, repo_full_name: str) -> list[dict[str, Any]]:
         return list(self.open_issues.get(repo_full_name, []))
@@ -57,6 +58,11 @@ class FakeGitHubCLI:
 
     def merge_pull_request(self, repo_full_name: str, pr_number: int) -> None:
         self.merged.append((repo_full_name, pr_number))
+
+    def ensure_issue_label(self, repo_full_name: str, issue_number: int, label: str) -> None:
+        labels = self.issue_labels.setdefault((repo_full_name, issue_number), [])
+        if label not in labels:
+            labels.append(label)
 
     def add_issue_signature(self, repo_full_name: str, issue_number: int, signature: str) -> None:
         self.issue_comment_map.setdefault((repo_full_name, issue_number), []).append({"body": signature})

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from github.GithubException import UnknownObjectException
 
 from dani.github import GitHubCLI
 
@@ -15,6 +16,7 @@ class FakeIssue:
     def __init__(self, comments: list[str] | None = None) -> None:
         self.comments = [FakeComment(body) for body in comments or []]
         self.created_comments: list[str] = []
+        self.labels: list[str] = []
         self.raw_data = {"number": 1}
 
     def get_comments(self) -> list[FakeComment]:
@@ -23,6 +25,14 @@ class FakeIssue:
     def create_comment(self, body: str) -> FakeComment:
         self.created_comments.append(body)
         return FakeComment(body)
+
+    def add_to_labels(self, label: str) -> None:
+        self.labels.append(label)
+
+
+class FakeLabel:
+    def __init__(self, name: str) -> None:
+        self.name = name
 
 
 class FakePullRequest:
@@ -60,6 +70,8 @@ class FakeRepo:
         self.issues = {5: FakeIssue(["existing issue comment"])}
         self.pulls = {7: FakePullRequest(number=7, body="body", comments=["existing pr comment"])}
         self.created_pulls: list[dict[str, str]] = []
+        self.labels: dict[str, FakeLabel] = {}
+        self.created_labels: list[dict[str, str]] = []
 
     def get_issues(self, *, state: str) -> list[FakeIssue]:
         assert state == "open"
@@ -67,6 +79,17 @@ class FakeRepo:
 
     def get_issue(self, issue_number: int) -> FakeIssue:
         return self.issues[issue_number]
+
+    def get_label(self, label_name: str) -> FakeLabel:
+        if label_name not in self.labels:
+            raise UnknownObjectException(status=404, data={"message": "Not Found"}, headers={})
+        return self.labels[label_name]
+
+    def create_label(self, *, name: str, color: str, description: str) -> FakeLabel:
+        self.created_labels.append({"name": name, "color": color, "description": description})
+        label = FakeLabel(name)
+        self.labels[name] = label
+        return label
 
     def get_pull(self, pr_number: int) -> FakePullRequest:
         return self.pulls[pr_number]
@@ -129,6 +152,31 @@ def test_create_issue_and_pr_comments_use_repository_objects(fake_repo: FakeRepo
     assert pr_comment["body"] == "hello pr"
     assert fake_repo.issues[5].created_comments == ["hello issue"]
     assert fake_repo.pulls[7].created_issue_comments == ["hello pr"]
+
+
+def test_ensure_issue_label_creates_missing_label_and_adds_to_issue(fake_repo: FakeRepo) -> None:
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    github.ensure_issue_label("acme/demo", 5, "Implementing")
+
+    assert fake_repo.created_labels == [
+        {
+            "name": "Implementing",
+            "color": "FBCA04",
+            "description": "Implementation has started for this issue.",
+        }
+    ]
+    assert fake_repo.issues[5].labels == ["Implementing"]
+
+
+def test_ensure_issue_label_reuses_existing_label(fake_repo: FakeRepo) -> None:
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+    fake_repo.labels["Implementing"] = FakeLabel("Implementing")
+
+    github.ensure_issue_label("acme/demo", 5, "Implementing")
+
+    assert fake_repo.created_labels == []
+    assert fake_repo.issues[5].labels == ["Implementing"]
 
 
 def test_ensure_pull_request_updates_existing_open_pull_request(fake_repo: FakeRepo) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -202,7 +202,7 @@ def test_general_issue_comment_without_existing_issue_session_is_ignored(tmp_pat
 
 
 def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, github, omx_runner = make_service(tmp_path)
     event = NormalizedEvent(
         kind="issue_comment",
         repo_full_name="acme/demo",
@@ -218,8 +218,30 @@ def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
     service.wait_for_idle()
 
     assert result["stage"] == "implementation"
+    assert github.issue_labels[("acme/demo", 11)] == ["Implementing"]
     assert omx_runner.launches[0]["job"].stage == "implementation"
     assert service.storage.list_jobs()[0].status == "completed"
+
+
+def test_repeated_approve_keeps_implementing_label_idempotent(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    event = NormalizedEvent(
+        kind="issue_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=11,
+        actor_login="human",
+        payload={"issue": {"body": "context"}},
+        body="/approve",
+        title="Need automation",
+    )
+
+    service.handle_event(event)
+    service.wait_for_idle()
+    service.handle_event(event)
+    service.wait_for_idle()
+
+    assert github.issue_labels[("acme/demo", 11)] == ["Implementing"]
 
 
 def test_failed_job_still_closes_runtime_handle_and_marks_failure(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add the `Implementing` issue label when an `/approve` issue comment queues implementation work.
- Ensure the GitHub wrapper creates the label if it does not exist, then applies it to the issue.
- Cover the approval label behavior and GitHub label helper with TDD tests.

## Verification
- `uv run pytest -q tests/test_service.py::test_approve_comment_queues_implementation tests/test_service.py::test_repeated_approve_keeps_implementing_label_idempotent tests/test_github.py::test_ensure_issue_label_creates_missing_label_and_adds_to_issue tests/test_github.py::test_ensure_issue_label_reuses_existing_label`
- `uv run pytest`
- `uv run python - <<'PY' ...` smoke-verified `/approve` queues implementation and records `['Implementing']`
- `uv run ruff check dani tests && uv run ty check`

<!-- dani:stage=implementation;job=c8bca99a061443a98fce96256407d82a;issue=25 -->
