### PR TITLE
Feature/#27

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,14 +129,16 @@ Before you submit a pull request, check that it meets these guidelines:
 
 For PRs opened by external contributors, `dani` follows a lighter event-driven review loop:
 
-1. A maintainer review runs when the PR is opened.
-2. If changes are requested, the contributor owns the follow-up implementation.
-3. `dani` reviews again only when the PR changes meaningfully, such as:
+1. External contributor PRs are eligible only when the PR author GitHub account is at least one year old. PRs
+   from newer accounts are closed automatically with guidance to open an issue instead.
+2. A maintainer review runs when the PR is opened.
+3. If changes are requested, the contributor owns the follow-up implementation.
+4. `dani` reviews again only when the PR changes meaningfully, such as:
    - a new commit (`synchronize`)
    - a renewed review request
    - another PR-open style re-entry event (`reopened`, `ready_for_review`)
    - duplicate webhook deliveries are ignored, using the GitHub delivery id when available and a PR activity fallback key otherwise
    - once all remaining automated review passes are already queued or running, extra PR-activity events are coalesced until one of those passes finishes
-4. The merge bar stays the same as the existing verdict session: requirements must be met, real verification must pass, and the PR must be approveable.
-5. Only completed automated review passes count toward escalation, but queued/running passes still reserve the remaining review budget.
-6. If automated review reaches 10 completed passes without approval, `dani` immediately escalates the PR to a human maintainer for a manual decision.
+5. The merge bar stays the same as the existing verdict session: requirements must be met, real verification must pass, and the PR must be approveable.
+6. Only completed automated review passes count toward escalation, but queued/running passes still reserve the remaining review budget.
+7. If automated review reaches 10 completed passes without approval, `dani` immediately escalates the PR to a human maintainer for a manual decision.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Simple GitHub webhook -> OMX automation loop.
   - issue request report
   - `/approve` implementation
   - 3 review rounds for agent-authored PRs
+  - external contributor account-age eligibility checks
   - event-driven, duplicate-delivery-safe re-review for external contributor PRs
   - final verdict + auto-merge on APPROVE
 

--- a/dani/github.py
+++ b/dani/github.py
@@ -78,6 +78,9 @@ class GitHubCLI:
     def get_pull_request(self, repo_full_name: str, pr_number: int) -> dict[str, Any]:
         return self._repo(repo_full_name).get_pull(pr_number).raw_data
 
+    def get_user(self, login: str) -> dict[str, Any]:
+        return self._client_for_request().get_user(login).raw_data
+
     def find_pr_by_signature(self, repo_full_name: str, signature_fragment: str) -> dict[str, Any] | None:
         for pull_request in self.list_pull_requests(repo_full_name):
             if signature_fragment in (pull_request.get("body") or ""):
@@ -117,6 +120,10 @@ class GitHubCLI:
     def create_pr_comment(self, repo_full_name: str, pr_number: int, body: str) -> dict[str, Any]:
         pull_request = self._repo(repo_full_name).get_pull(pr_number)
         return pull_request.create_issue_comment(body).raw_data
+
+    def close_pull_request(self, repo_full_name: str, pr_number: int) -> None:
+        pull_request = self._repo(repo_full_name).get_pull(pr_number)
+        pull_request.edit(state="closed")
 
     def ensure_issue_label(self, repo_full_name: str, issue_number: int, label: str) -> None:
         repo = self._repo(repo_full_name)

--- a/dani/service.py
+++ b/dani/service.py
@@ -4,6 +4,7 @@ import contextlib
 import logging
 import re
 import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +20,12 @@ from dani.storage import JsonStorage
 
 ISSUE_REF_PATTERN = re.compile(r"#(?P<number>\d+)")
 IMPLEMENTING_LABEL = "Implementing"
+MIN_EXTERNAL_CONTRIBUTOR_ACCOUNT_AGE = timedelta(days=365)
+INELIGIBLE_EXTERNAL_PR_COMMENT = (
+    "Thanks for your interest in contributing. This pull request has been closed automatically because this "
+    "repository only accepts pull requests from GitHub accounts that are at least one year old. If you would like "
+    "to request this change or feature, please open an issue instead so maintainers can review it."
+)
 
 RETRY_BACKOFF_SECONDS: list[int] = [60, 180, 600]
 
@@ -1054,6 +1061,12 @@ class DaniService:
             )
             return {"status": "queued", "job_id": job.id, "stage": job.stage}
 
+        if self._external_contributor_account_too_new(event):
+            event_key = self._external_pull_request_event_key(event)
+            if not self.storage.record_processed_event(event_key):
+                return {"status": "ignored", "reason": "duplicate_external_pr_event"}
+            return self._close_ineligible_external_pull_request(event)
+
         if issue_number is None:
             return {"status": "ignored", "reason": "untracked_pr"}
         return self._queue_external_pull_request_review(
@@ -1100,6 +1113,63 @@ class DaniService:
             metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
         )
         return {"status": "queued", "job_id": job.id, "stage": job.stage}
+
+    def _external_contributor_account_too_new(self, event: NormalizedEvent) -> bool:
+        created_at = self._external_contributor_created_at(event)
+        if not created_at:
+            return False
+        try:
+            account_created_at = self._parse_github_timestamp(created_at)
+        except ValueError:
+            logger.warning(
+                "Unable to parse external contributor account creation date",
+                extra={"repo_full_name": event.repo_full_name, "pr_number": event.number, "created_at": created_at},
+            )
+            return False
+        return datetime.now(tz=timezone.utc) - account_created_at < MIN_EXTERNAL_CONTRIBUTOR_ACCOUNT_AGE
+
+    def _external_contributor_created_at(self, event: NormalizedEvent) -> str | None:
+        pull_request = event.payload.get("pull_request") or {}
+        user = pull_request.get("user") or {}
+        if isinstance(user, dict):
+            created_at = user.get("created_at")
+            if created_at:
+                return str(created_at)
+        login = self._external_contributor_login(event)
+        if not login:
+            return None
+        try:
+            github_user = self.github.get_user(login)
+        except Exception:
+            logger.warning(
+                "Unable to fetch external contributor account metadata",
+                extra={"repo_full_name": event.repo_full_name, "pr_number": event.number, "login": login},
+                exc_info=True,
+            )
+            return None
+        created_at = github_user.get("created_at") if isinstance(github_user, dict) else None
+        return str(created_at) if created_at else None
+
+    def _external_contributor_login(self, event: NormalizedEvent) -> str | None:
+        pull_request = event.payload.get("pull_request") or {}
+        user = pull_request.get("user") or {}
+        if isinstance(user, dict) and user.get("login"):
+            return str(user["login"])
+        return event.actor_login or None
+
+    def _parse_github_timestamp(self, value: str) -> datetime:
+        normalized_value = value.strip()
+        if normalized_value.endswith("Z"):
+            normalized_value = f"{normalized_value[:-1]}+00:00"
+        parsed = datetime.fromisoformat(normalized_value)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    def _close_ineligible_external_pull_request(self, event: NormalizedEvent) -> dict[str, Any]:
+        self.github.create_pr_comment(event.repo_full_name, event.number, INELIGIBLE_EXTERNAL_PR_COMMENT)
+        self.github.close_pull_request(event.repo_full_name, event.number)
+        return {"status": "closed", "reason": "contributor_account_too_new", "pr_number": event.number}
 
     def _enqueue_external_human_escalation(
         self,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -22,6 +22,8 @@ class FakeGitHubCLI:
         self.merged: list[tuple[str, int]] = []
         self.merge_conflicts: set[tuple[str, int]] = set()
         self.issue_labels: dict[tuple[str, int], list[str]] = {}
+        self.users: dict[str, dict[str, Any]] = {}
+        self.closed_pull_requests: list[tuple[str, int]] = []
 
     def list_open_issues(self, repo_full_name: str) -> list[dict[str, Any]]:
         return list(self.open_issues.get(repo_full_name, []))
@@ -53,6 +55,9 @@ class FakeGitHubCLI:
             "head": {"ref": f"Feature/#{pr_number}"},
             "base": {"ref": "dev"},
         }
+
+    def get_user(self, login: str) -> dict[str, Any]:
+        return dict(self.users.get(login, {"login": login}))
 
     def latest_signature_comment(
         self, repo_full_name: str, number: int, *, kind: str
@@ -126,6 +131,7 @@ class FakeGitHubCLI:
         })
 
     def close_pull_request(self, repo_full_name: str, pr_number: int) -> None:
+        self.closed_pull_requests.append((repo_full_name, pr_number))
         for pr in self.prs.get(repo_full_name, []):
             if pr.get("number") == pr_number:
                 pr["state"] = "closed"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -764,6 +764,56 @@ def test_external_pr_review_requested_queues_review_round(tmp_path: Path) -> Non
     assert omx_runner.launches[-1]["job"].stage == "review_round"
 
 
+def test_external_pr_from_account_younger_than_one_year_is_closed(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.users["newcomer"] = {"login": "newcomer", "created_at": "3000-01-01T00:00:00Z"}
+
+    result = service.handle_event(
+        make_pr_event(pr_number=92, action="opened", body="Implements #21", actor_login="newcomer")
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "closed", "reason": "contributor_account_too_new", "pr_number": 92}
+    assert github.closed_pull_requests == [("acme/demo", 92)]
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=92) == []
+    assert omx_runner.launches == []
+    comments = github.pr_comments("acme/demo", 92)
+    assert len(comments) == 1
+    assert "at least one year old" in comments[0]["body"]
+    assert "open an issue instead" in comments[0]["body"]
+
+
+def test_external_pr_uses_pull_request_author_created_at_instead_of_sender(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    github.users["maintainer"] = {"login": "maintainer", "created_at": "2000-01-01T00:00:00Z"}
+    event = make_pr_event(pr_number=93, action="reopened", body="Implements #21", actor_login="maintainer")
+    event.payload["pull_request"]["user"] = {
+        "login": "newcomer",
+        "created_at": "3000-01-01T00:00:00Z",
+    }
+
+    result = service.handle_event(event)
+    service.wait_for_idle()
+
+    assert result == {"status": "closed", "reason": "contributor_account_too_new", "pr_number": 93}
+    assert github.closed_pull_requests == [("acme/demo", 93)]
+
+
+def test_external_pr_from_account_at_least_one_year_old_queues_review_round(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.users["veteran"] = {"login": "veteran", "created_at": "2000-01-01T00:00:00Z"}
+
+    result = service.handle_event(
+        make_pr_event(pr_number=94, action="opened", body="Implements #21", actor_login="veteran")
+    )
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    assert github.closed_pull_requests == []
+    assert all("at least one year old" not in comment["body"] for comment in github.pr_comments("acme/demo", 94))
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
 def test_external_review_comment_does_not_queue_implementation(tmp_path: Path) -> None:
     service, github, omx_runner = make_service(tmp_path)
     service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))


### PR DESCRIPTION
## Summary
- Close external contributor PRs automatically when the PR author's GitHub account is less than one year old.
- Post an English eligibility message telling contributors to open an issue instead.
- Add GitHub wrapper methods, service tests, and docs for the new policy.

## Validation
- Wrote failing service tests first for under-one-year auto-close, PR-author lookup, and eligible account review flow.
- `uv run pytest tests/test_service.py -k 'account_younger or pull_request_author_created_at or account_at_least_one_year'`
- `make check`
- `uv run pytest`
- Manual runtime verification with a temporary `DaniService` instance and fake GitHub client confirmed the PR comment and close result.

<!-- dani:stage=implementation;job=e8695a5476474c5bab5f08bf04a0d2ec;issue=27 -->
