### PR TITLE
Drive omo through opencode HTTP server to survive subagent runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,3 +124,19 @@ Before you submit a pull request, check that it meets these guidelines:
 
 2. If the pull request adds functionality, the docs should be updated.
    Put your new functionality into a function with a docstring, and add the feature to the list in `README.md`.
+
+## External contribution PR review process
+
+For PRs opened by external contributors, `dani` follows a lighter event-driven review loop:
+
+1. A maintainer review runs when the PR is opened.
+2. If changes are requested, the contributor owns the follow-up implementation.
+3. `dani` reviews again only when the PR changes meaningfully, such as:
+   - a new commit (`synchronize`)
+   - a renewed review request
+   - another PR-open style re-entry event (`reopened`, `ready_for_review`)
+   - duplicate webhook deliveries are ignored, using the GitHub delivery id when available and a PR activity fallback key otherwise
+   - once all remaining automated review passes are already queued or running, extra PR-activity events are coalesced until one of those passes finishes
+4. The merge bar stays the same as the existing verdict session: requirements must be met, real verification must pass, and the PR must be approveable.
+5. Only completed automated review passes count toward escalation, but queued/running passes still reserve the remaining review budget.
+6. If automated review reaches 10 completed passes without approval, `dani` immediately escalates the PR to a human maintainer for a manual decision.

--- a/README.md
+++ b/README.md
@@ -40,17 +40,46 @@ loop mode is always active, and runtime-specific prompt substitutions swap
 codex-only shell commands (`$ralph`, `$code-review`) for their opencode
 equivalents (ultrawork mode and the Momus-Plan-Critic subagent respectively).
 
+By default, `omo` drives opencode through its long-lived **HTTP server**
+(`opencode serve`) instead of one-shot `opencode run` subprocesses. Each
+registered repository gets its own cached `opencode serve` process, lazily
+spawned on first launch and reused for every subsequent session in that
+repo. The HTTP backend keeps the agent loop alive inside the server even
+when subagents (oh-my-openagents `task` calls) come and go, which avoids
+the parent-process termination problem the subprocess backend hit when
+subagents finished.
+
+Optional `omo` runtime environment variables:
+- `DANI_OPENCODE_SERVER_URL` — attach every repo to a single external
+  opencode server (e.g. `http://127.0.0.1:4096`) instead of spawning local
+  ones. Sessions are still scoped per repo via the `directory` query param.
+- `DANI_OPENCODE_PERMISSION_RESPONSE` — `once` (default), `always`, or
+  `reject`. Controls how dani responds to opencode `permission.updated`
+  events automatically.
+- `DANI_OMO_LEGACY_SUBPROCESS` — set to `1` to fall back to the legacy
+  `opencode run` subprocess implementation. Intended as a temporary
+  rollback hatch; the HTTP runtime is the supported path.
+- `OPENCODE_SERVER_PASSWORD` — forwarded to the spawned server and used
+  for HTTP basic auth on every request when set.
+
 ## Codex/OMX trust prerequisite
 Before dani can reliably launch or resume OMX/Codex sessions for a repository, that repository directory should be trusted by Codex at least once. In practice, run `omx exec 'hello'` or `codex exec 'hello'` once from the target repo and accept the trust prompt before using dani automation there. Otherwise a trust prompt can block session startup or resume.
 
 ## Oh-My-OpenAgents (opencode) prerequisite
-When running with `DANI_AGENT_RUNTIME=omo`, dani launches sessions through
-`opencode run --format json --dangerously-skip-permissions <prompt>` and resumes
-them with `opencode run --session <id> ...`. Install `opencode` (the
+When running with `DANI_AGENT_RUNTIME=omo`, dani drives opencode through the
+`opencode serve` HTTP backend by default: it spawns `opencode serve --port 0
+--hostname 127.0.0.1 --print-logs` once per registered repository (with the
+repo as cwd), then talks to that server over HTTP for session create, prompt
+submission, completion via SSE, and resume. Install `opencode` (the
 `oh-my-openagent` plugin is loaded automatically when configured in
 `~/.config/opencode/opencode.json`) and make sure the target repository
 directory is trusted at least once via `opencode run 'hello'` before pointing
 dani at it.
+
+If you set `DANI_OMO_LEGACY_SUBPROCESS=1`, dani falls back to the previous
+behavior — launching one-shot `opencode run --format json
+--dangerously-skip-permissions <prompt>` subprocesses and resuming them with
+`opencode run --session <id> ...`. Use this only as a temporary escape hatch.
 
 ## CLI
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Simple GitHub webhook -> OMX automation loop.
 - Workflows for:
   - issue request report
   - `/approve` implementation
-  - 3 review rounds for PRs
+  - 3 review rounds for agent-authored PRs
+  - event-driven, duplicate-delivery-safe re-review for external contributor PRs
   - final verdict + auto-merge on APPROVE
 
 ## Environment

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # dani
 
-Simple GitHub webhook -> OMX automation loop.
+Simple GitHub webhook -> agent automation loop. Supports two pluggable agent
+runtimes: **Oh-My-Codex (`omx`, default)** and **Oh-My-OpenAgents (`omo`,
+opt-in)**.
 
 ## What v1 includes
 - Typer CLI
 - FastAPI webhook server
 - Registered repos only
 - Repo-serial / cross-repo parallel job handling
-- non-interactive `omx exec` / `omx exec resume` launches
+- Pluggable agent runtime: non-interactive `omx exec` / `omx exec resume` (default)
+  or `opencode run --session <id>` (Oh-My-OpenAgents)
 - Separate prompt templates in `dani/prompts.py`
 - Workflows for:
   - issue request report
@@ -17,16 +20,37 @@ Simple GitHub webhook -> OMX automation loop.
   - final verdict + auto-merge on APPROVE
 
 ## Environment
-Required local tools:
+Required local tools (at least one depending on the selected runtime):
 - `git`
-- `omx`
+- `omx` — required when `DANI_AGENT_RUNTIME=omx` (default)
+- `opencode` — required when `DANI_AGENT_RUNTIME=omo`
 
 Required environment variables:
 - `DANI_WEBHOOK_SECRET`
 - `DANI_GITHUB_TOKEN` (preferred) or `GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_PAT`
 
+Optional environment variables:
+- `DANI_AGENT_RUNTIME` — selects the agent backend. Accepted values:
+  - `omx` / `oh-my-codex` / `codex` (default)
+  - `omo` / `oh-my-openagents` / `oh-my-openagent` / `opencode`
+
+When `DANI_AGENT_RUNTIME=omo` is selected, dani automatically prefixes every
+opencode prompt with the `ultrawork` keyword so oh-my-openagents' ultrawork
+loop mode is always active, and runtime-specific prompt substitutions swap
+codex-only shell commands (`$ralph`, `$code-review`) for their opencode
+equivalents (ultrawork mode and the Momus-Plan-Critic subagent respectively).
+
 ## Codex/OMX trust prerequisite
 Before dani can reliably launch or resume OMX/Codex sessions for a repository, that repository directory should be trusted by Codex at least once. In practice, run `omx exec 'hello'` or `codex exec 'hello'` once from the target repo and accept the trust prompt before using dani automation there. Otherwise a trust prompt can block session startup or resume.
+
+## Oh-My-OpenAgents (opencode) prerequisite
+When running with `DANI_AGENT_RUNTIME=omo`, dani launches sessions through
+`opencode run --format json --dangerously-skip-permissions <prompt>` and resumes
+them with `opencode run --session <id> ...`. Install `opencode` (the
+`oh-my-openagent` plugin is loaded automatically when configured in
+`~/.config/opencode/opencode.json`) and make sure the target repository
+directory is trusted at least once via `opencode run 'hello'` before pointing
+dani at it.
 
 ## CLI
 ```bash
@@ -42,7 +66,7 @@ State is stored under `~/.dani/` by default:
 - `jobs.json`
 - `sessions.json`
 - `events.jsonl`
-- `runs/` for generated OMX prompt/script artifacts
+- `runs/` for generated agent-runtime prompt/script artifacts (omx or omo)
 
 
 ## GitHub surfaces

--- a/dani/agent_runner.py
+++ b/dani/agent_runner.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
-from typing import Protocol, TextIO, runtime_checkable
+from typing import Protocol, TextIO, cast, runtime_checkable
 
 from dani.models import JobRecord, SessionRecord
 
@@ -14,6 +15,8 @@ class ManagedProcess(Protocol):
 
 
 ProcessEntry = tuple[ManagedProcess, TextIO, TextIO]
+
+DANI_OMO_LEGACY_SUBPROCESS_ENV = "DANI_OMO_LEGACY_SUBPROCESS"
 
 
 @runtime_checkable
@@ -50,16 +53,31 @@ class AgentRunner(Protocol):
 
     def get_session_id(self, runtime_handle: str) -> str | None: ...
 
+    def can_resume(self, session_id: str) -> bool: ...
+
+
+def _legacy_subprocess_enabled() -> bool:
+    raw = os.environ.get(DANI_OMO_LEGACY_SUBPROCESS_ENV, "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
 
 def build_agent_runner(runtime: str, run_dir: Path) -> AgentRunner:
-    """Factory returning the AgentRunner matching *runtime* (``omx`` or ``omo``)."""
+    """Factory returning the AgentRunner matching *runtime* (``omx`` or ``omo``).
+
+    The opencode (``omo``) runtime defaults to the long-lived HTTP-server
+    backend. Set ``DANI_OMO_LEGACY_SUBPROCESS=1`` to fall back to the legacy
+    one-shot ``opencode run`` subprocess implementation.
+    """
+    from dani.omo_http_runner import OmoHttpRunner
     from dani.omo_runner import OmoRunner
     from dani.omx_runner import OmxRunner
 
     normalized = (runtime or "omx").strip().lower()
     if normalized in {"omx", "oh-my-codex", "codex"}:
-        return OmxRunner(run_dir)
+        return cast(AgentRunner, OmxRunner(run_dir))
     if normalized in {"omo", "oh-my-openagents", "oh-my-openagent", "opencode"}:
-        return OmoRunner(run_dir)
+        if _legacy_subprocess_enabled():
+            return cast(AgentRunner, OmoRunner(run_dir))
+        return cast(AgentRunner, OmoHttpRunner(run_dir))
     msg = f"unknown agent runtime: {runtime!r} (expected 'omx' or 'omo')"
     raise ValueError(msg)

--- a/dani/agent_runner.py
+++ b/dani/agent_runner.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, TextIO, runtime_checkable
+
+from dani.models import JobRecord, SessionRecord
+
+
+class ManagedProcess(Protocol):
+    def poll(self) -> object: ...
+    def terminate(self) -> None: ...
+    def wait(self, timeout: float | None = None) -> object: ...
+    def kill(self) -> None: ...
+
+
+ProcessEntry = tuple[ManagedProcess, TextIO, TextIO]
+
+
+@runtime_checkable
+class AgentRunner(Protocol):
+    """Protocol every dani agent runtime adapter must satisfy.
+
+    Implementations wrap an external agent CLI (omx, opencode, ...) and expose
+    a uniform interface to ``DaniService`` for launching a new agent session,
+    resuming an existing one, waiting for completion, and releasing process
+    resources.
+    """
+
+    run_dir: Path
+
+    def launch(self, repo_path: Path, job: JobRecord, prompt: str) -> SessionRecord: ...
+
+    def resume(
+        self,
+        repo_path: Path,
+        job: JobRecord,
+        prompt: str,
+        omx_session_id: str,
+    ) -> SessionRecord: ...
+
+    def wait(
+        self,
+        runtime_handle: str,
+        *,
+        poll_interval: float = 0.5,
+        timeout_seconds: float = 1800,
+    ) -> None: ...
+
+    def close_session(self, runtime_handle: str) -> None: ...
+
+    def get_session_id(self, runtime_handle: str) -> str | None: ...
+
+
+def build_agent_runner(runtime: str, run_dir: Path) -> AgentRunner:
+    """Factory returning the AgentRunner matching *runtime* (``omx`` or ``omo``)."""
+    from dani.omo_runner import OmoRunner
+    from dani.omx_runner import OmxRunner
+
+    normalized = (runtime or "omx").strip().lower()
+    if normalized in {"omx", "oh-my-codex", "codex"}:
+        return OmxRunner(run_dir)
+    if normalized in {"omo", "oh-my-openagents", "oh-my-openagent", "opencode"}:
+        return OmoRunner(run_dir)
+    msg = f"unknown agent runtime: {runtime!r} (expected 'omx' or 'omo')"
+    raise ValueError(msg)

--- a/dani/cli.py
+++ b/dani/cli.py
@@ -24,7 +24,14 @@ DEV_BRANCH_OPTION = typer.Option("dev", help="Development branch name.")
 
 def build_config(data_dir: Path, host: str = "127.0.0.1", port: int = 8787) -> DaniConfig:
     secret = os.environ.get("DANI_WEBHOOK_SECRET", "")
-    return DaniConfig(data_dir=data_dir, webhook_secret=secret, host=host, port=port)
+    agent_runtime = os.environ.get("DANI_AGENT_RUNTIME", "omx")
+    return DaniConfig(
+        data_dir=data_dir,
+        webhook_secret=secret,
+        host=host,
+        port=port,
+        agent_runtime=agent_runtime,
+    )
 
 
 def build_service(data_dir: Path, host: str = "127.0.0.1", port: int = 8787) -> DaniService:

--- a/dani/cli.py
+++ b/dani/cli.py
@@ -78,3 +78,16 @@ def show_state(data_dir: Path = DATA_DIR_OPTION) -> None:
     """Print current dani state."""
     service = build_service(data_dir=data_dir)
     typer.echo(json.dumps(service.state_snapshot(), ensure_ascii=False, indent=2))
+
+
+@app.command("restart-issue")
+def restart_issue(
+    repo_full_name: str = FULL_NAME_ARGUMENT,
+    issue_number: int = typer.Argument(..., help="Issue number"),
+    data_dir: Path = DATA_DIR_OPTION,
+) -> None:
+    """Supersede stale issue jobs, run a fresh issue_request, and wait for completion."""
+    service = build_service(data_dir=data_dir)
+    job = service.restart_issue(repo_full_name, issue_number)
+    service.wait_for_idle()
+    typer.echo(json.dumps(job.to_dict(), ensure_ascii=False, indent=2))

--- a/dani/errors.py
+++ b/dani/errors.py
@@ -7,9 +7,22 @@ TRANSIENT_CAPACITY_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"model is currently overloaded", re.IGNORECASE),
 ]
 
+ROLLOUT_MISSING_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"thread/resume failed", re.IGNORECASE),
+    re.compile(r"no rollout found", re.IGNORECASE),
+]
+
 
 class TransientCapacityError(Exception):
     """Raised when an OMX session fails due to a transient model-capacity issue."""
+
+    def __init__(self, message: str, pattern: str) -> None:
+        super().__init__(message)
+        self.pattern = pattern
+
+
+class RolloutMissingError(Exception):
+    """Raised when a resume target rollout/session can no longer be found."""
 
     def __init__(self, message: str, pattern: str) -> None:
         super().__init__(message)
@@ -22,3 +35,11 @@ def check_transient_capacity_error(stderr_text: str) -> None:
         match = pattern.search(stderr_text)
         if match:
             raise TransientCapacityError(match.group(0), pattern.pattern)
+
+
+def check_rollout_missing_error(stderr_text: str) -> None:
+    """Raise ``RolloutMissingError`` if *stderr_text* matches known missing-rollout patterns."""
+    for pattern in ROLLOUT_MISSING_PATTERNS:
+        match = pattern.search(stderr_text)
+        if match:
+            raise RolloutMissingError(stderr_text.strip() or match.group(0), pattern.pattern)

--- a/dani/errors.py
+++ b/dani/errors.py
@@ -12,9 +12,19 @@ ROLLOUT_MISSING_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"no rollout found", re.IGNORECASE),
 ]
 
+# Patterns emitted by `opencode run --session ...` when the requested session
+# has been deleted/expired. Derived from the CLI source:
+#   "Session not found: ..." and related error text surfaced via the
+#   opencode run JSON event stream / stderr.
+OPENCODE_SESSION_MISSING_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"[Ss]ession not found", re.IGNORECASE),
+    re.compile(r"[Ss]ession does not exist", re.IGNORECASE),
+    re.compile(r"[Nn]o session with id", re.IGNORECASE),
+]
+
 
 class TransientCapacityError(Exception):
-    """Raised when an OMX session fails due to a transient model-capacity issue."""
+    """Raised when an agent session fails due to a transient model-capacity issue."""
 
     def __init__(self, message: str, pattern: str) -> None:
         super().__init__(message)
@@ -22,7 +32,12 @@ class TransientCapacityError(Exception):
 
 
 class RolloutMissingError(Exception):
-    """Raised when a resume target rollout/session can no longer be found."""
+    """Raised when a resume target rollout/session can no longer be found.
+
+    This error is runtime-agnostic: the OMX (codex) runner raises it when the
+    codex rollout file is gone; the OMO (opencode) runner raises it when
+    ``opencode run --session <id>`` reports the session no longer exists.
+    """
 
     def __init__(self, message: str, pattern: str) -> None:
         super().__init__(message)
@@ -38,8 +53,16 @@ def check_transient_capacity_error(stderr_text: str) -> None:
 
 
 def check_rollout_missing_error(stderr_text: str) -> None:
-    """Raise ``RolloutMissingError`` if *stderr_text* matches known missing-rollout patterns."""
+    """Raise ``RolloutMissingError`` if *stderr_text* matches known OMX missing-rollout patterns."""
     for pattern in ROLLOUT_MISSING_PATTERNS:
+        match = pattern.search(stderr_text)
+        if match:
+            raise RolloutMissingError(stderr_text.strip() or match.group(0), pattern.pattern)
+
+
+def check_opencode_session_missing_error(stderr_text: str) -> None:
+    """Raise ``RolloutMissingError`` if *stderr_text* matches known opencode session-missing patterns."""
+    for pattern in OPENCODE_SESSION_MISSING_PATTERNS:
         match = pattern.search(stderr_text)
         if match:
             raise RolloutMissingError(stderr_text.strip() or match.group(0), pattern.pattern)

--- a/dani/github.py
+++ b/dani/github.py
@@ -8,10 +8,11 @@ from typing import Any
 from github import Auth, Github
 from github.GithubException import GithubException
 
-from dani.signatures import parse_signature
+from dani.signatures import is_opt_out_comment, parse_agent_signature
 
 TOKEN_ENV_VARS = ("DANI_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT")
 LOGGER = logging.getLogger(__name__)
+MERGE_CONFLICT_STATUSES = frozenset({405, 409, 422})
 
 
 class MergeConflictError(RuntimeError):
@@ -88,7 +89,9 @@ class GitHubCLI:
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
         for comment in reversed(comments):
-            parsed = parse_signature(comment.get("body", ""))
+            if is_opt_out_comment(comment.get("body", "")):
+                continue
+            parsed = parse_agent_signature(comment.get("body", ""))
             if parsed is not None:
                 return comment, parsed
         return None
@@ -99,7 +102,11 @@ class GitHubCLI:
         comments = (
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
-        return [comment for comment in comments if signature_fragment in (comment.get("body") or "")]
+        return [
+            comment
+            for comment in comments
+            if not is_opt_out_comment(comment.get("body", "")) and signature_fragment in (comment.get("body") or "")
+        ]
 
     def create_issue_comment(self, repo_full_name: str, issue_number: int, body: str) -> dict[str, Any]:
         issue = self._repo(repo_full_name).get_issue(issue_number)
@@ -132,7 +139,9 @@ class GitHubCLI:
         try:
             merge_status = pull_request.merge(merge_method="merge", delete_branch=False)
         except GithubException as exc:
-            raise MergeConflictError(repo_full_name, pr_number, status=exc.status, message=str(exc)) from exc
+            if exc.status in MERGE_CONFLICT_STATUSES:
+                raise MergeConflictError(repo_full_name, pr_number, status=exc.status, message=str(exc)) from exc
+            raise
         if not merge_status.merged:
             raise MergeConflictError(repo_full_name, pr_number, message=merge_status.message)
         try:

--- a/dani/models.py
+++ b/dani/models.py
@@ -94,6 +94,7 @@ class DaniConfig:
     port: int = 8787
     review_rounds: int = 3
     external_review_limit: int = 10
+    agent_runtime: str = "omx"
 
     @property
     def registry_path(self) -> Path:

--- a/dani/models.py
+++ b/dani/models.py
@@ -80,6 +80,7 @@ class NormalizedEvent:
     title: str | None = None
     base_branch: str | None = None
     head_branch: str | None = None
+    delivery_id: str | None = None
     ref: str | None = None
     commit_sha: str | None = None
     is_pull_request: bool = False
@@ -92,6 +93,7 @@ class DaniConfig:
     host: str = "127.0.0.1"
     port: int = 8787
     review_rounds: int = 3
+    external_review_limit: int = 10
 
     @property
     def registry_path(self) -> Path:

--- a/dani/omo_http_runner.py
+++ b/dani/omo_http_runner.py
@@ -28,6 +28,7 @@ from dani.opencode_http import (
 logger = logging.getLogger(__name__)
 
 ULTRAWORK_PROMPT_PREFIX = "ultrawork\n\n"
+PLANNING_STAGES = frozenset({"issue_request", "issue_followup"})
 DANI_OPENCODE_SERVER_URL_ENV = "DANI_OPENCODE_SERVER_URL"
 DANI_OPENCODE_PERMISSION_RESPONSE_ENV = "DANI_OPENCODE_PERMISSION_RESPONSE"
 SESSION_ID_PATTERN = re.compile(r"^ses_[A-Za-z0-9]+$")
@@ -66,7 +67,7 @@ class OmoHttpRunner:
         self._consumer_factory = consumer_factory or _default_consumer_factory
 
     def launch(self, repo_path: Path, job: JobRecord, prompt: str) -> SessionRecord:
-        prompt_text = self._decorated_prompt(prompt)
+        prompt_text = self._decorated_prompt(prompt, stage=job.stage)
         session_dir, prompt_path, request_log_path, event_log_path, handle = self._prepare_session_files(job)
         prompt_path.write_text(prompt_text, encoding="utf-8")
         client, consumer = self._get_client_and_consumer(repo_path, event_log_path)
@@ -109,7 +110,7 @@ class OmoHttpRunner:
         if not omx_session_id:
             msg = "omx_session_id is required to resume an opencode session"
             raise ValueError(msg)
-        prompt_text = self._decorated_prompt(prompt)
+        prompt_text = self._decorated_prompt(prompt, stage=job.stage)
         session_dir, prompt_path, request_log_path, event_log_path, handle = self._prepare_session_files(job)
         prompt_path.write_text(prompt_text, encoding="utf-8")
         client, consumer = self._get_client_and_consumer(repo_path, event_log_path)
@@ -203,8 +204,10 @@ class OmoHttpRunner:
             consumer.stop()
         self._server_manager.shutdown_all()
 
-    def _decorated_prompt(self, prompt: str) -> str:
+    def _decorated_prompt(self, prompt: str, *, stage: str | None = None) -> str:
         if prompt.lstrip().lower().startswith("ultrawork"):
+            return prompt
+        if stage in PLANNING_STAGES:
             return prompt
         return f"{ULTRAWORK_PROMPT_PREFIX}{prompt}"
 

--- a/dani/omo_http_runner.py
+++ b/dani/omo_http_runner.py
@@ -261,7 +261,7 @@ class OmoHttpRunner:
         request_log_path: Path,
         event_log_path: Path,
     ) -> HttpTaskHandle:
-        state = consumer.register_session(session_id, event_log_path=event_log_path)
+        state = consumer.register_session(session_id, directory=directory, event_log_path=event_log_path)
         try:
             client.send_prompt_async(
                 session_id,

--- a/dani/omo_http_runner.py
+++ b/dani/omo_http_runner.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from subprocess import TimeoutExpired
+from uuid import uuid4
+
+from dani.errors import (
+    check_opencode_session_missing_error,
+    check_transient_capacity_error,
+)
+from dani.models import JobRecord, SessionRecord
+from dani.opencode_http import (
+    OPENCODE_BIN_DEFAULT,
+    PERMISSION_RESPONSE_DEFAULT,
+    HttpTaskHandle,
+    OpencodeClient,
+    OpencodeEventConsumer,
+    OpencodeHttpError,
+    OpencodeServerManager,
+)
+
+logger = logging.getLogger(__name__)
+
+ULTRAWORK_PROMPT_PREFIX = "ultrawork\n\n"
+DANI_OPENCODE_SERVER_URL_ENV = "DANI_OPENCODE_SERVER_URL"
+DANI_OPENCODE_PERMISSION_RESPONSE_ENV = "DANI_OPENCODE_PERMISSION_RESPONSE"
+SESSION_ID_PATTERN = re.compile(r"^ses_[A-Za-z0-9]+$")
+
+ClientFactory = Callable[[str], OpencodeClient]
+ConsumerFactory = Callable[[OpencodeClient, Path, str], OpencodeEventConsumer]
+
+
+class OmoHttpRunner:
+    def __init__(
+        self,
+        run_dir: Path,
+        *,
+        opencode_bin: str = OPENCODE_BIN_DEFAULT,
+        server_manager: OpencodeServerManager | None = None,
+        client_factory: ClientFactory | None = None,
+        consumer_factory: ConsumerFactory | None = None,
+        permission_response: str | None = None,
+    ) -> None:
+        self.run_dir = run_dir
+        self.opencode_bin = opencode_bin
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._tasks: dict[str, HttpTaskHandle] = {}
+        self._session_to_base_url: dict[str, str] = {}
+        self._handle_to_session: dict[str, str] = {}
+        self._consumers: dict[str, OpencodeEventConsumer] = {}
+        self._clients: dict[str, OpencodeClient] = {}
+        self._permission_response = self._resolve_permission_response(permission_response)
+        self._server_manager = server_manager or OpencodeServerManager(
+            run_dir,
+            opencode_bin=opencode_bin,
+            external_server_url=os.environ.get(DANI_OPENCODE_SERVER_URL_ENV),
+        )
+        self._client_factory = client_factory or _default_client_factory
+        self._consumer_factory = consumer_factory or _default_consumer_factory
+
+    def launch(self, repo_path: Path, job: JobRecord, prompt: str) -> SessionRecord:
+        prompt_text = self._decorated_prompt(prompt)
+        session_dir, prompt_path, request_log_path, event_log_path, handle = self._prepare_session_files(job)
+        prompt_path.write_text(prompt_text, encoding="utf-8")
+        client, consumer = self._get_client_and_consumer(repo_path, event_log_path)
+        try:
+            session = client.create_session(
+                directory=str(repo_path),
+                title=self._session_title(job),
+            )
+        except Exception:
+            logger.exception("opencode create_session failed for repo=%s job=%s", repo_path, job.id)
+            raise
+        self._submit_prompt_and_register(
+            client=client,
+            consumer=consumer,
+            session_id=session.id,
+            directory=session.directory,
+            prompt_text=prompt_text,
+            handle=handle,
+            request_log_path=request_log_path,
+            event_log_path=event_log_path,
+        )
+        del session_dir
+        return SessionRecord(
+            repo_full_name=job.repo_full_name,
+            stage=job.stage,
+            runtime_handle=handle,
+            prompt_path=str(prompt_path),
+            script_path=str(request_log_path),
+            worktree_path=str(repo_path),
+            job_id=job.id,
+            issue_number=job.issue_number,
+            pr_number=job.pr_number,
+            review_round=job.review_round,
+            omx_session_id=session.id,
+            stdout_path=str(event_log_path),
+            stderr_path=str(event_log_path),
+        )
+
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
+        if not omx_session_id:
+            msg = "omx_session_id is required to resume an opencode session"
+            raise ValueError(msg)
+        prompt_text = self._decorated_prompt(prompt)
+        session_dir, prompt_path, request_log_path, event_log_path, handle = self._prepare_session_files(job)
+        prompt_path.write_text(prompt_text, encoding="utf-8")
+        client, consumer = self._get_client_and_consumer(repo_path, event_log_path)
+        try:
+            client.get_session(omx_session_id, directory=str(repo_path))
+        except OpencodeHttpError as exc:
+            if exc.status == 404:
+                check_opencode_session_missing_error(f"Session not found: {omx_session_id}\n{exc.body}")
+                msg = f"opencode session {omx_session_id} not found (status 404)"
+                raise OpencodeHttpError(status=exc.status, body=msg, url=exc.url) from None
+            raise
+        self._submit_prompt_and_register(
+            client=client,
+            consumer=consumer,
+            session_id=omx_session_id,
+            directory=str(repo_path),
+            prompt_text=prompt_text,
+            handle=handle,
+            request_log_path=request_log_path,
+            event_log_path=event_log_path,
+        )
+        del session_dir
+        return SessionRecord(
+            repo_full_name=job.repo_full_name,
+            stage=job.stage,
+            runtime_handle=handle,
+            prompt_path=str(prompt_path),
+            script_path=str(request_log_path),
+            worktree_path=str(repo_path),
+            job_id=job.id,
+            issue_number=job.issue_number,
+            pr_number=job.pr_number,
+            review_round=job.review_round,
+            omx_session_id=omx_session_id,
+            stdout_path=str(event_log_path),
+            stderr_path=str(event_log_path),
+        )
+
+    def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
+        del poll_interval
+        with self._lock:
+            task = self._tasks.get(runtime_handle)
+        if task is None:
+            return
+        try:
+            task.wait(timeout=timeout_seconds)
+        except TimeoutExpired as exc:
+            msg = f"opencode session did not reach idle/error before timeout: {runtime_handle}"
+            raise TimeoutError(msg) from exc
+        outcome = task.outcome()
+        if outcome.aborted:
+            return
+        if outcome.error_message:
+            check_opencode_session_missing_error(outcome.error_message)
+            check_transient_capacity_error(outcome.error_message)
+            raise RuntimeError(outcome.error_message)
+
+    def close_session(self, runtime_handle: str) -> None:
+        with self._lock:
+            task = self._tasks.pop(runtime_handle, None)
+            session_id = self._handle_to_session.pop(runtime_handle, None)
+        if task is None:
+            return
+        try:
+            task.terminate()
+        finally:
+            if session_id is not None:
+                consumer = self._consumer_for_session(session_id)
+                if consumer is not None:
+                    consumer.unregister_session(session_id)
+
+    def get_session_id(self, runtime_handle: str) -> str | None:
+        with self._lock:
+            session_id = self._handle_to_session.get(runtime_handle)
+        if session_id and SESSION_ID_PATTERN.match(session_id):
+            return session_id
+        return None
+
+    def can_resume(self, session_id: str) -> bool:
+        return bool(session_id) and session_id.startswith("ses_")
+
+    def shutdown(self) -> None:
+        with self._lock:
+            consumers = list(self._consumers.values())
+            self._consumers.clear()
+            self._clients.clear()
+            self._tasks.clear()
+            self._handle_to_session.clear()
+            self._session_to_base_url.clear()
+        for consumer in consumers:
+            consumer.stop()
+        self._server_manager.shutdown_all()
+
+    def _decorated_prompt(self, prompt: str) -> str:
+        if prompt.lstrip().lower().startswith("ultrawork"):
+            return prompt
+        return f"{ULTRAWORK_PROMPT_PREFIX}{prompt}"
+
+    def _session_title(self, job: JobRecord) -> str:
+        suffix = job.id[:8] if job.id else "anon"
+        if job.issue_number:
+            return f"dani:{job.stage}:#{job.issue_number}:{suffix}"
+        if job.pr_number:
+            return f"dani:{job.stage}:pr#{job.pr_number}:{suffix}"
+        return f"dani:{job.stage}:{suffix}"
+
+    def _prepare_session_files(self, job: JobRecord) -> tuple[Path, Path, Path, Path, str]:
+        session_token = uuid4().hex[:10]
+        handle = f"dani-{job.stage}-{session_token}"
+        session_dir = self.run_dir / handle
+        session_dir.mkdir(parents=True, exist_ok=True)
+        prompt_path = session_dir / "prompt.txt"
+        request_log_path = session_dir / "request.json"
+        event_log_path = session_dir / "events.jsonl"
+        return session_dir, prompt_path, request_log_path, event_log_path, handle
+
+    def _get_client_and_consumer(
+        self, repo_path: Path, event_log_path: Path
+    ) -> tuple[OpencodeClient, OpencodeEventConsumer]:
+        base_url = self._server_manager.get_server_for_repo(repo_path)
+        with self._lock:
+            client = self._clients.get(base_url)
+            if client is None:
+                client = self._client_factory(base_url)
+                self._clients[base_url] = client
+            consumer = self._consumers.get(base_url)
+            if consumer is None:
+                consumer = self._consumer_factory(client, event_log_path, self._permission_response)
+                consumer.start()
+                self._consumers[base_url] = consumer
+        return client, consumer
+
+    def _consumer_for_session(self, session_id: str) -> OpencodeEventConsumer | None:
+        with self._lock:
+            base_url = self._session_to_base_url.get(session_id)
+            if base_url is None:
+                return None
+            return self._consumers.get(base_url)
+
+    def _submit_prompt_and_register(
+        self,
+        *,
+        client: OpencodeClient,
+        consumer: OpencodeEventConsumer,
+        session_id: str,
+        directory: str,
+        prompt_text: str,
+        handle: str,
+        request_log_path: Path,
+        event_log_path: Path,
+    ) -> HttpTaskHandle:
+        state = consumer.register_session(session_id, event_log_path=event_log_path)
+        try:
+            client.send_prompt_async(
+                session_id,
+                prompt_text=prompt_text,
+                directory=directory,
+            )
+        except Exception:
+            consumer.unregister_session(session_id)
+            raise
+        try:
+            self._write_request_log(request_log_path, session_id=session_id, prompt_text=prompt_text)
+        except OSError:
+            logger.debug("failed to write request log", exc_info=True)
+        task_handle = HttpTaskHandle(
+            session_id=session_id,
+            directory=directory,
+            client=client,
+            consumer=consumer,
+            state=state,
+        )
+        with self._lock:
+            self._tasks[handle] = task_handle
+            self._handle_to_session[handle] = session_id
+            self._session_to_base_url[session_id] = client.base_url
+        return task_handle
+
+    @staticmethod
+    def _resolve_permission_response(explicit: str | None) -> str:
+        if explicit and explicit in {"once", "always", "reject"}:
+            return explicit
+        env_value = os.environ.get(DANI_OPENCODE_PERMISSION_RESPONSE_ENV, "").strip().lower()
+        if env_value in {"once", "always", "reject"}:
+            return env_value
+        return PERMISSION_RESPONSE_DEFAULT
+
+    @staticmethod
+    def _write_request_log(path: Path, *, session_id: str, prompt_text: str) -> None:
+        path.write_text(
+            json.dumps(
+                {
+                    "session_id": session_id,
+                    "prompt_text": prompt_text,
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+
+def _default_client_factory(base_url: str) -> OpencodeClient:
+    password = os.environ.get("OPENCODE_SERVER_PASSWORD") or None
+    return OpencodeClient(base_url, password=password)
+
+
+def _default_consumer_factory(
+    client: OpencodeClient,
+    event_log_path: Path,
+    permission_response: str,
+) -> OpencodeEventConsumer:
+    return OpencodeEventConsumer(
+        client,
+        event_log_path=event_log_path,
+        permission_response=permission_response,
+    )

--- a/dani/omo_http_runner.py
+++ b/dani/omo_http_runner.py
@@ -116,9 +116,9 @@ class OmoHttpRunner:
         try:
             client.get_session(omx_session_id, directory=str(repo_path))
         except OpencodeHttpError as exc:
-            if exc.status == 404:
+            if self._is_session_missing_response(exc):
                 check_opencode_session_missing_error(f"Session not found: {omx_session_id}\n{exc.body}")
-                msg = f"opencode session {omx_session_id} not found (status 404)"
+                msg = f"opencode session {omx_session_id} not found (status {exc.status})"
                 raise OpencodeHttpError(status=exc.status, body=msg, url=exc.url) from None
             raise
         self._submit_prompt_and_register(
@@ -287,6 +287,18 @@ class OmoHttpRunner:
             self._handle_to_session[handle] = session_id
             self._session_to_base_url[session_id] = client.base_url
         return task_handle
+
+    @staticmethod
+    def _is_session_missing_response(exc: OpencodeHttpError) -> bool:
+        if exc.status == 404:
+            return True
+        if exc.status == 400:
+            body_lower = exc.body.lower() if exc.body else ""
+            if "must start with" in body_lower and "ses" in body_lower:
+                return True
+            if "invalid_format" in body_lower and "sessionid" in body_lower:
+                return True
+        return False
 
     @staticmethod
     def _resolve_permission_response(explicit: str | None) -> str:

--- a/dani/omo_runner.py
+++ b/dani/omo_runner.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import TextIO
+from uuid import uuid4
+
+from dani.agent_runner import ManagedProcess
+from dani.errors import (
+    check_opencode_session_missing_error,
+    check_rollout_missing_error,
+    check_transient_capacity_error,
+)
+from dani.models import JobRecord, SessionRecord
+
+OPENCODE_BIN = "opencode"
+ULTRAWORK_PROMPT_PREFIX = "ultrawork\n\n"
+
+
+class OmoRunner:
+    """Agent runner that drives the ``opencode`` CLI (oh-my-openagents stack)."""
+
+    def __init__(
+        self,
+        run_dir: Path,
+        opencode_bin: str = OPENCODE_BIN,
+    ) -> None:
+        self.run_dir = run_dir
+        self.opencode_bin = opencode_bin
+        self._processes: dict[str, tuple[ManagedProcess, TextIO, TextIO]] = {}
+        self._lock = threading.RLock()
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+
+    def _decorated_prompt(self, prompt: str) -> str:
+        if prompt.lstrip().lower().startswith("ultrawork"):
+            return prompt
+        return f"{ULTRAWORK_PROMPT_PREFIX}{prompt}"
+
+    def launch(self, repo_path: Path, job: JobRecord, prompt: str) -> SessionRecord:
+        session_dir, prompt_path, script_path, stdout_path, stderr_path, handle = self._prepare_session_files(job)
+        prompt_path.write_text(self._decorated_prompt(prompt), encoding="utf-8")
+        script_path.write_text(
+            self._build_script(repo_path=repo_path, prompt_path=prompt_path),
+            encoding="utf-8",
+        )
+        script_path.chmod(0o755)
+        process, stdout_file, stderr_file = self._spawn(script_path, stdout_path, stderr_path)
+        with self._lock:
+            self._processes[handle] = (process, stdout_file, stderr_file)
+        omx_session_id = None
+        if job.stage == "issue_request":
+            omx_session_id = self._capture_session_id(stdout_path=stdout_path)
+        del session_dir
+        return SessionRecord(
+            repo_full_name=job.repo_full_name,
+            stage=job.stage,
+            runtime_handle=handle,
+            prompt_path=str(prompt_path),
+            script_path=str(script_path),
+            worktree_path=str(repo_path),
+            job_id=job.id,
+            issue_number=job.issue_number,
+            pr_number=job.pr_number,
+            review_round=job.review_round,
+            omx_session_id=omx_session_id,
+            stdout_path=str(stdout_path),
+            stderr_path=str(stderr_path),
+        )
+
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
+        session_dir, prompt_path, script_path, stdout_path, stderr_path, handle = self._prepare_session_files(job)
+        prompt_path.write_text(self._decorated_prompt(prompt), encoding="utf-8")
+        script_path.write_text(
+            self._build_resume_script(
+                repo_path=repo_path,
+                prompt_path=prompt_path,
+                opencode_session_id=omx_session_id,
+            ),
+            encoding="utf-8",
+        )
+        script_path.chmod(0o755)
+        process, stdout_file, stderr_file = self._spawn(script_path, stdout_path, stderr_path)
+        with self._lock:
+            self._processes[handle] = (process, stdout_file, stderr_file)
+        del session_dir
+        return SessionRecord(
+            repo_full_name=job.repo_full_name,
+            stage=job.stage,
+            runtime_handle=handle,
+            prompt_path=str(prompt_path),
+            script_path=str(script_path),
+            worktree_path=str(repo_path),
+            job_id=job.id,
+            issue_number=job.issue_number,
+            pr_number=job.pr_number,
+            review_round=job.review_round,
+            omx_session_id=omx_session_id,
+            stdout_path=str(stdout_path),
+            stderr_path=str(stderr_path),
+        )
+
+    def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
+        del poll_interval
+        with self._lock:
+            entry = self._processes.get(runtime_handle)
+        if entry is None:
+            return
+        process, _, _ = entry
+        try:
+            process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired as exc:
+            msg = f"opencode run process did not exit before timeout: {runtime_handle}"
+            raise TimeoutError(msg) from exc
+        self._check_stderr_for_transient_error(runtime_handle)
+
+    def close_session(self, runtime_handle: str) -> None:
+        with self._lock:
+            entry = self._processes.pop(runtime_handle, None)
+        if entry is None:
+            return
+        process, stdout_file, stderr_file = entry
+        try:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+        finally:
+            stdout_file.close()
+            stderr_file.close()
+
+    def get_session_id(self, runtime_handle: str) -> str | None:
+        stdout_path = self.run_dir / runtime_handle / "stdout.log"
+        return self._session_id_from_stdout(stdout_path)
+
+    def _prepare_session_files(self, job: JobRecord) -> tuple[Path, Path, Path, Path, Path, str]:
+        session_token = uuid4().hex[:10]
+        handle = f"dani-{job.stage}-{session_token}"
+        session_dir = self.run_dir / handle
+        session_dir.mkdir(parents=True, exist_ok=True)
+        prompt_path = session_dir / "prompt.txt"
+        script_path = session_dir / "run.sh"
+        stdout_path = session_dir / "stdout.log"
+        stderr_path = session_dir / "stderr.log"
+        return session_dir, prompt_path, script_path, stdout_path, stderr_path, handle
+
+    def _spawn(
+        self, script_path: Path, stdout_path: Path, stderr_path: Path
+    ) -> tuple[subprocess.Popen[bytes], TextIO, TextIO]:
+        stdout_file = stdout_path.open("w", encoding="utf-8")
+        stderr_file = stderr_path.open("w", encoding="utf-8")
+        process = subprocess.Popen(  # noqa: S603
+            [str(script_path)],
+            stdin=subprocess.DEVNULL,
+            stdout=stdout_file,
+            stderr=stderr_file,
+            start_new_session=True,
+        )
+        return process, stdout_file, stderr_file
+
+    def _build_script(self, *, repo_path: Path, prompt_path: Path) -> str:
+        quoted_repo = shlex.quote(str(repo_path))
+        quoted_prompt = shlex.quote(str(prompt_path))
+        quoted_bin = shlex.quote(self.opencode_bin)
+        return (
+            "#!/bin/sh\n"
+            "set -eu\n"
+            f"cd {quoted_repo}\n"
+            f'exec {quoted_bin} run --format json --dangerously-skip-permissions "$(cat {quoted_prompt})"\n'
+        )
+
+    def _build_resume_script(self, *, repo_path: Path, prompt_path: Path, opencode_session_id: str) -> str:
+        quoted_repo = shlex.quote(str(repo_path))
+        quoted_prompt = shlex.quote(str(prompt_path))
+        quoted_session_id = shlex.quote(opencode_session_id)
+        quoted_bin = shlex.quote(self.opencode_bin)
+        return (
+            "#!/bin/sh\n"
+            "set -eu\n"
+            f"cd {quoted_repo}\n"
+            f"exec {quoted_bin} run --session {quoted_session_id} --format json "
+            f'--dangerously-skip-permissions "$(cat {quoted_prompt})"\n'
+        )
+
+    def _check_stderr_for_transient_error(self, runtime_handle: str) -> None:
+        stderr_path = self.run_dir / runtime_handle / "stderr.log"
+        if stderr_path.exists():
+            stderr_text = stderr_path.read_text(encoding="utf-8", errors="replace")
+            check_rollout_missing_error(stderr_text)
+            check_opencode_session_missing_error(stderr_text)
+            check_transient_capacity_error(stderr_text)
+        stdout_path = self.run_dir / runtime_handle / "stdout.log"
+        if stdout_path.exists():
+            stdout_text = stdout_path.read_text(encoding="utf-8", errors="replace")
+            check_opencode_session_missing_error(stdout_text)
+            check_transient_capacity_error(stdout_text)
+
+    def _capture_session_id(
+        self,
+        *,
+        stdout_path: Path,
+        poll_interval: float = 0.5,
+        timeout_seconds: float = 45.0,
+    ) -> str | None:
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            session_id = self._session_id_from_stdout(stdout_path)
+            if session_id:
+                return session_id
+            time.sleep(poll_interval)
+        return None
+
+    def _session_id_from_stdout(self, stdout_path: Path) -> str | None:
+        if not stdout_path.exists():
+            return None
+        try:
+            text = stdout_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return None
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or not line.startswith("{"):
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            session_id = event.get("sessionID") or event.get("sessionId")
+            if isinstance(session_id, str) and session_id.startswith("ses_"):
+                return session_id
+        return None

--- a/dani/omo_runner.py
+++ b/dani/omo_runner.py
@@ -19,6 +19,7 @@ from dani.models import JobRecord, SessionRecord
 
 OPENCODE_BIN = "opencode"
 ULTRAWORK_PROMPT_PREFIX = "ultrawork\n\n"
+PLANNING_STAGES = frozenset({"issue_request", "issue_followup"})
 
 
 class OmoRunner:
@@ -35,14 +36,16 @@ class OmoRunner:
         self._lock = threading.RLock()
         self.run_dir.mkdir(parents=True, exist_ok=True)
 
-    def _decorated_prompt(self, prompt: str) -> str:
+    def _decorated_prompt(self, prompt: str, *, stage: str | None = None) -> str:
         if prompt.lstrip().lower().startswith("ultrawork"):
+            return prompt
+        if stage in PLANNING_STAGES:
             return prompt
         return f"{ULTRAWORK_PROMPT_PREFIX}{prompt}"
 
     def launch(self, repo_path: Path, job: JobRecord, prompt: str) -> SessionRecord:
         session_dir, prompt_path, script_path, stdout_path, stderr_path, handle = self._prepare_session_files(job)
-        prompt_path.write_text(self._decorated_prompt(prompt), encoding="utf-8")
+        prompt_path.write_text(self._decorated_prompt(prompt, stage=job.stage), encoding="utf-8")
         script_path.write_text(
             self._build_script(repo_path=repo_path, prompt_path=prompt_path),
             encoding="utf-8",
@@ -73,7 +76,7 @@ class OmoRunner:
 
     def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
         session_dir, prompt_path, script_path, stdout_path, stderr_path, handle = self._prepare_session_files(job)
-        prompt_path.write_text(self._decorated_prompt(prompt), encoding="utf-8")
+        prompt_path.write_text(self._decorated_prompt(prompt, stage=job.stage), encoding="utf-8")
         script_path.write_text(
             self._build_resume_script(
                 repo_path=repo_path,

--- a/dani/omo_runner.py
+++ b/dani/omo_runner.py
@@ -139,6 +139,9 @@ class OmoRunner:
         stdout_path = self.run_dir / runtime_handle / "stdout.log"
         return self._session_id_from_stdout(stdout_path)
 
+    def can_resume(self, session_id: str) -> bool:
+        return bool(session_id) and session_id.startswith("ses_")
+
     def _prepare_session_files(self, job: JobRecord) -> tuple[Path, Path, Path, Path, Path, str]:
         session_token = uuid4().hex[:10]
         handle = f"dani-{job.stage}-{session_token}"

--- a/dani/omx_runner.py
+++ b/dani/omx_runner.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Protocol, TextIO
 from uuid import uuid4
 
-from dani.errors import check_transient_capacity_error
+from dani.errors import check_rollout_missing_error, check_transient_capacity_error
 from dani.models import JobRecord, SessionRecord
 
 
@@ -155,6 +155,7 @@ class OmxRunner:
         if not stderr_path.exists():
             return
         stderr_text = stderr_path.read_text(encoding="utf-8", errors="replace")
+        check_rollout_missing_error(stderr_text)
         check_transient_capacity_error(stderr_text)
 
     def close_session(self, runtime_handle: str) -> None:

--- a/dani/omx_runner.py
+++ b/dani/omx_runner.py
@@ -176,6 +176,9 @@ class OmxRunner:
         del runtime_handle
         return None
 
+    def can_resume(self, session_id: str) -> bool:
+        return bool(session_id) and not session_id.startswith("ses_")
+
     def _capture_omx_session_id(
         self,
         *,

--- a/dani/omx_runner.py
+++ b/dani/omx_runner.py
@@ -7,18 +7,14 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Protocol, TextIO
+from typing import TextIO
 from uuid import uuid4
 
+from dani.agent_runner import ManagedProcess
 from dani.errors import check_rollout_missing_error, check_transient_capacity_error
 from dani.models import JobRecord, SessionRecord
 
-
-class ManagedProcess(Protocol):
-    def poll(self) -> object: ...
-    def terminate(self) -> None: ...
-    def wait(self, timeout: float | None = None) -> object: ...
-    def kill(self) -> None: ...
+__all__ = ["ManagedProcess", "OmxRunner"]
 
 
 class OmxRunner:
@@ -175,6 +171,10 @@ class OmxRunner:
         finally:
             stdout_file.close()
             stderr_file.close()
+
+    def get_session_id(self, runtime_handle: str) -> str | None:
+        del runtime_handle
+        return None
 
     def _capture_omx_session_id(
         self,

--- a/dani/opencode_http/__init__.py
+++ b/dani/opencode_http/__init__.py
@@ -1,0 +1,26 @@
+from dani.opencode_http.client import OpencodeClient, OpencodeHttpError, OpencodeSessionInfo
+from dani.opencode_http.event_consumer import (
+    PERMISSION_RESPONSE_DEFAULT,
+    CompletionState,
+    OpencodeEventConsumer,
+)
+from dani.opencode_http.server_manager import (
+    OPENCODE_BIN_DEFAULT,
+    OpencodeServerError,
+    OpencodeServerManager,
+)
+from dani.opencode_http.task_handle import HttpTaskHandle, HttpTaskOutcome
+
+__all__ = [
+    "OPENCODE_BIN_DEFAULT",
+    "PERMISSION_RESPONSE_DEFAULT",
+    "CompletionState",
+    "HttpTaskHandle",
+    "HttpTaskOutcome",
+    "OpencodeClient",
+    "OpencodeEventConsumer",
+    "OpencodeHttpError",
+    "OpencodeServerError",
+    "OpencodeServerManager",
+    "OpencodeSessionInfo",
+]

--- a/dani/opencode_http/client.py
+++ b/dani/opencode_http/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import contextlib
 import json
 import logging
 import threading
@@ -136,7 +137,7 @@ class OpencodeClient:
         stop_event: threading.Event | None = None,
     ) -> Iterator[dict[str, Any]]:
         url = self._build_url("/event", self._directory_query(directory))
-        request = urllib.request.Request(url, headers=self._headers(accept="text/event-stream"))
+        request = urllib.request.Request(url, headers=self._headers(accept="text/event-stream"))  # noqa: S310
         with urllib.request.urlopen(request, timeout=None) as response:  # noqa: S310
             buffer: list[str] = []
             for raw_line in response:
@@ -172,7 +173,7 @@ class OpencodeClient:
         data = None
         if body is not None:
             data = json.dumps(body).encode("utf-8")
-        request = urllib.request.Request(url, data=data, method=method, headers=headers)
+        request = urllib.request.Request(url, data=data, method=method, headers=headers)  # noqa: S310
         try:
             with urllib.request.urlopen(request, timeout=self._request_timeout_seconds) as response:  # noqa: S310
                 raw = response.read()
@@ -184,10 +185,8 @@ class OpencodeClient:
                     return raw.decode("utf-8", errors="replace")
         except urllib.error.HTTPError as exc:
             body_text = ""
-            try:
+            with contextlib.suppress(Exception):
                 body_text = exc.read().decode("utf-8", errors="replace")
-            except Exception:  # noqa: BLE001
-                pass
             raise OpencodeHttpError(status=exc.code, body=body_text, url=url) from exc
 
     def _build_url(self, path: str, query: dict[str, str] | None) -> str:

--- a/dani/opencode_http/client.py
+++ b/dani/opencode_http/client.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class OpencodeHttpError(Exception):
+    def __init__(self, status: int, body: str, url: str) -> None:
+        super().__init__(f"opencode http {status} on {url}: {body[:400]}")
+        self.status = status
+        self.body = body
+        self.url = url
+
+
+@dataclass(slots=True)
+class OpencodeSessionInfo:
+    id: str
+    directory: str
+    title: str
+
+
+class OpencodeClient:
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        password: str | None = None,
+        request_timeout_seconds: float = 30.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._password = password
+        self._request_timeout_seconds = request_timeout_seconds
+        self._auth_header: str | None = None
+        if password:
+            self._auth_header = "Basic " + base64.b64encode(f":{password}".encode()).decode("ascii")
+
+    def create_session(self, *, directory: str, title: str | None = None) -> OpencodeSessionInfo:
+        body: dict[str, Any] = {}
+        if title:
+            body["title"] = title
+        payload = self._request(
+            "POST",
+            "/session",
+            query={"directory": directory},
+            body=body,
+        )
+        return OpencodeSessionInfo(
+            id=str(payload["id"]),
+            directory=str(payload.get("directory", directory)),
+            title=str(payload.get("title", title or "")),
+        )
+
+    def get_session(self, session_id: str, *, directory: str | None = None) -> dict[str, Any]:
+        return self._request("GET", f"/session/{session_id}", query=self._directory_query(directory))
+
+    def session_status(self, *, directory: str | None = None) -> dict[str, dict[str, Any]]:
+        payload = self._request("GET", "/session/status", query=self._directory_query(directory))
+        if not isinstance(payload, dict):
+            return {}
+        return payload
+
+    def send_prompt_async(
+        self,
+        session_id: str,
+        *,
+        prompt_text: str,
+        directory: str | None = None,
+        agent: str | None = None,
+    ) -> None:
+        body: dict[str, Any] = {
+            "parts": [{"type": "text", "text": prompt_text}],
+        }
+        if agent:
+            body["agent"] = agent
+        self._request(
+            "POST",
+            f"/session/{session_id}/prompt_async",
+            query=self._directory_query(directory),
+            body=body,
+            expect_json=False,
+        )
+
+    def abort_session(self, session_id: str, *, directory: str | None = None) -> bool:
+        try:
+            payload = self._request(
+                "POST",
+                f"/session/{session_id}/abort",
+                query=self._directory_query(directory),
+                body=None,
+            )
+        except OpencodeHttpError as exc:
+            if exc.status == 404:
+                return False
+            raise
+        return bool(payload) if payload is not None else True
+
+    def respond_permission(
+        self,
+        session_id: str,
+        permission_id: str,
+        *,
+        response: str,
+        directory: str | None = None,
+    ) -> bool:
+        if response not in {"once", "always", "reject"}:
+            msg = f"invalid permission response: {response!r}"
+            raise ValueError(msg)
+        try:
+            payload = self._request(
+                "POST",
+                f"/session/{session_id}/permissions/{permission_id}",
+                query=self._directory_query(directory),
+                body={"response": response},
+            )
+        except OpencodeHttpError as exc:
+            if exc.status in {404, 409}:
+                logger.debug("permission %s already resolved for session %s", permission_id, session_id)
+                return False
+            raise
+        return bool(payload) if payload is not None else True
+
+    def stream_events(
+        self,
+        *,
+        directory: str | None = None,
+        stop_event: threading.Event | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        url = self._build_url("/event", self._directory_query(directory))
+        request = urllib.request.Request(url, headers=self._headers(accept="text/event-stream"))
+        with urllib.request.urlopen(request, timeout=None) as response:  # noqa: S310
+            buffer: list[str] = []
+            for raw_line in response:
+                if stop_event is not None and stop_event.is_set():
+                    return
+                line = raw_line.decode("utf-8", errors="replace")
+                if line in {"\n", "\r\n"}:
+                    if not buffer:
+                        continue
+                    event_text = "".join(buffer).rstrip("\n")
+                    buffer.clear()
+                    data = self._extract_sse_data(event_text)
+                    if data is None:
+                        continue
+                    try:
+                        yield json.loads(data)
+                    except json.JSONDecodeError:
+                        logger.debug("ignoring non-json SSE data: %r", data[:200])
+                    continue
+                buffer.append(line)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        query: dict[str, str] | None = None,
+        body: dict[str, Any] | None = None,
+        expect_json: bool = True,
+    ) -> Any:
+        url = self._build_url(path, query)
+        headers = self._headers(content_type="application/json" if body is not None else None)
+        data = None
+        if body is not None:
+            data = json.dumps(body).encode("utf-8")
+        request = urllib.request.Request(url, data=data, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=self._request_timeout_seconds) as response:  # noqa: S310
+                raw = response.read()
+                if not expect_json or not raw:
+                    return None
+                try:
+                    return json.loads(raw.decode("utf-8"))
+                except json.JSONDecodeError:
+                    return raw.decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as exc:
+            body_text = ""
+            try:
+                body_text = exc.read().decode("utf-8", errors="replace")
+            except Exception:  # noqa: BLE001
+                pass
+            raise OpencodeHttpError(status=exc.code, body=body_text, url=url) from exc
+
+    def _build_url(self, path: str, query: dict[str, str] | None) -> str:
+        url = f"{self.base_url}{path}"
+        if query:
+            filtered = {k: v for k, v in query.items() if v is not None}
+            if filtered:
+                url = f"{url}?{urllib.parse.urlencode(filtered)}"
+        return url
+
+    def _headers(self, *, content_type: str | None = None, accept: str | None = None) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if content_type:
+            headers["Content-Type"] = content_type
+        if accept:
+            headers["Accept"] = accept
+        if self._auth_header:
+            headers["Authorization"] = self._auth_header
+        return headers
+
+    def _directory_query(self, directory: str | None) -> dict[str, str]:
+        if not directory:
+            return {}
+        return {"directory": directory}
+
+    @staticmethod
+    def _extract_sse_data(event_text: str) -> str | None:
+        data_lines: list[str] = []
+        for line in event_text.splitlines():
+            if line.startswith("data:"):
+                data_lines.append(line[5:].lstrip())
+        if not data_lines:
+            return None
+        return "\n".join(data_lines)

--- a/dani/opencode_http/event_consumer.py
+++ b/dani/opencode_http/event_consumer.py
@@ -40,24 +40,22 @@ class OpencodeEventConsumer:
         self._permission_response = permission_response
         self._sessions: dict[str, CompletionState] = {}
         self._session_log_paths: dict[str, Path] = {}
+        self._session_directories: dict[str, str] = {}
+        self._directory_threads: dict[str, threading.Thread] = {}
+        self._directory_connected: dict[str, threading.Event] = {}
         self._lock = threading.RLock()
         self._stop_event = threading.Event()
-        self._thread: threading.Thread | None = None
         self._fallback_thread: threading.Thread | None = None
-        self._sse_connected = threading.Event()
+        self._started = False
         if event_log_path is not None:
             event_log_path.parent.mkdir(parents=True, exist_ok=True)
 
     def start(self) -> None:
-        if self._thread is not None and self._thread.is_alive():
-            return
-        self._stop_event.clear()
-        self._thread = threading.Thread(
-            target=self._run_event_loop,
-            name="opencode-event-consumer",
-            daemon=True,
-        )
-        self._thread.start()
+        with self._lock:
+            if self._started:
+                return
+            self._stop_event.clear()
+            self._started = True
         self._fallback_thread = threading.Thread(
             target=self._run_status_fallback_loop,
             name="opencode-status-fallback",
@@ -67,14 +65,21 @@ class OpencodeEventConsumer:
 
     def stop(self) -> None:
         self._stop_event.set()
-        thread = self._thread
-        if thread is not None:
+        with self._lock:
+            threads = list(self._directory_threads.values())
+        for thread in threads:
             thread.join(timeout=2.0)
         fallback = self._fallback_thread
         if fallback is not None:
             fallback.join(timeout=2.0)
 
-    def register_session(self, session_id: str, *, event_log_path: Path | None = None) -> CompletionState:
+    def register_session(
+        self,
+        session_id: str,
+        *,
+        directory: str | None = None,
+        event_log_path: Path | None = None,
+    ) -> CompletionState:
         with self._lock:
             state = self._sessions.get(session_id)
             if state is None:
@@ -83,12 +88,17 @@ class OpencodeEventConsumer:
             if event_log_path is not None:
                 event_log_path.parent.mkdir(parents=True, exist_ok=True)
                 self._session_log_paths[session_id] = event_log_path
-            return state
+            if directory:
+                self._session_directories[session_id] = directory
+        if directory:
+            self._ensure_directory_listener(directory)
+        return state
 
     def unregister_session(self, session_id: str) -> None:
         with self._lock:
             self._sessions.pop(session_id, None)
             self._session_log_paths.pop(session_id, None)
+            self._session_directories.pop(session_id, None)
 
     def get_state(self, session_id: str) -> CompletionState | None:
         with self._lock:
@@ -103,25 +113,40 @@ class OpencodeEventConsumer:
             state.status = "aborted"
             state.event.set()
 
-    def _run_event_loop(self) -> None:
+    def _ensure_directory_listener(self, directory: str) -> None:
+        with self._lock:
+            existing = self._directory_threads.get(directory)
+            if existing is not None and existing.is_alive():
+                return
+            connected = threading.Event()
+            self._directory_connected[directory] = connected
+            thread = threading.Thread(
+                target=self._run_event_loop_for_directory,
+                args=(directory, connected),
+                name=f"opencode-event-{Path(directory).name or 'root'}",
+                daemon=True,
+            )
+            self._directory_threads[directory] = thread
+        thread.start()
+
+    def _run_event_loop_for_directory(self, directory: str, connected: threading.Event) -> None:
         backoff_index = 0
         while not self._stop_event.is_set():
             try:
-                for event in self._client.stream_events(stop_event=self._stop_event):
-                    self._sse_connected.set()
+                for event in self._client.stream_events(directory=directory, stop_event=self._stop_event):
+                    connected.set()
                     backoff_index = 0
                     self._handle_event(event)
                     if self._stop_event.is_set():
                         break
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 if self._stop_event.is_set():
                     return
-                self._sse_connected.clear()
-                backoff = SSE_RECONNECT_BACKOFF_SECONDS[
-                    min(backoff_index, len(SSE_RECONNECT_BACKOFF_SECONDS) - 1)
-                ]
+                connected.clear()
+                backoff = SSE_RECONNECT_BACKOFF_SECONDS[min(backoff_index, len(SSE_RECONNECT_BACKOFF_SECONDS) - 1)]
                 logger.warning(
-                    "opencode SSE stream error (%s); reconnecting in %.1fs",
+                    "opencode SSE stream error for directory=%s (%s); reconnecting in %.1fs",
+                    directory,
                     type(exc).__name__,
                     backoff,
                 )
@@ -129,7 +154,7 @@ class OpencodeEventConsumer:
                 if self._stop_event.wait(timeout=backoff):
                     return
                 continue
-            self._sse_connected.clear()
+            connected.clear()
             if self._stop_event.is_set():
                 return
             if self._stop_event.wait(timeout=1.0):
@@ -139,21 +164,43 @@ class OpencodeEventConsumer:
         while not self._stop_event.is_set():
             if self._stop_event.wait(timeout=STATUS_FALLBACK_POLL_SECONDS):
                 return
-            if self._sse_connected.is_set():
-                continue
+            self._poll_status_for_pending_sessions()
+
+    def _poll_status_for_pending_sessions(self) -> None:
+        with self._lock:
+            pending: list[tuple[str, str | None]] = [
+                (sid, self._session_directories.get(sid))
+                for sid, state in self._sessions.items()
+                if not state.event.is_set()
+            ]
+            all_connected = bool(self._directory_connected) and all(
+                ev.is_set() for ev in self._directory_connected.values()
+            )
+        if all_connected or not pending:
+            return
+        directories_to_probe: set[str | None] = {directory for _sid, directory in pending}
+        for directory in directories_to_probe:
             try:
-                statuses = self._client.session_status()
-            except Exception:  # noqa: BLE001
+                statuses = self._client.session_status(directory=directory)
+            except Exception as exc:
+                logger.debug("session_status fallback poll failed for %s: %s", directory, exc)
                 continue
-            with self._lock:
-                pending = [sid for sid, state in self._sessions.items() if not state.event.is_set()]
-            for session_id in pending:
-                status = statuses.get(session_id)
-                if status is None:
-                    continue
-                status_type = str(status.get("type", "")) if isinstance(status, dict) else ""
-                if status_type == "idle":
-                    self._mark_idle(session_id)
+            self._mark_idle_for_matching(pending, directory, statuses)
+
+    def _mark_idle_for_matching(
+        self,
+        pending: list[tuple[str, str | None]],
+        directory: str | None,
+        statuses: dict[str, dict[str, Any]],
+    ) -> None:
+        for session_id, session_dir in pending:
+            if session_dir != directory:
+                continue
+            status = statuses.get(session_id)
+            if not isinstance(status, dict):
+                continue
+            if str(status.get("type", "")) == "idle":
+                self._mark_idle(session_id)
 
     def _handle_event(self, event: dict[str, Any]) -> None:
         event_type = str(event.get("type", ""))
@@ -220,11 +267,14 @@ class OpencodeEventConsumer:
         permission_id = str(properties.get("id", "") or "")
         if not session_id or not permission_id:
             return
+        with self._lock:
+            directory = self._session_directories.get(session_id)
         try:
             self._client.respond_permission(
                 session_id,
                 permission_id,
                 response=self._permission_response,
+                directory=directory,
             )
         except OpencodeHttpError as exc:
             logger.warning(
@@ -234,7 +284,7 @@ class OpencodeEventConsumer:
                 permission_id,
                 exc.body[:200],
             )
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.warning(
                 "permission grant failed for session=%s permission=%s",
                 session_id,
@@ -246,11 +296,14 @@ class OpencodeEventConsumer:
         target_paths = self._resolve_log_paths(properties)
         if not target_paths:
             return
-        line = json.dumps({
-            "ts": time.time(),
-            "type": event_type,
-            "properties": properties,
-        }) + "\n"
+        line = (
+            json.dumps({
+                "ts": time.time(),
+                "type": event_type,
+                "properties": properties,
+            })
+            + "\n"
+        )
         for path in target_paths:
             try:
                 with path.open("a", encoding="utf-8") as handle:

--- a/dani/opencode_http/event_consumer.py
+++ b/dani/opencode_http/event_consumer.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from dani.opencode_http.client import OpencodeClient, OpencodeHttpError
+
+logger = logging.getLogger(__name__)
+
+PERMISSION_RESPONSE_DEFAULT = "once"
+SSE_RECONNECT_BACKOFF_SECONDS = (1.0, 2.0, 5.0, 10.0)
+STATUS_FALLBACK_POLL_SECONDS = 5.0
+
+
+@dataclass(slots=True)
+class CompletionState:
+    sessionID: str
+    event: threading.Event = field(default_factory=threading.Event)
+    error_payload: dict[str, Any] | None = None
+    error_message: str | None = None
+    aborted: bool = False
+    status: str = "submitted"
+
+
+class OpencodeEventConsumer:
+    def __init__(
+        self,
+        client: OpencodeClient,
+        *,
+        event_log_path: Path | None = None,
+        permission_response: str = PERMISSION_RESPONSE_DEFAULT,
+    ) -> None:
+        self._client = client
+        self._default_event_log_path = event_log_path
+        self._permission_response = permission_response
+        self._sessions: dict[str, CompletionState] = {}
+        self._session_log_paths: dict[str, Path] = {}
+        self._lock = threading.RLock()
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._fallback_thread: threading.Thread | None = None
+        self._sse_connected = threading.Event()
+        if event_log_path is not None:
+            event_log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run_event_loop,
+            name="opencode-event-consumer",
+            daemon=True,
+        )
+        self._thread.start()
+        self._fallback_thread = threading.Thread(
+            target=self._run_status_fallback_loop,
+            name="opencode-status-fallback",
+            daemon=True,
+        )
+        self._fallback_thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=2.0)
+        fallback = self._fallback_thread
+        if fallback is not None:
+            fallback.join(timeout=2.0)
+
+    def register_session(self, session_id: str, *, event_log_path: Path | None = None) -> CompletionState:
+        with self._lock:
+            state = self._sessions.get(session_id)
+            if state is None:
+                state = CompletionState(sessionID=session_id)
+                self._sessions[session_id] = state
+            if event_log_path is not None:
+                event_log_path.parent.mkdir(parents=True, exist_ok=True)
+                self._session_log_paths[session_id] = event_log_path
+            return state
+
+    def unregister_session(self, session_id: str) -> None:
+        with self._lock:
+            self._sessions.pop(session_id, None)
+            self._session_log_paths.pop(session_id, None)
+
+    def get_state(self, session_id: str) -> CompletionState | None:
+        with self._lock:
+            return self._sessions.get(session_id)
+
+    def mark_aborted(self, session_id: str) -> None:
+        with self._lock:
+            state = self._sessions.get(session_id)
+            if state is None:
+                return
+            state.aborted = True
+            state.status = "aborted"
+            state.event.set()
+
+    def _run_event_loop(self) -> None:
+        backoff_index = 0
+        while not self._stop_event.is_set():
+            try:
+                for event in self._client.stream_events(stop_event=self._stop_event):
+                    self._sse_connected.set()
+                    backoff_index = 0
+                    self._handle_event(event)
+                    if self._stop_event.is_set():
+                        break
+            except Exception as exc:  # noqa: BLE001
+                if self._stop_event.is_set():
+                    return
+                self._sse_connected.clear()
+                backoff = SSE_RECONNECT_BACKOFF_SECONDS[
+                    min(backoff_index, len(SSE_RECONNECT_BACKOFF_SECONDS) - 1)
+                ]
+                logger.warning(
+                    "opencode SSE stream error (%s); reconnecting in %.1fs",
+                    type(exc).__name__,
+                    backoff,
+                )
+                backoff_index += 1
+                if self._stop_event.wait(timeout=backoff):
+                    return
+                continue
+            self._sse_connected.clear()
+            if self._stop_event.is_set():
+                return
+            if self._stop_event.wait(timeout=1.0):
+                return
+
+    def _run_status_fallback_loop(self) -> None:
+        while not self._stop_event.is_set():
+            if self._stop_event.wait(timeout=STATUS_FALLBACK_POLL_SECONDS):
+                return
+            if self._sse_connected.is_set():
+                continue
+            try:
+                statuses = self._client.session_status()
+            except Exception:  # noqa: BLE001
+                continue
+            with self._lock:
+                pending = [sid for sid, state in self._sessions.items() if not state.event.is_set()]
+            for session_id in pending:
+                status = statuses.get(session_id)
+                if status is None:
+                    continue
+                status_type = str(status.get("type", "")) if isinstance(status, dict) else ""
+                if status_type == "idle":
+                    self._mark_idle(session_id)
+
+    def _handle_event(self, event: dict[str, Any]) -> None:
+        event_type = str(event.get("type", ""))
+        properties = event.get("properties") or {}
+        if not isinstance(properties, dict):
+            properties = {}
+        self._log_event(event_type, properties)
+        if event_type == "session.idle":
+            self._mark_idle(str(properties.get("sessionID", "")))
+        elif event_type == "session.error":
+            self._mark_error(properties)
+        elif event_type == "permission.updated":
+            self._auto_grant_permission(properties)
+        elif event_type == "session.status":
+            session_id = str(properties.get("sessionID", ""))
+            status = properties.get("status") or {}
+            status_type = str(status.get("type", "")) if isinstance(status, dict) else ""
+            with self._lock:
+                state = self._sessions.get(session_id)
+                if state is not None and status_type:
+                    state.status = status_type
+
+    def _mark_idle(self, session_id: str) -> None:
+        if not session_id:
+            return
+        with self._lock:
+            state = self._sessions.get(session_id)
+            if state is None or state.event.is_set():
+                return
+            state.status = "idle"
+            state.event.set()
+
+    def _mark_error(self, properties: dict[str, Any]) -> None:
+        session_id = str(properties.get("sessionID", "") or "")
+        error_payload = properties.get("error") or {}
+        if not isinstance(error_payload, dict):
+            error_payload = {"raw": error_payload}
+        message = ""
+        nested = error_payload.get("data") if isinstance(error_payload, dict) else None
+        if isinstance(nested, dict):
+            message = str(nested.get("message", "") or "")
+        if not message:
+            message = str(error_payload.get("name", "") or error_payload.get("type", "") or "session.error")
+        if not session_id:
+            with self._lock:
+                pending = [sid for sid, state in self._sessions.items() if not state.event.is_set()]
+            for sid in pending:
+                self._record_error_locked(sid, error_payload, message)
+            return
+        self._record_error_locked(session_id, error_payload, message)
+
+    def _record_error_locked(self, session_id: str, error_payload: dict[str, Any], message: str) -> None:
+        with self._lock:
+            state = self._sessions.get(session_id)
+            if state is None or state.event.is_set():
+                return
+            state.error_payload = error_payload
+            state.error_message = message
+            state.status = "error"
+            state.event.set()
+
+    def _auto_grant_permission(self, properties: dict[str, Any]) -> None:
+        session_id = str(properties.get("sessionID", "") or "")
+        permission_id = str(properties.get("id", "") or "")
+        if not session_id or not permission_id:
+            return
+        try:
+            self._client.respond_permission(
+                session_id,
+                permission_id,
+                response=self._permission_response,
+            )
+        except OpencodeHttpError as exc:
+            logger.warning(
+                "permission grant rejected (status=%s) for session=%s permission=%s: %s",
+                exc.status,
+                session_id,
+                permission_id,
+                exc.body[:200],
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "permission grant failed for session=%s permission=%s",
+                session_id,
+                permission_id,
+                exc_info=True,
+            )
+
+    def _log_event(self, event_type: str, properties: dict[str, Any]) -> None:
+        target_paths = self._resolve_log_paths(properties)
+        if not target_paths:
+            return
+        line = json.dumps({
+            "ts": time.time(),
+            "type": event_type,
+            "properties": properties,
+        }) + "\n"
+        for path in target_paths:
+            try:
+                with path.open("a", encoding="utf-8") as handle:
+                    handle.write(line)
+            except OSError:
+                logger.debug("failed to write opencode event log to %s", path, exc_info=True)
+
+    def _resolve_log_paths(self, properties: dict[str, Any]) -> list[Path]:
+        candidates: list[Path] = []
+        session_id = self._extract_session_id(properties)
+        with self._lock:
+            session_log = self._session_log_paths.get(session_id) if session_id else None
+            default_log = self._default_event_log_path
+        if session_log is not None:
+            candidates.append(session_log)
+        if default_log is not None and default_log != session_log:
+            candidates.append(default_log)
+        return candidates
+
+    @staticmethod
+    def _extract_session_id(properties: dict[str, Any]) -> str | None:
+        sid = properties.get("sessionID")
+        if isinstance(sid, str) and sid:
+            return sid
+        info = properties.get("info")
+        if isinstance(info, dict):
+            inner = info.get("sessionID") or info.get("id")
+            if isinstance(inner, str) and inner:
+                return inner
+        part = properties.get("part")
+        if isinstance(part, dict):
+            inner = part.get("sessionID")
+            if isinstance(inner, str) and inner:
+                return inner
+        return None

--- a/dani/opencode_http/server_manager.py
+++ b/dani/opencode_http/server_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import atexit
+import contextlib
 import logging
 import os
 import re
@@ -149,7 +150,7 @@ class OpencodeServerManager:
                     for line in stream:
                         log_handle.write(line)
                         log_handle.flush()
-            except Exception:  # noqa: BLE001
+            except Exception:
                 logger.debug("opencode server log pump exited", exc_info=True)
 
         thread = threading.Thread(target=_pump, daemon=True, name=f"opencode-server-log-{process.pid}")
@@ -179,13 +180,11 @@ class OpencodeServerManager:
                 try:
                     process.wait(timeout=SERVER_SHUTDOWN_GRACE_SECONDS)
                 except subprocess.TimeoutExpired:
-                    try:
+                    with contextlib.suppress(ProcessLookupError):
                         os.killpg(os.getpgid(process.pid), signal.SIGKILL)
-                    except ProcessLookupError:
-                        pass
                     process.kill()
                     process.wait(timeout=SERVER_SHUTDOWN_GRACE_SECONDS)
-            except Exception:  # noqa: BLE001
+            except Exception:
                 logger.warning("error terminating opencode server pid=%s", process.pid, exc_info=True)
         if entry.log_thread is not None and entry.log_thread.is_alive():
             entry.log_thread.join(timeout=1.0)

--- a/dani/opencode_http/server_manager.py
+++ b/dani/opencode_http/server_manager.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import re
+import shlex
+import signal
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+OPENCODE_BIN_DEFAULT = "opencode"
+SERVER_LISTENING_PATTERN = re.compile(r"opencode server listening on (http://\S+)")
+SERVER_READY_TIMEOUT_SECONDS = 30.0
+SERVER_SHUTDOWN_GRACE_SECONDS = 5.0
+
+
+class OpencodeServerError(RuntimeError):
+    pass
+
+
+@dataclass(slots=True)
+class _ServerEntry:
+    base_url: str
+    repo_path: Path
+    process: subprocess.Popen[str] | None
+    log_path: Path | None
+    log_thread: threading.Thread | None = None
+    log_buffer: list[str] = field(default_factory=list)
+
+
+class OpencodeServerManager:
+    def __init__(
+        self,
+        run_dir: Path,
+        *,
+        opencode_bin: str = OPENCODE_BIN_DEFAULT,
+        external_server_url: str | None = None,
+        ready_timeout_seconds: float = SERVER_READY_TIMEOUT_SECONDS,
+    ) -> None:
+        self.run_dir = run_dir
+        self.opencode_bin = opencode_bin
+        self.external_server_url = (external_server_url or "").strip() or None
+        self._ready_timeout_seconds = ready_timeout_seconds
+        self._lock = threading.RLock()
+        self._servers: dict[str, _ServerEntry] = {}
+        self._atexit_registered = False
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+
+    def get_server_for_repo(self, repo_path: Path) -> str:
+        if self.external_server_url:
+            return self.external_server_url
+        key = self._cache_key(repo_path)
+        with self._lock:
+            entry = self._servers.get(key)
+            if entry is not None and self._is_alive(entry):
+                return entry.base_url
+            if entry is not None:
+                logger.warning("opencode server for %s exited; respawning", key)
+                self._dispose_locked(entry)
+                self._servers.pop(key, None)
+            entry = self._spawn_server(Path(key))
+            self._servers[key] = entry
+            self._register_atexit_locked()
+            return entry.base_url
+
+    def shutdown_all(self) -> None:
+        with self._lock:
+            entries = list(self._servers.values())
+            self._servers.clear()
+        for entry in entries:
+            self._dispose_locked(entry)
+
+    def _spawn_server(self, repo_path: Path) -> _ServerEntry:
+        if not repo_path.exists():
+            msg = f"opencode server repo path does not exist: {repo_path}"
+            raise OpencodeServerError(msg)
+        log_path = self.run_dir / f"opencode-server-{repo_path.name}-{os.getpid()}-{int(time.time())}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        process = subprocess.Popen(  # noqa: S603
+            [self.opencode_bin, "serve", "--port", "0", "--hostname", "127.0.0.1", "--print-logs"],
+            cwd=str(repo_path),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            start_new_session=True,
+        )
+        entry = _ServerEntry(
+            base_url="",
+            repo_path=repo_path,
+            process=process,
+            log_path=log_path,
+        )
+        base_url = self._await_ready_url(entry)
+        entry.base_url = base_url
+        entry.log_thread = self._start_log_pump(entry)
+        logger.info("opencode server ready for %s at %s (pid=%s)", repo_path, base_url, process.pid)
+        return entry
+
+    def _await_ready_url(self, entry: _ServerEntry) -> str:
+        process = entry.process
+        if process is None or process.stdout is None:
+            msg = "opencode server subprocess has no stdout pipe"
+            raise OpencodeServerError(msg)
+        deadline = time.monotonic() + self._ready_timeout_seconds
+        log_handle = entry.log_path.open("w", encoding="utf-8") if entry.log_path else None
+        try:
+            while time.monotonic() < deadline:
+                line = process.stdout.readline()
+                if line == "":
+                    if process.poll() is not None:
+                        msg = self._format_startup_failure(entry)
+                        raise OpencodeServerError(msg)
+                    time.sleep(0.05)
+                    continue
+                entry.log_buffer.append(line)
+                if log_handle is not None:
+                    log_handle.write(line)
+                    log_handle.flush()
+                match = SERVER_LISTENING_PATTERN.search(line)
+                if match:
+                    return match.group(1)
+            msg = (
+                f"opencode server did not announce ready URL within {self._ready_timeout_seconds:.0f}s; "
+                f"log: {entry.log_path}"
+            )
+            raise OpencodeServerError(msg)
+        finally:
+            if log_handle is not None:
+                log_handle.close()
+
+    def _start_log_pump(self, entry: _ServerEntry) -> threading.Thread:
+        process = entry.process
+        log_path = entry.log_path
+        if process is None or process.stdout is None or log_path is None:
+            return threading.Thread(target=lambda: None, daemon=True)
+        stream = process.stdout
+
+        def _pump() -> None:
+            try:
+                with log_path.open("a", encoding="utf-8") as log_handle:
+                    for line in stream:
+                        log_handle.write(line)
+                        log_handle.flush()
+            except Exception:  # noqa: BLE001
+                logger.debug("opencode server log pump exited", exc_info=True)
+
+        thread = threading.Thread(target=_pump, daemon=True, name=f"opencode-server-log-{process.pid}")
+        thread.start()
+        return thread
+
+    def _format_startup_failure(self, entry: _ServerEntry) -> str:
+        process = entry.process
+        exit_code = process.poll() if process is not None else None
+        cmd = " ".join(
+            shlex.quote(part) for part in [self.opencode_bin, "serve", "--port", "0", "--hostname", "127.0.0.1"]
+        )
+        tail = "".join(entry.log_buffer[-20:]) or "(no output)"
+        return f"opencode server exited before ready (exit_code={exit_code}, cmd={cmd}); tail:\n{tail}"
+
+    def _is_alive(self, entry: _ServerEntry) -> bool:
+        process = entry.process
+        return process is not None and process.poll() is None
+
+    def _dispose_locked(self, entry: _ServerEntry) -> None:
+        process = entry.process
+        if process is None:
+            return
+        if process.poll() is None:
+            try:
+                process.terminate()
+                try:
+                    process.wait(timeout=SERVER_SHUTDOWN_GRACE_SECONDS)
+                except subprocess.TimeoutExpired:
+                    try:
+                        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    process.kill()
+                    process.wait(timeout=SERVER_SHUTDOWN_GRACE_SECONDS)
+            except Exception:  # noqa: BLE001
+                logger.warning("error terminating opencode server pid=%s", process.pid, exc_info=True)
+        if entry.log_thread is not None and entry.log_thread.is_alive():
+            entry.log_thread.join(timeout=1.0)
+
+    def _register_atexit_locked(self) -> None:
+        if self._atexit_registered:
+            return
+        atexit.register(self.shutdown_all)
+        self._atexit_registered = True
+
+    @staticmethod
+    def _cache_key(repo_path: Path) -> str:
+        return str(repo_path.resolve())

--- a/dani/opencode_http/task_handle.py
+++ b/dani/opencode_http/task_handle.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dani.opencode_http.client import OpencodeClient
+    from dani.opencode_http.event_consumer import CompletionState, OpencodeEventConsumer
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class HttpTaskOutcome:
+    completed: bool
+    aborted: bool
+    error_message: str | None
+    error_payload: dict | None
+
+
+class HttpTaskHandle:
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        directory: str,
+        client: "OpencodeClient",
+        consumer: "OpencodeEventConsumer",
+        state: "CompletionState",
+    ) -> None:
+        self.session_id = session_id
+        self.directory = directory
+        self._client = client
+        self._consumer = consumer
+        self._state = state
+        self._closed = threading.Event()
+        self._exit_code: int | None = None
+
+    @property
+    def state(self) -> "CompletionState":
+        return self._state
+
+    def poll(self) -> int | None:
+        if self._exit_code is not None:
+            return self._exit_code
+        if not self._state.event.is_set():
+            return None
+        self._exit_code = 0 if self._state.error_message is None and not self._state.aborted else 1
+        return self._exit_code
+
+    def wait(self, timeout: float | None = None) -> int:
+        deadline_seconds = float(timeout) if timeout is not None else None
+        signaled = self._state.event.wait(timeout=deadline_seconds)
+        if not signaled:
+            from subprocess import TimeoutExpired
+
+            raise TimeoutExpired(cmd=f"opencode-session:{self.session_id}", timeout=deadline_seconds or 0.0)
+        self._exit_code = 0 if self._state.error_message is None and not self._state.aborted else 1
+        return self._exit_code
+
+    def terminate(self) -> None:
+        self._abort()
+
+    def kill(self) -> None:
+        self._abort()
+
+    def _abort(self) -> None:
+        if self._closed.is_set():
+            return
+        self._closed.set()
+        try:
+            self._client.abort_session(self.session_id, directory=self.directory)
+        except Exception:  # noqa: BLE001
+            logger.debug("abort failed for session %s", self.session_id, exc_info=True)
+        self._consumer.mark_aborted(self.session_id)
+        if self._exit_code is None:
+            self._exit_code = 1
+
+    def outcome(self) -> HttpTaskOutcome:
+        return HttpTaskOutcome(
+            completed=self._state.event.is_set(),
+            aborted=self._state.aborted,
+            error_message=self._state.error_message,
+            error_payload=self._state.error_payload,
+        )
+
+    def wait_until_settled(self, *, deadline_seconds: float, poll_interval: float = 0.1) -> bool:
+        end = time.monotonic() + deadline_seconds
+        while time.monotonic() < end:
+            if self._state.event.is_set():
+                return True
+            time.sleep(poll_interval)
+        return self._state.event.is_set()

--- a/dani/opencode_http/task_handle.py
+++ b/dani/opencode_http/task_handle.py
@@ -27,9 +27,9 @@ class HttpTaskHandle:
         *,
         session_id: str,
         directory: str,
-        client: "OpencodeClient",
-        consumer: "OpencodeEventConsumer",
-        state: "CompletionState",
+        client: OpencodeClient,
+        consumer: OpencodeEventConsumer,
+        state: CompletionState,
     ) -> None:
         self.session_id = session_id
         self.directory = directory
@@ -40,7 +40,7 @@ class HttpTaskHandle:
         self._exit_code: int | None = None
 
     @property
-    def state(self) -> "CompletionState":
+    def state(self) -> CompletionState:
         return self._state
 
     def poll(self) -> int | None:
@@ -73,7 +73,7 @@ class HttpTaskHandle:
         self._closed.set()
         try:
             self._client.abort_session(self.session_id, directory=self.directory)
-        except Exception:  # noqa: BLE001
+        except Exception:
             logger.debug("abort failed for session %s", self.session_id, exc_info=True)
         self._consumer.mark_aborted(self.session_id)
         if self._exit_code is None:

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -18,14 +18,26 @@ $issue_body
 Existing issue discussion history:
 $discussion
 
+Before writing the comment, do real research — do not produce a plan from memory alone.
+Research requirements:
+- Search the codebase for existing reusable code (modules, functions, utilities, patterns) that already address part of the issue. Cite any findings as path/to/file.py:line.
+- Investigate external sources (official docs, GitHub repos, package registries, web search) for APIs or libraries that already provide the needed capability. Cite any findings as "Title - URL".
+- If nothing is reusable in-repo, state exactly: "no existing reusable code found".
+- If no suitable external dependency exists, state exactly: "no suitable external library found".
+
 Write one GitHub issue comment.
 Checklist:
 - [ ] AI-understood issue summary
 - [ ] Why this issue is needed
 - [ ] Why this issue may not be needed
 - [ ] Expected Outcome
-- [ ] Concise implementation plan
+- [ ] Evidence-based implementation plan
 - [ ] Agent Signature
+
+For the "Evidence-based implementation plan" section, report:
+- Feasibility grounded in the research above (reusable code and/or external libraries, with citations).
+- A concrete step-by-step plan that references the cited evidence (path/to/file.py:line for code, "Title - URL" for external references).
+- Any risks or assumptions surfaced by the research.
 
 Use this exact signature somewhere in the comment:
 $signature
@@ -227,7 +239,18 @@ After the push succeeds, exit.
 }
 
 
-def render_prompt(template_name: str, context: dict[str, Any]) -> str:
+# omx uses codex shell-slash commands ($ralph, $code-review); omo (opencode)
+# has neither, so the equivalent intents are swapped in post-render: ralph loop
+# -> ultrawork mode (always-on for omo), $code-review -> Momus-Plan-Critic subagent.
+_RUNTIME_SUBSTITUTIONS: dict[str, tuple[tuple[str, str], ...]] = {
+    "omo": (
+        ("$code-review", "the Momus-Plan-Critic subagent for rigorous verification"),
+        ("$ralph", "ultrawork"),
+    ),
+}
+
+
+def render_prompt(template_name: str, context: dict[str, Any], *, runtime: str = "omx") -> str:
     template = TEMPLATES[template_name]
     context = dict(context)
     context.setdefault("review_cycle", "")
@@ -238,4 +261,9 @@ def render_prompt(template_name: str, context: dict[str, Any]) -> str:
             **context,
             "signature": build_signature(stage=template_name, job_id=context.get("job_id", "unknown")),
         }
-    return template.substitute({key: "" if value is None else str(value) for key, value in context.items()})
+    rendered = template.substitute({key: "" if value is None else str(value) for key, value in context.items()})
+    substitutions = _RUNTIME_SUBSTITUTIONS.get((runtime or "omx").strip().lower())
+    if substitutions:
+        for needle, replacement in substitutions:
+            rendered = rendered.replace(needle, replacement)
+    return rendered

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -15,6 +15,9 @@ Task: review GitHub issue #$issue_number titled "$issue_title".
 Issue body:
 $issue_body
 
+Existing issue discussion history:
+$discussion
+
 Write one GitHub issue comment.
 Checklist:
 - [ ] AI-understood issue summary
@@ -90,7 +93,7 @@ After creating or updating the PR, exit.
     "review_round": Template(
         """
 You are reviewing PR #$pr_number in $repo.
-Round: $round_number / 3
+Round: $round_number / $round_total
 PR title: $pr_title
 PR body:
 $pr_body
@@ -98,6 +101,7 @@ $pr_body
 Recent discussion:
 $discussion
 
+$review_mode_note
 Use the code locally and run $$code-review before writing the review comment.
 Do real verification, not only static inspection.
 Checklist:
@@ -148,6 +152,7 @@ After posting the PR comment, exit.
     "final_verdict": Template(
         """
 You are deciding the final verdict for PR #$pr_number in $repo.
+$review_cycle
 PR title: $pr_title
 PR body:
 $pr_body
@@ -155,17 +160,40 @@ $pr_body
 Review history:
 $discussion
 
-Leave exactly one final GitHub PR comment.
+Leave exactly one GitHub PR comment for this review pass.
 Checklist:
 - [ ] Verdict: APPROVE or REJECT
 - [ ] Short reason
 - [ ] Real Result from actual verification
 - [ ] Include concrete evidence appropriate for what you verified
+- [ ] If REJECT, make the next contributor action clear
 - [ ] If APPROVE, include: $approve_signature
 - [ ] If REJECT, include: $reject_signature
 
 Post it with gh:
 gh pr comment $pr_number --repo $repo --body-file <final-verdict.md>
+
+After posting the PR comment, exit.
+        """.strip()
+    ),
+    "human_escalation": Template(
+        """
+You are escalating PR #$pr_number in $repo to a human maintainer.
+Review limit reached: $review_limit
+PR title: $pr_title
+PR body:
+$pr_body
+
+Recent review history:
+$discussion
+
+Leave exactly one GitHub PR comment that:
+- [ ] States automated review stopped after $review_limit review passes
+- [ ] Asks a human maintainer to take over triage / scope / merge judgment
+- [ ] Includes this exact signature: $signature
+
+Post it with gh:
+gh pr comment $pr_number --repo $repo --body-file <human-escalation.md>
 
 After posting the PR comment, exit.
         """.strip()
@@ -202,6 +230,9 @@ After the push succeeds, exit.
 def render_prompt(template_name: str, context: dict[str, Any]) -> str:
     template = TEMPLATES[template_name]
     context = dict(context)
+    context.setdefault("review_cycle", "")
+    context.setdefault("round_total", "3")
+    context.setdefault("review_mode_note", "")
     if template_name != "final_verdict" and "signature" not in context:
         context = {
             **context,

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -12,6 +12,13 @@ You are operating inside repository: $repo
 Local path: $local_path
 Task: review GitHub issue #$issue_number titled "$issue_title".
 
+ROLE: PLANNING AGENT (read-only analysis, no implementation).
+- You analyze and propose a plan. You DO NOT write code, create branches, or open PRs in this session.
+- After you post the comment, your session ENDS. dani discards your in-memory state.
+- Implementation only starts when a human responds with a comment containing "/approve". At that point dani spawns a NEW, SEPARATE agent session in a fresh process. That agent does not inherit your reasoning trace — it only sees the issue body and the GitHub discussion.
+- Do NOT promise to "create a PR", "open a branch", "write the code", "push commits", or "do the work next". Phrase the plan as "the implementation agent will...".
+- Your comment is the entire handoff. Make it self-contained: anything the implementation agent must know has to be IN the comment text.
+
 Issue body:
 $issue_body
 
@@ -31,7 +38,9 @@ Checklist:
 - [ ] Why this issue is needed
 - [ ] Why this issue may not be needed
 - [ ] Expected Outcome
-- [ ] Evidence-based implementation plan
+- [ ] Evidence-based implementation plan (phrased as instructions for the implementation agent)
+- [ ] Open questions for the human (if any) — they must answer in a follow-up comment before /approve
+- [ ] Reminder that implementation starts only after a human comment containing "/approve"
 - [ ] Agent Signature
 
 For the "Evidence-based implementation plan" section, report:
@@ -54,6 +63,13 @@ You are resuming the existing discussion for GitHub issue #$issue_number in $rep
 Local path: $local_path
 Issue title: $issue_title
 
+ROLE: PLANNING AGENT (read-only analysis, no implementation).
+- You refine the plan based on the new comment. You DO NOT write code, create branches, or open PRs in this session.
+- After you post the comment, your session ENDS. dani discards your in-memory state.
+- Implementation only starts when a human responds with a comment containing "/approve". At that point dani spawns a NEW, SEPARATE agent session in a fresh process. That agent does not inherit your reasoning trace — it only sees the issue body and the GitHub discussion.
+- Do NOT promise to "create a PR", "open a branch", "write the code", "push commits", or "do the work next". Phrase next steps as "the implementation agent will...".
+- Your comment is the entire handoff. Make it self-contained: anything the implementation agent must know has to be IN the comment text or in earlier visible discussion.
+
 Original issue body:
 $issue_body
 
@@ -61,7 +77,12 @@ New user follow-up comment:
 $comment_body
 
 Continue the existing issue discussion instead of restarting the analysis from scratch.
-Write exactly one GitHub issue comment that addresses the new follow-up and includes this exact signature:
+Write exactly one GitHub issue comment that addresses the new follow-up. The comment must:
+- Answer or clarify the user's follow-up directly.
+- Update the implementation plan if the follow-up changes scope/approach.
+- Note any remaining open questions the human must resolve before "/approve".
+- Remind the human that implementation starts only after a comment containing "/approve".
+- Include this exact signature on its own line:
 $signature
 
 Post it with gh (write the comment to a file first, then send it):

--- a/dani/queue.py
+++ b/dani/queue.py
@@ -85,7 +85,7 @@ class RepoQueueManager:
     def _after_job(self, repo: str, job: JobRecord) -> None:
         if not self._needs_issue_lock(job):
             return
-        if job.stage in _TERMINAL_STAGES or job.status == "failed":
+        if job.stage in _TERMINAL_STAGES or job.status in {"failed", "superseded"}:
             self._flush_deferred(repo)
 
     def _flush_deferred(self, repo: str) -> None:

--- a/dani/server.py
+++ b/dani/server.py
@@ -23,7 +23,7 @@ def create_app(service: DaniService) -> FastAPI:
         if event_name is None:
             raise HTTPException(status_code=400, detail="missing event name")
         payload = parse_body(body)
-        event = normalize_event(event_name, payload)
+        event = normalize_event(event_name, payload, delivery_id=request.headers.get("x-github-delivery"))
         if event is None:
             return {"status": "ignored", "reason": "unsupported_event"}
         return service.handle_event(event)

--- a/dani/service.py
+++ b/dani/service.py
@@ -1077,6 +1077,9 @@ class DaniService:
         self, repo: RepoConfig, event: NormalizedEvent, signature: dict[str, str] | None
     ) -> dict[str, Any]:
         is_agent_managed_pr = bool(signature and signature.get("stage") == "implementation")
+        is_release_pr = event.head_branch == repo.dev_branch and event.base_branch == repo.main_branch
+        if is_release_pr:
+            return {"status": "ignored", "reason": "release_loop_excluded"}
         if not is_agent_managed_pr and event.base_branch is not None and event.base_branch != repo.dev_branch:
             self._post_retarget_request_if_missing(repo, event)
             return {"status": "ignored", "reason": "non_dev_target_branch"}

--- a/dani/service.py
+++ b/dani/service.py
@@ -1026,6 +1026,8 @@ class DaniService:
         )
         if session is None or session.omx_session_id is None:
             return {"status": "ignored", "reason": "missing_issue_session"}
+        if not self.omx_runner.can_resume(session.omx_session_id):
+            return self._queue_issue_request(repo, event)
         job = self._enqueue_job(
             repo,
             stage="issue_followup",

--- a/dani/service.py
+++ b/dani/service.py
@@ -24,6 +24,8 @@ from dani.storage import JsonStorage
 
 ISSUE_REF_PATTERN = re.compile(r"#(?P<number>\d+)")
 
+RETARGET_REQUEST_STAGE = "retarget_request"
+
 RETRY_BACKOFF_SECONDS: list[int] = [60, 180, 600]
 
 logger = logging.getLogger(__name__)
@@ -160,6 +162,9 @@ class DaniService:
 
         if stage == "final_verdict" and signature.get("verdict") == "APPROVE":
             return self._handle_final_verdict_agent_event(event, signature)
+
+        if stage == RETARGET_REQUEST_STAGE:
+            return {"status": "ignored", "reason": "retarget_request_no_action"}
 
         return {"status": "updated", "stage": stage}
 
@@ -952,6 +957,26 @@ class DaniService:
             self.github.find_comments_by_signature(repo_full_name, pr_number, kind="pr", signature_fragment=signature)
         )
 
+    def _post_retarget_request_if_missing(self, repo: RepoConfig, event: NormalizedEvent) -> None:
+        pr_number = event.number
+        signature = build_signature(stage=RETARGET_REQUEST_STAGE, pr=pr_number)
+        if self._has_exact_pr_signature(repo.full_name, pr_number, signature):
+            return
+        body = (
+            f"Thanks for the contribution! \U0001f64f\n\n"
+            f"This repository's automation only reviews pull requests that target the "
+            f"`{repo.dev_branch}` branch (this PR currently targets `{event.base_branch}`). "
+            f"Please change the base branch to `{repo.dev_branch}` so dani can pick it up "
+            f"for automated review.\n\n"
+            f'GitHub UI \u2192 click "Edit" next to the PR title \u2192 change the base '
+            f"branch to `{repo.dev_branch}`, then push (or reopen) the PR.\n\n"
+            f"{signature}"
+        )
+        try:
+            self.github.create_pr_comment(repo.full_name, pr_number, body)
+        except Exception:
+            logger.warning("failed to post retarget-to-dev comment for %s#%s", repo.full_name, pr_number, exc_info=True)
+
     def _has_exact_issue_signature(self, repo_full_name: str, issue_number: int, signature: str) -> bool:
         return bool(
             self.github.find_comments_by_signature(
@@ -1051,6 +1076,10 @@ class DaniService:
     def _queue_pull_request_review(
         self, repo: RepoConfig, event: NormalizedEvent, signature: dict[str, str] | None
     ) -> dict[str, Any]:
+        is_agent_managed_pr = bool(signature and signature.get("stage") == "implementation")
+        if not is_agent_managed_pr and event.base_branch is not None and event.base_branch != repo.dev_branch:
+            self._post_retarget_request_if_missing(repo, event)
+            return {"status": "ignored", "reason": "non_dev_target_branch"}
         if event.base_branch == repo.main_branch:
             return {"status": "ignored", "reason": "release_loop_excluded"}
         issue_number = None
@@ -1060,7 +1089,6 @@ class DaniService:
                 self.storage.update_job(signature["job"], status="completed", pr_number=event.number)
         if issue_number is None:
             issue_number = self._extract_issue_number(event.body)
-        is_agent_managed_pr = bool(signature and signature.get("stage") == "implementation")
         if is_agent_managed_pr:
             if event.action != "opened":
                 return {"status": "ignored", "reason": "agent_managed_pr_followup"}

--- a/dani/service.py
+++ b/dani/service.py
@@ -7,14 +7,14 @@ import time
 from pathlib import Path
 from typing import Any
 
-from dani.errors import TransientCapacityError
+from dani.errors import ROLLOUT_MISSING_PATTERNS, RolloutMissingError, TransientCapacityError
 from dani.git_sync import DevSyncConflictError, GitDevSyncer
 from dani.github import GitHubCLI, MergeConflictError
 from dani.models import DaniConfig, JobRecord, NormalizedEvent, RepoConfig, SessionRecord, utc_now
 from dani.omx_runner import OmxRunner
 from dani.prompts import render_prompt
 from dani.queue import RepoQueueManager
-from dani.signatures import build_signature, parse_signature
+from dani.signatures import build_signature, is_opt_out_comment, parse_signature
 from dani.storage import JsonStorage
 
 ISSUE_REF_PATTERN = re.compile(r"#(?P<number>\d+)")
@@ -76,6 +76,26 @@ class DaniService:
     def state_snapshot(self) -> dict[str, Any]:
         return self.storage.snapshot()
 
+    def restart_issue(self, repo_full_name: str, issue_number: int) -> JobRecord:
+        repo = self.storage.get_repo(repo_full_name)
+        if repo is None:
+            msg = f"missing_repo: {repo_full_name}"
+            raise RuntimeError(msg)
+
+        for job in self.storage.find_jobs(repo_full_name=repo_full_name, issue_number=issue_number):
+            self.storage.update_job(job.id, status="superseded")
+
+        issue_metadata = self._issue_metadata(repo_full_name, issue_number)
+        return self._enqueue_job(
+            repo,
+            stage="issue_request",
+            issue_number=issue_number,
+            metadata={
+                "title": issue_metadata.get("title", f"Issue #{issue_number}"),
+                "body": issue_metadata.get("body", ""),
+            },
+        )
+
     def handle_event(self, event: NormalizedEvent) -> dict[str, Any]:
         self.storage.append_event({
             "repo_full_name": event.repo_full_name,
@@ -87,12 +107,16 @@ class DaniService:
             "title": event.title,
             "base_branch": event.base_branch,
             "head_branch": event.head_branch,
+            "delivery_id": event.delivery_id,
             "ref": event.ref,
             "commit_sha": event.commit_sha,
         })
         repo = self.storage.get_repo(event.repo_full_name)
         if repo is None or not repo.enabled:
             return {"status": "ignored", "reason": "unregistered_repo"}
+
+        if event.kind in {"issue_comment", "pull_request_comment"} and is_opt_out_comment(event.body):
+            return {"status": "ignored", "reason": "comment_opt_out"}
 
         signature = parse_signature(event.body or "")
         if signature and event.kind != "pull_request_opened":
@@ -118,7 +142,7 @@ class DaniService:
     def _handle_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         stage = signature.get("stage")
         if stage == "review_round":
-            return self._handle_review_round_agent_event(event, signature)
+            return self._handle_review_round_event(event, signature)
 
         if stage == "implementation" and event.kind == "pull_request_comment":
             return self._handle_implementation_agent_event(event, signature)
@@ -130,36 +154,6 @@ class DaniService:
             return self._handle_final_verdict_agent_event(event, signature)
 
         return {"status": "updated", "stage": stage}
-
-    def _handle_review_round_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
-        event_key = self._agent_event_key(signature, default_pr=event.number if event.is_pull_request else None)
-        if not self.storage.record_processed_event(event_key):
-            return {"status": "ignored", "reason": "duplicate_agent_event"}
-        review_round = int(signature["round"])
-        pr_number = int(signature["pr"])
-        issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
-        if issue_number is None:
-            return {"status": "ignored", "reason": "untracked_pr"}
-        repo = self.storage.get_repo(event.repo_full_name)
-        if repo is None:
-            return {"status": "ignored", "reason": "missing_repo"}
-        if not self._is_pr_open(event.repo_full_name, pr_number):
-            return {"status": "ignored", "reason": "pr_not_open"}
-        pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
-        next_job = self._enqueue_job(
-            repo,
-            stage="implementation",
-            issue_number=issue_number,
-            pr_number=pr_number,
-            review_round=review_round,
-            metadata={
-                **pr_metadata,
-                "title": (pr_metadata.get("title") or event.title or ""),
-                "review_comment_body": event.body or "",
-                "triggering_review_round": review_round,
-            },
-        )
-        return {"status": "queued", "job_id": next_job.id, "stage": next_job.stage}
 
     def _handle_implementation_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         pr_number = int(signature.get("pr") or event.number)
@@ -206,10 +200,13 @@ class DaniService:
     def _handle_merge_conflict_resolution_agent_event(
         self, event: NormalizedEvent, signature: dict[str, str]
     ) -> dict[str, Any]:
+        pr_number = int(signature["pr"])
+        event_key = self._agent_event_key(signature, default_pr=pr_number)
+        if not self.storage.record_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_agent_event"}
         repo = self.storage.get_repo(event.repo_full_name)
         if repo is None:
             return {"status": "ignored", "reason": "missing_repo"}
-        pr_number = int(signature["pr"])
         if not self._is_pr_open(event.repo_full_name, pr_number):
             return {"status": "ignored", "reason": "pr_not_open"}
         pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
@@ -230,6 +227,9 @@ class DaniService:
 
     def _handle_final_verdict_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         pr_number = int(signature["pr"])
+        event_key = self._agent_event_key(signature, default_pr=pr_number)
+        if self.storage.has_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_agent_event"}
         if not self._is_pr_open(event.repo_full_name, pr_number):
             return {"status": "ignored", "reason": "pr_not_open"}
         try:
@@ -239,10 +239,13 @@ class DaniService:
             if repo is None:
                 return {"status": "ignored", "reason": "missing_repo"}
             pull_request = self.github.get_pull_request(event.repo_full_name, pr_number)
+            issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
+            if issue_number is None:
+                issue_number = self._extract_issue_number(pull_request.get("body"))
             merge_conflict_job = self._enqueue_job(
                 repo,
                 stage="merge_conflict_resolution",
-                issue_number=self._extract_issue_number(pull_request.get("body")),
+                issue_number=issue_number,
                 pr_number=pr_number,
                 metadata={
                     "title": pull_request.get("title") or event.title or f"PR #{pr_number}",
@@ -252,8 +255,100 @@ class DaniService:
                     "conflict_reason": str(exc),
                 },
             )
+            self.storage.record_processed_event(event_key)
             return {"status": "queued", "job_id": merge_conflict_job.id, "stage": merge_conflict_job.stage}
+        self.storage.record_processed_event(event_key)
         return {"status": "merged", "pr_number": pr_number}
+
+    def _handle_review_round_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
+        event_key = self._agent_event_key(signature, default_pr=event.number if event.is_pull_request else None)
+        if not self.storage.record_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_agent_event"}
+        review_round = int(signature["round"])
+        pr_number = int(signature["pr"])
+        issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
+        if issue_number is None:
+            return {"status": "ignored", "reason": "untracked_pr"}
+        source_job = self.storage.get_job(signature.get("job", ""))
+        repo = self.storage.get_repo(event.repo_full_name)
+        if repo is None:
+            return {"status": "ignored", "reason": "missing_repo"}
+        if not self._is_pr_open(event.repo_full_name, pr_number):
+            return {"status": "ignored", "reason": "pr_not_open"}
+        pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
+        if bool(source_job and source_job.metadata.get("external_contribution")):
+            return self._handle_external_review_round_event(
+                repo,
+                event,
+                source_job=source_job,
+                pr_metadata=pr_metadata,
+                issue_number=issue_number,
+                pr_number=pr_number,
+                review_round=review_round,
+            )
+        if issue_number is None:
+            return {"status": "ignored", "reason": "untracked_pr"}
+        if not self._is_pr_open(event.repo_full_name, pr_number):
+            return {"status": "ignored", "reason": "pr_not_open"}
+        next_job = self._enqueue_job(
+            repo,
+            stage="implementation",
+            issue_number=issue_number,
+            pr_number=pr_number,
+            review_round=review_round,
+            metadata={
+                **pr_metadata,
+                "title": (pr_metadata.get("title") or event.title or ""),
+                "review_comment_body": event.body or "",
+                "triggering_review_round": review_round,
+            },
+        )
+        return {"status": "queued", "job_id": next_job.id, "stage": next_job.stage}
+
+    def _handle_external_review_round_event(
+        self,
+        repo: RepoConfig,
+        event: NormalizedEvent,
+        *,
+        source_job: JobRecord,
+        pr_metadata: dict[str, str],
+        issue_number: int | None,
+        pr_number: int,
+        review_round: int,
+    ) -> dict[str, Any]:
+        if self._is_approve_comment(event.body):
+            verdict_job = self._enqueue_job(
+                repo,
+                stage="final_verdict",
+                issue_number=issue_number,
+                pr_number=pr_number,
+                review_round=review_round,
+                metadata={
+                    **pr_metadata,
+                    "title": (pr_metadata.get("title") or event.title or ""),
+                    "external_contribution": True,
+                },
+            )
+            return {"status": "queued", "job_id": verdict_job.id, "stage": verdict_job.stage}
+
+        completed_reviews = self._completed_external_review_count(event.repo_full_name, pr_number)
+        if source_job.status != "completed":
+            completed_reviews += 1
+        if completed_reviews >= self.config.external_review_limit and not self._has_human_escalation(
+            event.repo_full_name, pr_number
+        ):
+            escalation_job = self._enqueue_external_human_escalation(
+                repo,
+                issue_number=issue_number,
+                pr_number=pr_number,
+                metadata={
+                    **pr_metadata,
+                    "title": (pr_metadata.get("title") or event.title or ""),
+                    "external_contribution": True,
+                },
+            )
+            return {"status": "queued", "job_id": escalation_job.id, "stage": escalation_job.stage}
+        return {"status": "updated", "stage": "review_round"}
 
     def _enqueue_job(
         self,
@@ -278,6 +373,11 @@ class DaniService:
         return job
 
     def _run_job(self, job: JobRecord) -> None:
+        stored_job = self.storage.get_job(job.id)
+        if stored_job is not None and stored_job.status == "superseded":
+            job.status = "superseded"
+            return
+
         repo = self.storage.get_repo(job.repo_full_name)
         if repo is None:
             self.storage.update_job(job.id, status="failed", metadata={**job.metadata, "error": "missing repo"})
@@ -393,16 +493,18 @@ class DaniService:
         attempt: int,
         retry_history: list[dict[str, str]],
     ) -> None:
-        self.storage.update_job(
-            job.id,
-            status="failed",
-            metadata={
-                **job.metadata,
-                "error": str(exc),
-                "retry_attempts": attempt - 1,
-                "retry_history": retry_history,
-            },
-        )
+        metadata = {
+            **job.metadata,
+            "error": str(exc),
+            "retry_attempts": attempt - 1,
+            "retry_history": retry_history,
+        }
+        if self._is_rollout_missing_error(exc):
+            metadata["error"] = "rollout_missing"
+            metadata["error_detail"] = str(exc)
+            with contextlib.suppress(Exception):
+                self._post_session_lost_warning(job)
+        self.storage.update_job(job.id, status="failed", metadata=metadata)
 
     def _run_dev_sync_job(self, repo: RepoConfig, job: JobRecord) -> None:
         session = None
@@ -491,6 +593,9 @@ class DaniService:
         if job.stage == "review_round":
             return self._build_review_round_prompt(repo, job, issue_number, pr_number, pr_title, pr_body)
 
+        if job.stage == "human_escalation":
+            return self._build_human_escalation_prompt(repo, job, issue_number, pr_number, pr_title, pr_body)
+
         if job.stage == "merge_conflict_resolution":
             return self._build_merge_conflict_resolution_prompt(repo, job, issue_number, pr_number, pr_title, pr_body)
 
@@ -508,6 +613,9 @@ class DaniService:
             return
         if job.stage == "review_round":
             self._verify_review_round_side_effect(repo, job)
+            return
+        if job.stage == "human_escalation":
+            self._verify_human_escalation_side_effect(repo, job)
             return
         if job.stage == "merge_conflict_resolution":
             self._verify_merge_conflict_resolution_side_effect(repo, job)
@@ -531,6 +639,7 @@ class DaniService:
                 "issue_number": issue_number,
                 "issue_title": issue_title,
                 "issue_body": issue_body,
+                "discussion": self._render_issue_discussion(repo.full_name, issue_number),
                 "signature": build_signature(stage="issue_request", job=job.id, issue=issue_number),
             },
         )
@@ -641,6 +750,7 @@ class DaniService:
         pr_discussion = self._render_pr_discussion(repo.full_name, pr_number)
         if pr_discussion:
             discussion_parts.append(pr_discussion)
+        is_external_review = bool(job.metadata.get("external_contribution"))
         return render_prompt(
             "review_round",
             {
@@ -650,6 +760,13 @@ class DaniService:
                 "pr_body": pr_body,
                 "discussion": "\n\n".join(discussion_parts),
                 "round_number": job.review_round or 1,
+                "round_total": self.config.external_review_limit if is_external_review else self.config.review_rounds,
+                "review_mode_note": (
+                    "This is an external contribution PR. The contributor owns any follow-up implementation. "
+                    "If the PR is ready to merge, include /approve in your review comment so dani can run the final verdict pass."
+                    if is_external_review
+                    else ""
+                ),
                 "signature": build_signature(**signature_fields),
             },
         )
@@ -701,6 +818,11 @@ class DaniService:
                 "pr_title": pr_title,
                 "pr_body": pr_body,
                 "discussion": "\n\n".join(discussion_parts),
+                "review_cycle": (
+                    f"Review pass: {job.review_round} / {self.config.external_review_limit}"
+                    if job.review_round and job.metadata.get("external_contribution")
+                    else ""
+                ),
                 "approve_signature": build_signature(
                     stage="final_verdict", job=job.id, pr=pr_number, verdict="APPROVE"
                 ),
@@ -708,13 +830,42 @@ class DaniService:
             },
         )
 
+    def _build_human_escalation_prompt(
+        self,
+        repo: RepoConfig,
+        job: JobRecord,
+        issue_number: int,
+        pr_number: int,
+        pr_title: str,
+        pr_body: str,
+    ) -> str:
+        discussion_parts = []
+        if issue_number:
+            discussion_parts.append(f"Related issue: #{issue_number}")
+        pr_discussion = self._render_pr_discussion(repo.full_name, pr_number)
+        if pr_discussion:
+            discussion_parts.append(pr_discussion)
+        return render_prompt(
+            "human_escalation",
+            {
+                "repo": repo.full_name,
+                "pr_number": pr_number,
+                "pr_title": pr_title,
+                "pr_body": pr_body,
+                "discussion": "\n\n".join(discussion_parts),
+                "review_limit": self.config.external_review_limit,
+                "signature": build_signature(stage="human_escalation", job=job.id, pr=pr_number),
+            },
+        )
+
     def _verify_issue_request_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
-        if self.github.latest_signature_comment(repo.full_name, int(job.issue_number or 0), kind="issue") is None:
+        signature = build_signature(stage="issue_request", job=job.id, issue=int(job.issue_number or 0))
+        if not self._has_exact_issue_signature(repo.full_name, int(job.issue_number or 0), signature):
             raise RuntimeError("issue-request-comment-missing")
 
     def _verify_issue_followup_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
-        latest_comment = self.github.latest_signature_comment(repo.full_name, int(job.issue_number or 0), kind="issue")
-        if latest_comment is None or latest_comment[1].get("stage") != "issue_followup":
+        signature = build_signature(stage="issue_followup", job=job.id, issue=int(job.issue_number or 0))
+        if not self._has_exact_issue_signature(repo.full_name, int(job.issue_number or 0), signature):
             raise RuntimeError("issue-followup-comment-missing")
 
     def _verify_implementation_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
@@ -771,9 +922,21 @@ class DaniService:
         ):
             raise RuntimeError("final-verdict-comment-missing")
 
+    def _verify_human_escalation_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
+        signature = build_signature(stage="human_escalation", job=job.id, pr=int(job.pr_number or 0))
+        if not self._has_exact_pr_signature(repo.full_name, int(job.pr_number or 0), signature):
+            raise RuntimeError("human-escalation-comment-missing")
+
     def _has_exact_pr_signature(self, repo_full_name: str, pr_number: int, signature: str) -> bool:
         return bool(
             self.github.find_comments_by_signature(repo_full_name, pr_number, kind="pr", signature_fragment=signature)
+        )
+
+    def _has_exact_issue_signature(self, repo_full_name: str, issue_number: int, signature: str) -> bool:
+        return bool(
+            self.github.find_comments_by_signature(
+                repo_full_name, issue_number, kind="issue", signature_fragment=signature
+            )
         )
 
     def _is_approve_comment(self, body: str | None) -> bool:
@@ -875,17 +1038,82 @@ class DaniService:
                 self.storage.update_job(signature["job"], status="completed", pr_number=event.number)
         if issue_number is None:
             issue_number = self._extract_issue_number(event.body)
+        is_agent_managed_pr = bool(signature and signature.get("stage") == "implementation")
+        if is_agent_managed_pr:
+            if event.action != "opened":
+                return {"status": "ignored", "reason": "agent_managed_pr_followup"}
+            job = self._enqueue_job(
+                repo,
+                stage="review_round",
+                issue_number=issue_number,
+                pr_number=event.number,
+                review_round=1,
+                metadata={"title": event.title or "", "body": event.body or ""},
+            )
+            return {"status": "queued", "job_id": job.id, "stage": job.stage}
+
         if issue_number is None:
             return {"status": "ignored", "reason": "untracked_pr"}
+        return self._queue_external_pull_request_review(
+            repo,
+            event,
+            issue_number=issue_number,
+        )
+
+    def _queue_external_pull_request_review(
+        self,
+        repo: RepoConfig,
+        event: NormalizedEvent,
+        *,
+        issue_number: int,
+    ) -> dict[str, Any]:
+        event_key = self._external_pull_request_event_key(event)
+        if not self.storage.record_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_external_pr_event"}
+
+        if self._has_human_escalation(event.repo_full_name, event.number):
+            return {"status": "ignored", "reason": "human_review_required"}
+
+        completed_reviews = self._completed_external_review_count(event.repo_full_name, event.number)
+        consumed_review_rounds = self._consumed_external_review_rounds(event.repo_full_name, event.number)
+        if completed_reviews >= self.config.external_review_limit:
+            escalation_job = self._enqueue_external_human_escalation(
+                repo,
+                issue_number=issue_number,
+                pr_number=event.number,
+                metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
+            )
+            return {"status": "queued", "job_id": escalation_job.id, "stage": escalation_job.stage}
+
+        if len(consumed_review_rounds) >= self.config.external_review_limit:
+            return {"status": "ignored", "reason": "external_review_limit_pending"}
+
+        next_review_round = max(consumed_review_rounds, default=0) + 1
         job = self._enqueue_job(
             repo,
             stage="review_round",
             issue_number=issue_number,
             pr_number=event.number,
-            review_round=1,
-            metadata={"title": event.title or "", "body": event.body or ""},
+            review_round=next_review_round,
+            metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
         )
         return {"status": "queued", "job_id": job.id, "stage": job.stage}
+
+    def _enqueue_external_human_escalation(
+        self,
+        repo: RepoConfig,
+        *,
+        issue_number: int | None,
+        pr_number: int,
+        metadata: dict[str, Any],
+    ) -> JobRecord:
+        return self._enqueue_job(
+            repo,
+            stage="human_escalation",
+            issue_number=issue_number,
+            pr_number=pr_number,
+            metadata=metadata,
+        )
 
     def _latest_resumable_session(
         self,
@@ -913,12 +1141,62 @@ class DaniService:
                 fields.append((key, value))
         return ";".join(f"{key}={value}" for key, value in fields)
 
+    def _external_pull_request_event_key(self, event: NormalizedEvent) -> str:
+        if event.delivery_id:
+            return f"external_pr_event;delivery={event.delivery_id}"
+
+        fields = [
+            ("repo", event.repo_full_name),
+            ("kind", event.kind),
+            ("pr", str(event.number)),
+            ("action", event.action),
+        ]
+        if event.commit_sha:
+            fields.append(("head_sha", event.commit_sha))
+        elif event.head_branch:
+            fields.append(("head_branch", event.head_branch))
+        requested_reviewer = event.payload.get("requested_reviewer") or {}
+        reviewer_login = requested_reviewer.get("login")
+        if reviewer_login:
+            fields.append(("reviewer", str(reviewer_login)))
+        requested_team = event.payload.get("requested_team") or {}
+        team_slug = requested_team.get("slug") or requested_team.get("name")
+        if team_slug:
+            fields.append(("team", str(team_slug)))
+        updated_at = (event.payload.get("pull_request") or {}).get("updated_at")
+        if updated_at:
+            fields.append(("updated_at", str(updated_at)))
+        return ";".join(f"{key}={value}" for key, value in fields)
+
     def _latest_review_round(self, repo_full_name: str, pr_number: int) -> int:
         rounds = [
             int(job.review_round or 0)
             for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
         ]
         return max(rounds, default=0)
+
+    def _completed_external_review_count(self, repo_full_name: str, pr_number: int) -> int:
+        return sum(
+            1
+            for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
+            if job.metadata.get("external_contribution") and job.status == "completed"
+        )
+
+    def _consumed_external_review_rounds(self, repo_full_name: str, pr_number: int) -> set[int]:
+        return {
+            int(job.review_round)
+            for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
+            if (
+                job.metadata.get("external_contribution")
+                and job.review_round is not None
+                and job.status in {"queued", "launched", "completed"}
+            )
+        }
+
+    def _has_human_escalation(self, repo_full_name: str, pr_number: int) -> bool:
+        return bool(
+            self.storage.find_jobs(repo_full_name=repo_full_name, stage="human_escalation", pr_number=pr_number)
+        )
 
     def _issue_number_for_signature_event(
         self,
@@ -973,3 +1251,44 @@ class DaniService:
             author = comment.get("user", {}).get("login") or comment.get("author", {}).get("login") or "unknown"
             rendered.append(f"[{author}]\n{body}")
         return "\n\n".join(rendered)
+
+    def _render_issue_discussion(self, repo_full_name: str, issue_number: int, *, limit: int = 8) -> str:
+        comments = self.github.issue_comments(repo_full_name, issue_number)
+        rendered: list[str] = []
+        for comment in comments[-limit:]:
+            body = str(comment.get("body") or "").strip()
+            if not body:
+                continue
+            author = comment.get("user", {}).get("login") or comment.get("author", {}).get("login") or "unknown"
+            rendered.append(f"[{author}]\n{body}")
+        return "\n\n".join(rendered)
+
+    def _is_rollout_missing_error(self, exc: Exception) -> bool:
+        if isinstance(exc, RolloutMissingError):
+            return True
+        error_text = str(exc)
+        return any(pattern.search(error_text) for pattern in ROLLOUT_MISSING_PATTERNS)
+
+    def _post_session_lost_warning(self, job: JobRecord) -> None:
+        if job.stage != "issue_followup" or job.issue_number is None:
+            return
+        event_key = f"repo={job.repo_full_name};stage=session_lost;issue={job.issue_number}"
+        signature = build_signature(stage="session_lost", issue=job.issue_number)
+        if self.github.find_comments_by_signature(
+            job.repo_full_name,
+            job.issue_number,
+            kind="issue",
+            signature_fragment=signature,
+        ):
+            if not self.storage.has_processed_event(event_key):
+                self.storage.record_processed_event(event_key)
+            return
+        if self.storage.has_processed_event(event_key):
+            return
+        body = (
+            "⚠️ dani 세션 기록이 유실되어 이전 대화를 이어갈 수 없습니다. "
+            f"`dani restart-issue {job.repo_full_name} {job.issue_number}` 로 새 세션을 시작해 주세요.\n\n"
+            f"{signature}"
+        )
+        self.github.create_issue_comment(job.repo_full_name, job.issue_number, body)
+        self.storage.record_processed_event(event_key)

--- a/dani/service.py
+++ b/dani/service.py
@@ -7,11 +7,16 @@ import time
 from pathlib import Path
 from typing import Any
 
-from dani.errors import ROLLOUT_MISSING_PATTERNS, RolloutMissingError, TransientCapacityError
+from dani.agent_runner import AgentRunner, build_agent_runner
+from dani.errors import (
+    OPENCODE_SESSION_MISSING_PATTERNS,
+    ROLLOUT_MISSING_PATTERNS,
+    RolloutMissingError,
+    TransientCapacityError,
+)
 from dani.git_sync import DevSyncConflictError, GitDevSyncer
 from dani.github import GitHubCLI, MergeConflictError
 from dani.models import DaniConfig, JobRecord, NormalizedEvent, RepoConfig, SessionRecord, utc_now
-from dani.omx_runner import OmxRunner
 from dani.prompts import render_prompt
 from dani.queue import RepoQueueManager
 from dani.signatures import build_signature, is_opt_out_comment, parse_signature
@@ -30,13 +35,16 @@ class DaniService:
         config: DaniConfig,
         storage: JsonStorage | None = None,
         github: Any = None,
-        omx_runner: Any = None,
+        omx_runner: AgentRunner | None = None,
         dev_syncer: Any = None,
     ) -> None:
         self.config = config
         self.storage = storage or JsonStorage(config)
         self.github = github or GitHubCLI()
-        self.omx_runner = omx_runner or OmxRunner(config.run_dir)
+        self.omx_runner: AgentRunner = omx_runner or build_agent_runner(
+            config.agent_runtime,
+            config.run_dir,
+        )
         self.dev_syncer = dev_syncer or GitDevSyncer(config.run_dir)
         self.queue_manager = RepoQueueManager(self._run_job)
 
@@ -424,6 +432,10 @@ class DaniService:
         except Exception:
             self._finalize_session(session, status="failed", termination_reason="failed")
             raise
+        if session.omx_session_id is None:
+            post_wait_session_id = self.omx_runner.get_session_id(session.runtime_handle)
+            if post_wait_session_id:
+                self.storage.update_session(session.id, omx_session_id=post_wait_session_id)
         self._finalize_session(session, status="completed", termination_reason="completed")
 
     def _handle_transient_failure(
@@ -527,6 +539,7 @@ class DaniService:
                     "temp_branch": conflict_context.temp_branch,
                     "commit_message": self.dev_syncer.build_commit_message(repo, job),
                 },
+                runtime=self.config.agent_runtime,
             )
             session = self.omx_runner.launch(conflict_context.worktree_path, job, prompt)
             self.storage.create_session(session)
@@ -546,7 +559,7 @@ class DaniService:
             self.storage.update_job(
                 job.id,
                 status="completed",
-                metadata={**job.metadata, "sync_status": "resolved_with_omx"},
+                metadata={**job.metadata, "sync_status": "resolved_with_agent"},
             )
         except Exception as exc:
             if session is not None:
@@ -642,6 +655,7 @@ class DaniService:
                 "discussion": self._render_issue_discussion(repo.full_name, issue_number),
                 "signature": build_signature(stage="issue_request", job=job.id, issue=issue_number),
             },
+            runtime=self.config.agent_runtime,
         )
 
     def _build_implementation_prompt(
@@ -704,6 +718,7 @@ class DaniService:
                 "signature": signature,
                 "signature_instructions": signature_instructions,
             },
+            runtime=self.config.agent_runtime,
         )
 
     def _build_issue_followup_prompt(
@@ -725,6 +740,7 @@ class DaniService:
                 "comment_body": job.metadata.get("comment_body", ""),
                 "signature": build_signature(stage="issue_followup", job=job.id, issue=issue_number),
             },
+            runtime=self.config.agent_runtime,
         )
 
     def _build_review_round_prompt(
@@ -769,6 +785,7 @@ class DaniService:
                 ),
                 "signature": build_signature(**signature_fields),
             },
+            runtime=self.config.agent_runtime,
         )
 
     def _build_merge_conflict_resolution_prompt(
@@ -794,6 +811,7 @@ class DaniService:
                 "conflict_reason": job.metadata.get("conflict_reason", "Merge conflict detected while merging."),
                 "signature": build_signature(stage="merge_conflict_resolution", job=job.id, pr=pr_number),
             },
+            runtime=self.config.agent_runtime,
         )
 
     def _build_final_verdict_prompt(
@@ -828,6 +846,7 @@ class DaniService:
                 ),
                 "reject_signature": build_signature(stage="final_verdict", job=job.id, pr=pr_number, verdict="REJECT"),
             },
+            runtime=self.config.agent_runtime,
         )
 
     def _build_human_escalation_prompt(
@@ -856,6 +875,7 @@ class DaniService:
                 "review_limit": self.config.external_review_limit,
                 "signature": build_signature(stage="human_escalation", job=job.id, pr=pr_number),
             },
+            runtime=self.config.agent_runtime,
         )
 
     def _verify_issue_request_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
@@ -1267,7 +1287,9 @@ class DaniService:
         if isinstance(exc, RolloutMissingError):
             return True
         error_text = str(exc)
-        return any(pattern.search(error_text) for pattern in ROLLOUT_MISSING_PATTERNS)
+        return any(
+            pattern.search(error_text) for pattern in (*ROLLOUT_MISSING_PATTERNS, *OPENCODE_SESSION_MISSING_PATTERNS)
+        )
 
     def _post_session_lost_warning(self, job: JobRecord) -> None:
         if job.stage != "issue_followup" or job.issue_number is None:

--- a/dani/signatures.py
+++ b/dani/signatures.py
@@ -3,6 +3,18 @@ from __future__ import annotations
 import re
 
 SIGNATURE_PATTERN = re.compile(r"<!--\s*(?:dani|DANI):\s*(?P<body>[^>]+)\s*-->")
+IGNORE_COMMAND_PATTERN = re.compile(r"(?mi)(?:^|\s)/dani\s+ignore(?:\s|$)")
+
+
+def _parse_signature_body(raw_body: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    parts = raw_body.split(";") if ";" in raw_body else raw_body.split()
+    for item in parts:
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        fields[key.strip()] = value.strip()
+    return fields
 
 
 def build_signature(**fields: object) -> str:
@@ -21,16 +33,30 @@ def parse_signature(text: str | None) -> dict[str, str] | None:
     match = SIGNATURE_PATTERN.search(text)
     if not match:
         return None
-    fields: dict[str, str] = {}
-    raw_body = match.group("body")
-    parts = raw_body.split(";") if ";" in raw_body else raw_body.split()
-    for item in parts:
-        if "=" not in item:
-            continue
-        key, value = item.split("=", 1)
-        fields[key.strip()] = value.strip()
+    fields = _parse_signature_body(match.group("body"))
     return fields or None
 
 
+def parse_agent_signature(text: str | None) -> dict[str, str] | None:
+    fields = parse_signature(text)
+    if fields is None or fields.get("stage", "").lower() == "ignore":
+        return None
+    return fields
+
+
 def has_agent_signature(text: str | None) -> bool:
-    return parse_signature(text) is not None
+    return parse_agent_signature(text) is not None
+
+
+def has_ignore_signature(text: str | None) -> bool:
+    if not text:
+        return False
+    for match in SIGNATURE_PATTERN.finditer(text):
+        fields = _parse_signature_body(match.group("body"))
+        if fields.get("stage", "").lower() == "ignore":
+            return True
+    return False
+
+
+def is_opt_out_comment(text: str | None) -> bool:
+    return has_ignore_signature(text) or bool(text and IGNORE_COMMAND_PATTERN.search(text))

--- a/dani/webhook.py
+++ b/dani/webhook.py
@@ -15,7 +15,9 @@ def verify_github_signature(secret: str, body: bytes, signature_header: str | No
     return hmac.compare_digest(expected, signature_header)
 
 
-def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent | None:
+def normalize_event(
+    event_name: str, payload: dict[str, Any], *, delivery_id: str | None = None
+) -> NormalizedEvent | None:
     repo = payload.get("repository") or {}
     repo_full_name = repo.get("full_name")
     if not repo_full_name:
@@ -33,6 +35,7 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             payload=payload,
             body=issue.get("body"),
             title=issue.get("title"),
+            delivery_id=delivery_id,
         )
 
     if event_name == "issue_comment" and action == "created":
@@ -47,6 +50,7 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             payload=payload,
             body=payload["comment"].get("body"),
             title=issue.get("title"),
+            delivery_id=delivery_id,
             is_pull_request=is_pr,
         )
 
@@ -62,11 +66,18 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             number=0,
             actor_login=payload["sender"]["login"],
             payload=payload,
+            delivery_id=delivery_id,
             ref=ref,
             commit_sha=commit_sha,
         )
 
-    if event_name == "pull_request" and action == "opened":
+    if event_name == "pull_request" and action in {
+        "opened",
+        "synchronize",
+        "reopened",
+        "ready_for_review",
+        "review_requested",
+    }:
         pull_request = payload["pull_request"]
         return NormalizedEvent(
             kind="pull_request_opened",
@@ -79,6 +90,8 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             title=pull_request.get("title"),
             base_branch=pull_request["base"]["ref"],
             head_branch=pull_request["head"]["ref"],
+            delivery_id=delivery_id,
+            commit_sha=pull_request["head"].get("sha"),
             is_pull_request=True,
         )
 
@@ -95,6 +108,8 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             title=pull_request.get("title"),
             base_branch=pull_request["base"]["ref"],
             head_branch=pull_request["head"]["ref"],
+            delivery_id=delivery_id,
+            commit_sha=pull_request["head"].get("sha"),
             is_pull_request=True,
         )
 

--- a/docs/issue-33-verification.md
+++ b/docs/issue-33-verification.md
@@ -1,0 +1,63 @@
+# Issue 33 verification log
+
+This document records the development-time evidence that Issue 33 was resolved
+according to the user's process constraints (no global install, no pm2
+redeploy) and that the new OMO (Oh-My-OpenAgents) backend actually works
+end-to-end against a real `opencode` subprocess.
+
+## Process constraints
+
+| Constraint | Evidence |
+|---|---|
+| No `uv tool install` during development | All commands used `uv run ...` against the local workspace only. No `uv tool install` was invoked. `git grep "uv tool install"` returns no matches in project-owned files; matches only come from vendored `.venv/**/METADATA` files unrelated to this work. |
+| No pm2 redeploy | No changes to any pm2 config (none exists in repo) and no `pm2 start` / `pm2 reload` was invoked during development. `git grep pm2` returns no matches. |
+| Local version only | `dani` is a uv-managed editable install in `.venv`. Verified via `uv run python -c "import dani, sys; print(dani.__file__)"` pointing inside the repo's working tree, not `~/.local/share/uv/tools/...`. |
+
+## Live OMO subprocess runs (requirement 4)
+
+Three reproducible smoke scripts under `scripts/dev/omo_smoke/` spawn real
+`opencode run` subprocesses and inspect the logs. They are checked into the
+repo so future reviewers can re-run them. An equivalent pytest file at
+`tests/test_omo_live.py` is opt-in (`DANI_OMO_LIVE=1 uv run pytest tests/test_omo_live.py`)
+and is skipped by default because it consumes model tokens.
+
+| Script | Proves | Sample captured session id |
+|---|---|---|
+| `smoke_launch.py` | `OmoRunner.launch` spawns opencode, gets back `{"type":"text","text":"dani omo smoke ok"}`, sessionID captured. | `ses_25e9164e7ffeleSyF3UGalrfuo` |
+| `smoke_resume.py` | `OmoRunner.resume` runs `opencode run --session <id>` and opencode **remembers** a keyword planted in phase 1 (`PURPLE_HIPPO_9182`). | `ses_25e99ee42ffeZiayJpmLNjDbBQ` |
+| `smoke_ultrawork.py` | `OmoRunner` unconditionally prefixes `prompt.txt` with `"ultrawork\n\n"` and real opencode accepts it. | `ses_25e919f1cffe7LPKpAR04SCyNQ` |
+
+All three scripts passed their assertions when executed locally with
+`uv run python scripts/dev/omo_smoke/<name>.py` against `opencode` 1.4.11 on
+macOS (Darwin), with opencode data dir at `~/.local/share/opencode/opencode.db`.
+Session IDs above are pulled from actual run logs and are specific to that
+environment — they will differ on every execution.
+
+## Unit / integration test coverage
+
+- 154 tests pass (`uv run pytest -q`), up from 125 before this work.
+- New tests in `tests/test_omo_runner.py` cover:
+  - Factory selection (both `omx` and `omo`; ultrawork flag forwarded only to omo; ultrawork+omx rejected with `ValueError`).
+  - `opencode run` and `opencode run --session <id>` script construction.
+  - JSONL `sessionID` parsing from stdout, including partial-line / malformed-line tolerance.
+  - `get_session_id(runtime_handle)` post-wait recovery.
+  - Prompt-file contents (raw and ultrawork-decorated, idempotency).
+  - Error handling: `Session not found` (→ `RolloutMissingError`) and `model is at capacity` (→ `TransientCapacityError`).
+  - Full `DaniService` integration paths:
+    - `issue_request` launched through OMO → session persisted → job completed.
+    - `issue_opened` → persisted sessionID → `issue_comment` → OmoRunner.resume with exact `--session <id>` flag.
+    - Follow-up resume failing with `Session not found` stderr → job marked failed with `error=rollout_missing` → `stage=session_lost` warning comment posted.
+    - Late sessionID emission (opencode emits id AFTER launch's pre-wait poll times out): service re-queries `get_session_id` post-wait and updates storage.
+- New tests in `tests/test_omo_live.py` cover the same surface with **real**
+  opencode subprocess execution, opt-in via `DANI_OMO_LIVE=1`.
+
+## Backward compatibility
+
+- No field renames in persisted records (`SessionRecord.omx_session_id`,
+  `JobRecord.metadata["omx_session_id"]`, `storage.find_latest_session(require_omx_session_id=...)`)
+  — existing `~/.dani/sessions.json` and `jobs.json` stay readable.
+- Default runtime is unchanged (`agent_runtime="omx"`); OMO is strictly opt-in
+  via `DANI_AGENT_RUNTIME=omo`.
+- All 125 pre-existing tests still pass without modification.
+- `FakeOmxRunner` test double unchanged; satisfies the new `AgentRunner`
+  protocol structurally.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dani"
 version = "0.0.1"
-description = "Simple loop for managing Github Repository; Backend is Oh-My-Codex"
+description = "Simple loop for managing Github Repository; Backend is Oh-My-Codex or Oh-My-OpenAgents"
 authors = [{ name = "NomaDamas", email = "vkehfdl1@gmail.com" }]
 readme = "README.md"
 keywords = ["python"]
@@ -88,6 +88,8 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101", "S105", "S106"]
 "dani/omx_runner.py" = ["S607"]
+"dani/omo_runner.py" = ["S607"]
+"scripts/dev/**" = ["S101", "S108", "S603", "S607", "T201"]
 
 [tool.ruff.format]
 preview = true

--- a/scripts/dev/omo_smoke/README.md
+++ b/scripts/dev/omo_smoke/README.md
@@ -1,0 +1,42 @@
+# OMO (Oh-My-OpenAgents) live smoke scripts
+
+These three scripts exercise the `OmoRunner` against a **real** `opencode`
+binary. They are committed here so anyone verifying Issue 33 (`omo` backend
+support) can reproduce the same end-to-end evidence locally.
+
+Unlike the unit/integration tests under `tests/test_omo_runner.py`, these
+scripts do **not** monkeypatch `subprocess.Popen`. They spawn real `opencode run`
+processes, consume real model tokens, and assert on real CLI output.
+
+## Prerequisites
+
+- `opencode` binary on `PATH` (install via `curl -fsSL https://opencode.ai/install | bash`,
+  `npm install -g oh-my-opencode`, `brew install opencode`, etc.).
+- An opencode model provider configured (`opencode auth login` once).
+- `uv` available for running the scripts inside the project's virtualenv.
+
+## Running
+
+Each script creates its own throwaway workspace under `/tmp/dani-omo-smoke/`
+(or the path the script defines). No global state, no writes to your repos.
+
+```sh
+# from the dani repo root, using the local (uninstalled) version:
+uv run python scripts/dev/omo_smoke/smoke_launch.py
+uv run python scripts/dev/omo_smoke/smoke_resume.py
+uv run python scripts/dev/omo_smoke/smoke_ultrawork.py
+```
+
+## What each script proves
+
+| Script | Proves |
+|--------|--------|
+| `smoke_launch.py` | `OmoRunner.launch` actually spawns `opencode run --format json --dangerously-skip-permissions ...`, the model replies, and `_capture_session_id` extracts a valid `ses_...` id from the JSONL stream. |
+| `smoke_resume.py` | `OmoRunner.resume` runs `opencode run --session <id> ...` and opencode **continues** the prior conversation (recalls a keyword planted in phase 1). |
+| `smoke_ultrawork.py` | `OmoRunner` always prepends `"ultrawork\n\n"` to `prompt.txt` and opencode accepts it. |
+
+## Why these are not part of `pytest` by default
+
+They take 10–60 seconds each and cost model tokens. The equivalent pytest
+integration file is `tests/test_omo_live.py`, which is skipped unless you set
+`DANI_OMO_LIVE=1` and have `opencode` on `PATH`.

--- a/scripts/dev/omo_smoke/smoke_launch.py
+++ b/scripts/dev/omo_smoke/smoke_launch.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+from dani.agent_runner import build_agent_runner
+from dani.models import JobRecord
+
+REPO_PATH = Path("/tmp/dani-omo-smoke/repo")
+RUN_DIR = Path("/tmp/dani-omo-smoke/runs-launch")
+
+
+def ensure_repo() -> None:
+    import subprocess
+
+    REPO_PATH.mkdir(parents=True, exist_ok=True)
+    if not (REPO_PATH / ".git").exists():
+        subprocess.run(["git", "init", "-q"], cwd=REPO_PATH, check=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+            cwd=REPO_PATH,
+            check=True,
+        )
+
+
+def main() -> int:
+    ensure_repo()
+    runner = build_agent_runner("omo", RUN_DIR)
+    print(f"[smoke-launch] runner class: {type(runner).__name__}")
+
+    job = JobRecord(repo_full_name="acme/smoke", stage="issue_request", issue_number=42)
+    prompt = "Reply with exactly the words 'dani omo smoke ok' and stop. Do not use tools. Do not call any agents."
+
+    t0 = time.monotonic()
+    session = runner.launch(REPO_PATH, job, prompt)
+    print(f"[smoke-launch] launch() took {time.monotonic() - t0:.2f}s")
+    print(f"[smoke-launch] captured session id: {session.omx_session_id!r}")
+    script_text = Path(session.script_path).read_text(encoding="utf-8")
+    assert "opencode run --format json --dangerously-skip-permissions" in script_text
+    assert f"cd {REPO_PATH}" in script_text
+
+    runner.wait(session.runtime_handle, timeout_seconds=180)
+    runner.close_session(session.runtime_handle)
+
+    assert session.stdout_path is not None
+    stdout_text = Path(session.stdout_path).read_text(encoding="utf-8", errors="replace")
+    captured = session.omx_session_id or runner.get_session_id(session.runtime_handle)
+    assert captured is not None and captured.startswith("ses_"), f"expected a ses_... session id, got {captured!r}"
+    print(f"[smoke-launch] stdout head: {stdout_text[:300]}")
+    print("[smoke-launch] ==> PASS: opencode ran; session id captured; script matched expectations")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/omo_smoke/smoke_resume.py
+++ b/scripts/dev/omo_smoke/smoke_resume.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+from dani.agent_runner import build_agent_runner
+from dani.models import JobRecord
+
+REPO_PATH = Path("/tmp/dani-omo-smoke/repo")
+RUN_DIR = Path("/tmp/dani-omo-smoke/runs-resume")
+
+
+def ensure_repo() -> None:
+    import subprocess
+
+    REPO_PATH.mkdir(parents=True, exist_ok=True)
+    if not (REPO_PATH / ".git").exists():
+        subprocess.run(["git", "init", "-q"], cwd=REPO_PATH, check=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+            cwd=REPO_PATH,
+            check=True,
+        )
+
+
+def main() -> int:
+    ensure_repo()
+    runner = build_agent_runner("omo", RUN_DIR)
+
+    job1 = JobRecord(repo_full_name="acme/smoke", stage="issue_request", issue_number=77)
+    launch_prompt = "Remember this exact keyword: PURPLE_HIPPO_9182. Reply only with 'ok' and stop."
+
+    print("[smoke-resume] phase 1: launching opencode session...")
+    t0 = time.monotonic()
+    session1 = runner.launch(REPO_PATH, job1, launch_prompt)
+    runner.wait(session1.runtime_handle, timeout_seconds=180)
+    runner.close_session(session1.runtime_handle)
+    first_sid = session1.omx_session_id or runner.get_session_id(session1.runtime_handle)
+    assert first_sid is not None and first_sid.startswith("ses_")
+    print(f"[smoke-resume] phase 1 session id: {first_sid} ({time.monotonic() - t0:.1f}s)")
+
+    job2 = JobRecord(repo_full_name="acme/smoke", stage="issue_followup", issue_number=77)
+    resume_prompt = (
+        "What was the keyword I told you earlier in this conversation? Reply with only the keyword and nothing else."
+    )
+
+    print("[smoke-resume] phase 2: resuming prior session via --session flag...")
+    t1 = time.monotonic()
+    session2 = runner.resume(REPO_PATH, job2, resume_prompt, first_sid)
+    script = Path(session2.script_path).read_text(encoding="utf-8")
+    assert f"opencode run --session {first_sid} --format json --dangerously-skip-permissions" in script
+    runner.wait(session2.runtime_handle, timeout_seconds=180)
+    runner.close_session(session2.runtime_handle)
+    assert session2.stdout_path is not None
+    stdout_text = Path(session2.stdout_path).read_text(encoding="utf-8", errors="replace")
+    print(f"[smoke-resume] phase 2 wall: {time.monotonic() - t1:.1f}s")
+
+    assert "PURPLE_HIPPO_9182" in stdout_text, (
+        f"resume did NOT continue prior session; stdout tail: {stdout_text[-400:]!r}"
+    )
+    print("[smoke-resume] ==> PASS: opencode resumed; keyword recovered from conversation state")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/omo_smoke/smoke_ultrawork.py
+++ b/scripts/dev/omo_smoke/smoke_ultrawork.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+from dani.agent_runner import build_agent_runner
+from dani.models import JobRecord
+
+REPO_PATH = Path("/tmp/dani-omo-smoke/repo")
+RUN_DIR = Path("/tmp/dani-omo-smoke/runs-ultrawork")
+
+
+def ensure_repo() -> None:
+    import subprocess
+
+    REPO_PATH.mkdir(parents=True, exist_ok=True)
+    if not (REPO_PATH / ".git").exists():
+        subprocess.run(["git", "init", "-q"], cwd=REPO_PATH, check=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+            cwd=REPO_PATH,
+            check=True,
+        )
+
+
+def main() -> int:
+    ensure_repo()
+    runner = build_agent_runner("omo", RUN_DIR)
+    print(f"[smoke-ulw] runner={type(runner).__name__}")
+
+    job = JobRecord(repo_full_name="acme/smoke", stage="issue_request", issue_number=777)
+    prompt = (
+        "Reply with exactly the words 'ulw mode ok' and stop immediately. "
+        "Do NOT enter any loop. Do NOT call any agents."
+    )
+
+    session = runner.launch(REPO_PATH, job, prompt)
+    actual_prompt = Path(session.prompt_path).read_text(encoding="utf-8")
+    assert actual_prompt.startswith("ultrawork\n\n"), f"expected ultrawork prefix, got: {actual_prompt[:60]!r}"
+    print(f"[smoke-ulw] prompt-file starts with ultrawork prefix: {actual_prompt[:60]!r}")
+
+    t0 = time.monotonic()
+    runner.wait(session.runtime_handle, timeout_seconds=300)
+    runner.close_session(session.runtime_handle)
+
+    assert session.stdout_path is not None and session.stderr_path is not None
+    stdout_text = Path(session.stdout_path).read_text(encoding="utf-8", errors="replace")
+    stderr_text = Path(session.stderr_path).read_text(encoding="utf-8", errors="replace")
+    assert "ses_" in stdout_text, "expected sessionID events in opencode stdout"
+    assert "error" not in stderr_text.lower(), f"opencode emitted error: {stderr_text[:400]}"
+    print(f"[smoke-ulw] wait: {time.monotonic() - t0:.1f}s; stderr bytes: {len(stderr_text)}")
+    print("[smoke-ulw] ==> PASS: opencode accepted ultrawork-prefixed prompt and ran clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/verify_http_runner_live.py
+++ b/scripts/dev/verify_http_runner_live.py
@@ -140,7 +140,7 @@ def test2_session_management() -> dict[str, Any]:
             _emit(test_id, "launch with simple deterministic prompt")
             launch_job = JobRecord(
                 repo_full_name="live/verify",
-                stage="issue_request",
+                stage="implementation",
                 issue_number=2001,
             )
             prompt_a = (
@@ -169,7 +169,7 @@ def test2_session_management() -> dict[str, Any]:
             _emit(test_id, "resume same session with follow-up prompt")
             resume_job = JobRecord(
                 repo_full_name="live/verify",
-                stage="issue_followup",
+                stage="implementation",
                 issue_number=2001,
             )
             prompt_b = (
@@ -221,7 +221,7 @@ def test3_ultrawork_subagents() -> dict[str, Any]:
             _emit(test_id, "launch with ultrawork prompt that demands ONE quick subagent call via task()")
             job = JobRecord(
                 repo_full_name="live/verify",
-                stage="issue_request",
+                stage="implementation",
                 issue_number=3001,
             )
             prompt = (

--- a/scripts/dev/verify_http_runner_live.py
+++ b/scripts/dev/verify_http_runner_live.py
@@ -6,8 +6,6 @@ Run with: uv run python scripts/dev/verify_http_runner_live.py
 from __future__ import annotations
 
 import json
-import os
-import shutil
 import sys
 import tempfile
 import time
@@ -241,17 +239,20 @@ def test3_ultrawork_subagents() -> dict[str, Any]:
             )
             t0 = time.monotonic()
             session = runner.launch(repo_path, job, prompt)
-            _emit(test_id, f"launch returned in {time.monotonic() - t0:.2f}s; parent session_id={session.omx_session_id}")
+            _emit(
+                test_id, f"launch returned in {time.monotonic() - t0:.2f}s; parent session_id={session.omx_session_id}"
+            )
             assert session.omx_session_id and session.omx_session_id.startswith("ses_")
 
             base_url_before = runner._server_manager.get_server_for_repo(repo_path)
             try:
-                req = urllib.request.Request(f"{base_url_before}/path")
+                req = urllib.request.Request(f"{base_url_before}/path")  # noqa: S310
                 with urllib.request.urlopen(req, timeout=5) as response:  # noqa: S310
                     _ = response.read(1)
                 _emit(test_id, "server reachable BEFORE wait (HTTP 200 on /path)")
             except urllib.error.URLError as exc:
-                raise RuntimeError(f"server unreachable before wait: {exc}") from exc
+                msg = f"server unreachable before wait: {exc}"
+                raise RuntimeError(msg) from exc
 
             _emit(test_id, "wait for parent session.idle (timeout=300s)")
             t0 = time.monotonic()
@@ -259,12 +260,13 @@ def test3_ultrawork_subagents() -> dict[str, Any]:
             _emit(test_id, f"wait returned in {time.monotonic() - t0:.2f}s")
 
             try:
-                req = urllib.request.Request(f"{base_url_before}/path")
+                req = urllib.request.Request(f"{base_url_before}/path")  # noqa: S310
                 with urllib.request.urlopen(req, timeout=5) as response:  # noqa: S310
                     _ = response.read(1)
                 _emit(test_id, "server STILL reachable AFTER subagent run (HTTP 200 on /path)")
             except urllib.error.URLError as exc:
-                raise RuntimeError(f"server died during subagent run: {exc}") from exc
+                msg = f"server died during subagent run: {exc}"
+                raise RuntimeError(msg) from exc
 
             events = _read_events(session.stdout_path)
             summary = _summarize_events(events)
@@ -302,7 +304,11 @@ def main() -> int:
     results: dict[str, Any] = {}
     failures: list[str] = []
 
-    for test_id, fn in [("TEST1", test1_server_lifecycle), ("TEST2", test2_session_management), ("TEST3", test3_ultrawork_subagents)]:
+    for test_id, fn in [
+        ("TEST1", test1_server_lifecycle),
+        ("TEST2", test2_session_management),
+        ("TEST3", test3_ultrawork_subagents),
+    ]:
         print(f"\n{'=' * 72}\n{test_id}\n{'=' * 72}", flush=True)
         try:
             t0 = time.monotonic()
@@ -310,7 +316,7 @@ def main() -> int:
             duration = time.monotonic() - t0
             results[test_id] = {"status": "PASS", "duration_seconds": round(duration, 2), "data": result}
             print(f"\n{test_id} PASS in {duration:.1f}s", flush=True)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             duration = time.monotonic() - t0
             results[test_id] = {"status": "FAIL", "duration_seconds": round(duration, 2), "error": repr(exc)}
             failures.append(f"{test_id}: {exc!r}")

--- a/scripts/dev/verify_http_runner_live.py
+++ b/scripts/dev/verify_http_runner_live.py
@@ -1,0 +1,332 @@
+"""Live verification of OmoHttpRunner. Requires CCAPI_API_KEY/MYPROXY_API_KEY.
+
+Run with: uv run python scripts/dev/verify_http_runner_live.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from dani.models import JobRecord  # noqa: E402
+from dani.omo_http_runner import OmoHttpRunner  # noqa: E402
+from dani.opencode_http import OpencodeClient, OpencodeServerManager  # noqa: E402
+
+
+def _stamp(label: str, *, indent: int = 2) -> str:
+    return f"{' ' * indent}[{label}]"
+
+
+def _emit(test_id: str, message: str) -> None:
+    ts = time.strftime("%H:%M:%S")
+    print(f"{ts} {test_id} {message}", flush=True)
+
+
+@contextmanager
+def temp_repo() -> Any:
+    with tempfile.TemporaryDirectory(prefix="dani-verify-repo-") as repo_dir:
+        repo_path = Path(repo_dir)
+        (repo_path / "AGENTS.md").write_text("# verification scratch\n", encoding="utf-8")
+        (repo_path / "hello.txt").write_text("dani verification\n", encoding="utf-8")
+        yield repo_path
+
+
+def test1_server_lifecycle() -> dict[str, Any]:
+    test_id = "TEST1"
+    _emit(test_id, "spawning opencode serve via OpencodeServerManager")
+    with tempfile.TemporaryDirectory(prefix="dani-verify-runs-") as run_dir, temp_repo() as repo_path:
+        manager = OpencodeServerManager(Path(run_dir))
+        base_url = manager.get_server_for_repo(repo_path)
+        _emit(test_id, f"server URL: {base_url}")
+
+        client = OpencodeClient(base_url)
+
+        statuses = client.session_status()
+        _emit(test_id, f"initial /session/status: {statuses!r}")
+        assert isinstance(statuses, dict), "session_status must return a dict"
+
+        info = client.create_session(directory=str(repo_path), title="dani-verify-lifecycle")
+        _emit(test_id, f"created session: {info.id} (directory={info.directory})")
+        assert info.id.startswith("ses_"), "session id must start with ses_"
+        assert info.directory == str(repo_path) or info.directory.endswith(repo_path.name), (
+            f"directory mismatch: got {info.directory}, expected ~ {repo_path}"
+        )
+
+        aborted = client.abort_session(info.id)
+        _emit(test_id, f"abort returned: {aborted}")
+        assert aborted is True
+
+        post_abort_statuses = client.session_status()
+        _emit(test_id, f"post-abort /session/status: {post_abort_statuses!r}")
+
+        process = manager._servers[str(repo_path.resolve())].process
+        assert process is not None and process.poll() is None, "server died during test"
+        _emit(test_id, f"server pid={process.pid} still alive after abort -> shutting down")
+
+        manager.shutdown_all()
+        time.sleep(0.5)
+        assert process.poll() is not None, "server did not exit on shutdown_all"
+        _emit(test_id, f"server exited cleanly with returncode={process.poll()}")
+
+        return {
+            "url": base_url,
+            "session_id": info.id,
+            "exit_code": process.poll(),
+        }
+
+
+def _read_events(event_log_path: str | None) -> list[dict[str, Any]]:
+    if not event_log_path:
+        return []
+    path = Path(event_log_path)
+    if not path.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def _summarize_events(events: list[dict[str, Any]]) -> dict[str, int]:
+    summary: dict[str, int] = {}
+    for event in events:
+        kind = str(event.get("type", "?"))
+        summary[kind] = summary.get(kind, 0) + 1
+    return summary
+
+
+def _parent_idle_seen(events: list[dict[str, Any]], parent_session_id: str) -> bool:
+    return any(
+        e.get("type") == "session.idle" and (e.get("properties") or {}).get("sessionID") == parent_session_id
+        for e in events
+    )
+
+
+def _child_session_created(events: list[dict[str, Any]], parent_session_id: str) -> list[str]:
+    child_ids: list[str] = []
+    for event in events:
+        if event.get("type") != "session.created":
+            continue
+        props = event.get("properties") or {}
+        info = props.get("info") or {}
+        if isinstance(info, dict) and info.get("parentID") == parent_session_id:
+            sid = info.get("id")
+            if isinstance(sid, str):
+                child_ids.append(sid)
+    return child_ids
+
+
+def test2_session_management() -> dict[str, Any]:
+    test_id = "TEST2"
+    with tempfile.TemporaryDirectory(prefix="dani-verify-runs-") as run_dir, temp_repo() as repo_path:
+        runner = OmoHttpRunner(Path(run_dir))
+        try:
+            _emit(test_id, "launch with simple deterministic prompt")
+            launch_job = JobRecord(
+                repo_full_name="live/verify",
+                stage="issue_request",
+                issue_number=2001,
+            )
+            prompt_a = (
+                "Verification ping #1. Reply with EXACTLY the single word 'session-ack-1' "
+                "and immediately stop. Do not use any tools. Do not enter any loop. "
+                "This is a smoke test."
+            )
+            t0 = time.monotonic()
+            session_a = runner.launch(repo_path, launch_job, prompt_a)
+            _emit(test_id, f"launch returned in {time.monotonic() - t0:.2f}s; session_id={session_a.omx_session_id}")
+            assert session_a.omx_session_id and session_a.omx_session_id.startswith("ses_")
+
+            _emit(test_id, "wait for session idle (timeout=180s)")
+            t0 = time.monotonic()
+            runner.wait(session_a.runtime_handle, timeout_seconds=180)
+            _emit(test_id, f"wait returned in {time.monotonic() - t0:.2f}s")
+
+            events_a = _read_events(session_a.stdout_path)
+            summary_a = _summarize_events(events_a)
+            _emit(test_id, f"events seen for session A: {summary_a}")
+            assert _parent_idle_seen(events_a, session_a.omx_session_id), (
+                "parent session.idle event was never recorded in event log"
+            )
+            runner.close_session(session_a.runtime_handle)
+
+            _emit(test_id, "resume same session with follow-up prompt")
+            resume_job = JobRecord(
+                repo_full_name="live/verify",
+                stage="issue_followup",
+                issue_number=2001,
+            )
+            prompt_b = (
+                "Verification ping #2 in the SAME session. What was the EXACT word you replied with "
+                "in your previous turn? Reply with ONLY that word, nothing else, then stop."
+            )
+            t0 = time.monotonic()
+            session_b = runner.resume(repo_path, resume_job, prompt_b, session_a.omx_session_id)
+            _emit(test_id, f"resume returned in {time.monotonic() - t0:.2f}s; session_id={session_b.omx_session_id}")
+            assert session_b.omx_session_id == session_a.omx_session_id, (
+                f"resume should target same session: got {session_b.omx_session_id}, "
+                f"expected {session_a.omx_session_id}"
+            )
+
+            t0 = time.monotonic()
+            runner.wait(session_b.runtime_handle, timeout_seconds=180)
+            _emit(test_id, f"resume-wait returned in {time.monotonic() - t0:.2f}s")
+
+            events_b = _read_events(session_b.stdout_path)
+            text_parts: list[str] = []
+            for event in events_b:
+                if event.get("type") != "message.part.updated":
+                    continue
+                props = event.get("properties") or {}
+                part = props.get("part") or {}
+                if part.get("type") == "text":
+                    text_parts.append(str(part.get("text", "")))
+            joined = " ".join(text_parts).lower()
+            _emit(test_id, f"resume reply text snapshot (truncated): {joined[:200]!r}")
+            assert "session-ack-1" in joined, (
+                f"resume must reference prior turn keyword 'session-ack-1'; saw {joined[:300]!r}"
+            )
+            runner.close_session(session_b.runtime_handle)
+
+            return {
+                "session_id": session_a.omx_session_id,
+                "events_seen_a": summary_a,
+                "resume_continuity_keyword_present": True,
+            }
+        finally:
+            runner.shutdown()
+
+
+def test3_ultrawork_subagents() -> dict[str, Any]:
+    test_id = "TEST3"
+    with tempfile.TemporaryDirectory(prefix="dani-verify-runs-") as run_dir, temp_repo() as repo_path:
+        runner = OmoHttpRunner(Path(run_dir))
+        try:
+            _emit(test_id, "launch with ultrawork prompt that demands ONE quick subagent call via task()")
+            job = JobRecord(
+                repo_full_name="live/verify",
+                stage="issue_request",
+                issue_number=3001,
+            )
+            prompt = (
+                "ultrawork\n\n"
+                "VERIFICATION TEST FOR SUBAGENT SPAWNING. Do EXACTLY this: invoke the `task` tool "
+                "ONCE with the following arguments to delegate a tiny subtask:\n"
+                "  - category: 'quick'\n"
+                "  - load_skills: []\n"
+                "  - run_in_background: false\n"
+                "  - description: 'subagent ack'\n"
+                "  - prompt: 'Reply with EXACTLY the word: subagent-ack. Stop immediately.'\n"
+                "After the subagent returns, reply with EXACTLY the single word 'parent-ack' and stop. "
+                "Do not loop, do not call any other tool, do not delegate again. "
+                "This is a verification test of the HTTP server subagent path."
+            )
+            t0 = time.monotonic()
+            session = runner.launch(repo_path, job, prompt)
+            _emit(test_id, f"launch returned in {time.monotonic() - t0:.2f}s; parent session_id={session.omx_session_id}")
+            assert session.omx_session_id and session.omx_session_id.startswith("ses_")
+
+            base_url_before = runner._server_manager.get_server_for_repo(repo_path)
+            try:
+                req = urllib.request.Request(f"{base_url_before}/path")
+                with urllib.request.urlopen(req, timeout=5) as response:  # noqa: S310
+                    _ = response.read(1)
+                _emit(test_id, "server reachable BEFORE wait (HTTP 200 on /path)")
+            except urllib.error.URLError as exc:
+                raise RuntimeError(f"server unreachable before wait: {exc}") from exc
+
+            _emit(test_id, "wait for parent session.idle (timeout=300s)")
+            t0 = time.monotonic()
+            runner.wait(session.runtime_handle, timeout_seconds=300)
+            _emit(test_id, f"wait returned in {time.monotonic() - t0:.2f}s")
+
+            try:
+                req = urllib.request.Request(f"{base_url_before}/path")
+                with urllib.request.urlopen(req, timeout=5) as response:  # noqa: S310
+                    _ = response.read(1)
+                _emit(test_id, "server STILL reachable AFTER subagent run (HTTP 200 on /path)")
+            except urllib.error.URLError as exc:
+                raise RuntimeError(f"server died during subagent run: {exc}") from exc
+
+            events = _read_events(session.stdout_path)
+            summary = _summarize_events(events)
+            _emit(test_id, f"events seen: {summary}")
+
+            child_session_ids = _child_session_created(events, session.omx_session_id)
+            _emit(test_id, f"child sessions spawned with parentID={session.omx_session_id}: {child_session_ids}")
+            assert child_session_ids, (
+                "no child session.created events with parentID matching parent — subagent did not spawn"
+            )
+
+            assert _parent_idle_seen(events, session.omx_session_id), (
+                "parent session.idle was never recorded in event log"
+            )
+
+            for child_id in child_session_ids:
+                child_idle = any(
+                    e.get("type") == "session.idle" and (e.get("properties") or {}).get("sessionID") == child_id
+                    for e in events
+                )
+                _emit(test_id, f"child {child_id} idle observed: {child_idle}")
+
+            runner.close_session(session.runtime_handle)
+            return {
+                "parent_session_id": session.omx_session_id,
+                "child_session_ids": child_session_ids,
+                "events_summary": summary,
+            }
+        finally:
+            runner.shutdown()
+
+
+def main() -> int:
+    started = time.monotonic()
+    results: dict[str, Any] = {}
+    failures: list[str] = []
+
+    for test_id, fn in [("TEST1", test1_server_lifecycle), ("TEST2", test2_session_management), ("TEST3", test3_ultrawork_subagents)]:
+        print(f"\n{'=' * 72}\n{test_id}\n{'=' * 72}", flush=True)
+        try:
+            t0 = time.monotonic()
+            result = fn()
+            duration = time.monotonic() - t0
+            results[test_id] = {"status": "PASS", "duration_seconds": round(duration, 2), "data": result}
+            print(f"\n{test_id} PASS in {duration:.1f}s", flush=True)
+        except Exception as exc:  # noqa: BLE001
+            duration = time.monotonic() - t0
+            results[test_id] = {"status": "FAIL", "duration_seconds": round(duration, 2), "error": repr(exc)}
+            failures.append(f"{test_id}: {exc!r}")
+            print(f"\n{test_id} FAIL in {duration:.1f}s: {exc!r}", flush=True)
+
+    total = time.monotonic() - started
+    print("\n" + "=" * 72, flush=True)
+    print(f"FINAL VERDICT: {'PASS' if not failures else 'FAIL'} (total {total:.1f}s)", flush=True)
+    print(json.dumps(results, indent=2), flush=True)
+    if failures:
+        print("\nFAILURES:", flush=True)
+        for f in failures:
+            print(f"  - {f}", flush=True)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,7 +8,7 @@ from dani.errors import TransientCapacityError
 from dani.git_sync import DevSyncConflictError, DevSyncContext, DevSyncOutcome
 from dani.github import MergeConflictError
 from dani.models import JobRecord, SessionRecord
-from dani.signatures import build_signature, parse_signature
+from dani.signatures import build_signature, is_opt_out_comment, parse_agent_signature, parse_signature
 
 _CAPACITY_MSG = "capacity"
 
@@ -60,7 +60,9 @@ class FakeGitHubCLI:
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
         for comment in reversed(comments):
-            parsed = parse_signature(comment.get("body", ""))
+            if is_opt_out_comment(comment.get("body", "")):
+                continue
+            parsed = parse_agent_signature(comment.get("body", ""))
             if parsed is not None:
                 return comment, parsed
         return None
@@ -71,7 +73,11 @@ class FakeGitHubCLI:
         comments = (
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
-        return [comment for comment in comments if signature_fragment in (comment.get("body") or "")]
+        return [
+            comment
+            for comment in comments
+            if not is_opt_out_comment(comment.get("body", "")) and signature_fragment in (comment.get("body") or "")
+        ]
 
     def merge_pull_request(self, repo_full_name: str, pr_number: int) -> None:
         if (repo_full_name, pr_number) in self.merge_conflicts:
@@ -83,6 +89,16 @@ class FakeGitHubCLI:
 
     def add_pr_signature(self, repo_full_name: str, pr_number: int, signature: str) -> None:
         self.pr_comment_map.setdefault((repo_full_name, pr_number), []).append({"body": signature})
+
+    def create_issue_comment(self, repo_full_name: str, issue_number: int, body: str) -> dict[str, Any]:
+        comment = {"body": body}
+        self.issue_comment_map.setdefault((repo_full_name, issue_number), []).append(comment)
+        return comment
+
+    def create_pr_comment(self, repo_full_name: str, pr_number: int, body: str) -> dict[str, Any]:
+        comment = {"body": body}
+        self.pr_comment_map.setdefault((repo_full_name, pr_number), []).append(comment)
+        return comment
 
     def add_pull_request(
         self,
@@ -130,10 +146,14 @@ class FakeOmxRunner:
         self.resumes: list[ResumeRecord] = []
         self.closed_sessions: list[str] = []
         self._transient_failures_remaining: int = 0
+        self.resume_error: Exception | None = None
 
     def set_transient_failures(self, count: int) -> None:
         """Configure the runner to raise TransientCapacityError for the next *count* wait() calls."""
         self._transient_failures_remaining = count
+
+    def set_resume_failure(self, exc: Exception) -> None:
+        self.resume_error = exc
 
     def launch(self, repo_path: Path, job: JobRecord, prompt: str) -> SessionRecord:
         repo_full_name = job.repo_full_name
@@ -193,6 +213,13 @@ class FakeOmxRunner:
                 pr_number,
                 build_signature(stage="merge_conflict_resolution", job=job.id, pr=pr_number),
             )
+        elif job.stage == "human_escalation":
+            pr_number = int((signature or {}).get("pr", job.pr_number or 0))
+            self.github.add_pr_signature(
+                repo_full_name,
+                pr_number,
+                build_signature(stage="human_escalation", job=job.id, pr=pr_number),
+            )
         elif job.stage != "dev_sync":
             self.github.add_pr_signature(
                 repo_full_name,
@@ -201,6 +228,8 @@ class FakeOmxRunner:
             )
 
     def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
+        if self.resume_error is not None:
+            raise self.resume_error
         issue_number = job.issue_number or 0
         self.github.add_issue_signature(
             job.repo_full_name,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -269,6 +269,9 @@ class FakeOmxRunner:
         del runtime_handle
         return None
 
+    def can_resume(self, session_id: str) -> bool:
+        return bool(session_id)
+
 
 class FakeGitDevSyncer:
     def __init__(self, *, conflict: bool = False, fail: bool = False) -> None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -265,6 +265,10 @@ class FakeOmxRunner:
     def close_session(self, runtime_handle: str) -> None:
         self.closed_sessions.append(runtime_handle)
 
+    def get_session_id(self, runtime_handle: str) -> str | None:
+        del runtime_handle
+        return None
+
 
 class FakeGitDevSyncer:
     def __init__(self, *, conflict: bool = False, fail: bool = False) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from typer.testing import CliRunner
 
 import dani.cli as cli_module
 from dani.cli import app
+from dani.models import JobRecord
 
 
 class FakeBootstrapService:
@@ -15,6 +16,18 @@ class FakeBootstrapService:
     def bootstrap_repo(self, repo_full_name: str) -> int:
         self.calls.append(("bootstrap_repo", repo_full_name))
         return self.count
+
+    def wait_for_idle(self) -> None:
+        self.calls.append(("wait_for_idle", None))
+
+
+class FakeRestartService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, int] | tuple[str, None]] = []
+
+    def restart_issue(self, repo_full_name: str, issue_number: int) -> JobRecord:
+        self.calls.append(("restart_issue", repo_full_name, issue_number))
+        return JobRecord(repo_full_name=repo_full_name, stage="issue_request", issue_number=issue_number, id="job-123")
 
     def wait_for_idle(self) -> None:
         self.calls.append(("wait_for_idle", None))
@@ -44,3 +57,19 @@ def test_bootstrap_waits_for_idle_before_exiting(tmp_path: Path, monkeypatch) ->
     assert result.exit_code == 0
     assert fake_service.calls == [("bootstrap_repo", "acme/demo"), ("wait_for_idle", None)]
     assert result.stdout.strip() == "processed 2 issues"
+
+
+def test_restart_issue_invokes_service_waits_for_idle_and_prints_job(tmp_path: Path, monkeypatch) -> None:
+    runner = CliRunner()
+    data_dir = tmp_path / ".dani"
+    fake_service = FakeRestartService()
+    monkeypatch.setattr(cli_module, "build_service", lambda data_dir: fake_service)
+
+    result = runner.invoke(app, ["restart-issue", "acme/demo", "41", "--data-dir", str(data_dir)])
+
+    assert result.exit_code == 0
+    assert fake_service.calls == [("restart_issue", "acme/demo", 41), ("wait_for_idle", None)]
+    payload = json.loads(result.stdout)
+    assert payload["id"] == "job-123"
+    assert payload["stage"] == "issue_request"
+    assert payload["issue_number"] == 41

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -175,6 +175,42 @@ def test_create_issue_and_pr_comments_use_repository_objects(fake_repo: FakeRepo
     assert fake_repo.pulls[7].created_issue_comments == ["hello pr"]
 
 
+def test_latest_signature_comment_ignores_opt_out_marker(fake_repo: FakeRepo) -> None:
+    fake_repo.issues[5] = FakeIssue([
+        "<!-- dani:stage=issue_request;job=job-1;issue=5 -->",
+        "<!-- dani:stage=ignore -->",
+    ])
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    latest = github.latest_signature_comment("acme/demo", 5, kind="issue")
+
+    assert latest is not None
+    assert latest[1]["stage"] == "issue_request"
+
+
+def test_latest_signature_comment_skips_dani_ignore_command_even_with_embedded_signature(fake_repo: FakeRepo) -> None:
+    fake_repo.issues[5] = FakeIssue([
+        "<!-- dani:stage=issue_request;job=job-1;issue=5 -->",
+        "/dani ignore\nQuoted marker <!-- dani:stage=review_round;job=job-2;pr=7;round=1 -->",
+    ])
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    latest = github.latest_signature_comment("acme/demo", 5, kind="issue")
+
+    assert latest is not None
+    assert latest[1]["stage"] == "issue_request"
+
+
+def test_find_comments_by_signature_skips_opt_out_comment_that_quotes_exact_signature(fake_repo: FakeRepo) -> None:
+    signature = "<!-- dani:stage=review_round;job=job-2;pr=7;round=1 -->"
+    fake_repo.pulls[7] = FakePullRequest(number=7, body="body", comments=[f"/dani ignore\nQuoted marker {signature}"])
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    matching_comments = github.find_comments_by_signature("acme/demo", 7, kind="pr", signature_fragment=signature)
+
+    assert matching_comments == []
+
+
 def test_ensure_pull_request_updates_existing_open_pull_request(fake_repo: FakeRepo) -> None:
     github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
 
@@ -216,6 +252,16 @@ def test_merge_pull_request_raises_merge_conflict_error_for_merge_api_failures(
         github.merge_pull_request("acme/demo", 7)
 
     assert exc_info.value.status == status
+
+
+def test_merge_pull_request_reraises_non_conflict_github_failures(fake_repo: FakeRepo) -> None:
+    fake_repo.pulls[7].merge_exception = GithubException(500, {"message": "GitHub outage"}, {})
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    with pytest.raises(GithubException) as exc_info:
+        github.merge_pull_request("acme/demo", 7)
+
+    assert exc_info.value.status == 500
 
 
 def test_merge_pull_request_raises_merge_conflict_error_when_merge_status_is_false(fake_repo: FakeRepo) -> None:

--- a/tests/test_omo_http_runner.py
+++ b/tests/test_omo_http_runner.py
@@ -252,6 +252,26 @@ def test_resume_raises_rollout_missing_when_session_404(runner_factory, tmp_path
         runner.resume(tmp_path, job, "Continue", "ses_zzz")
 
 
+def test_resume_raises_rollout_missing_when_opencode_400_invalid_session_id_format(
+    runner_factory, tmp_path: Path
+) -> None:
+    runner, client, _ = runner_factory()
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=2)
+    client.get_session_raises = OpencodeHttpError(
+        status=400,
+        body=(
+            '{"data":{"sessionID":"019da0f4-6ef1-7923-811f-57eb3e93bd8e"},'
+            '"error":[{"origin":"string","code":"invalid_format","format":"starts_with",'
+            '"prefix":"ses","path":["sessionID"],"message":"Invalid string: must start with \\"ses\\""}],'
+            '"success":false}'
+        ),
+        url="http://test-server/session/019da0f4-6ef1-7923-811f-57eb3e93bd8e",
+    )
+
+    with pytest.raises(RolloutMissingError):
+        runner.resume(tmp_path, job, "Continue", "019da0f4-6ef1-7923-811f-57eb3e93bd8e")
+
+
 def test_wait_returns_when_consumer_marks_idle(runner_factory, tmp_path: Path) -> None:
     runner, _, consumer = runner_factory()
     job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=3)

--- a/tests/test_omo_http_runner.py
+++ b/tests/test_omo_http_runner.py
@@ -1,0 +1,614 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dani.errors import RolloutMissingError, TransientCapacityError
+from dani.models import JobRecord
+from dani.omo_http_runner import OmoHttpRunner
+from dani.opencode_http import (
+    CompletionState,
+    OpencodeClient,
+    OpencodeEventConsumer,
+    OpencodeHttpError,
+    OpencodeServerError,
+    OpencodeServerManager,
+    OpencodeSessionInfo,
+)
+
+
+class FakeOpencodeClient:
+    def __init__(self, base_url: str = "http://test-server") -> None:
+        self.base_url = base_url
+        self.created_sessions: list[dict[str, Any]] = []
+        self.prompt_calls: list[dict[str, Any]] = []
+        self.aborted_sessions: list[str] = []
+        self.permission_calls: list[dict[str, Any]] = []
+        self.session_lookup: dict[str, dict[str, Any]] = {}
+        self._next_session_index = 0
+        self.create_session_raises: Exception | None = None
+        self.send_prompt_raises: Exception | None = None
+        self.get_session_raises: Exception | None = None
+        self.statuses: dict[str, dict[str, Any]] = {}
+
+    def create_session(self, *, directory: str, title: str | None = None) -> OpencodeSessionInfo:
+        if self.create_session_raises is not None:
+            raise self.create_session_raises
+        session_id = f"ses_fakehttp{self._next_session_index:08d}"
+        self._next_session_index += 1
+        self.created_sessions.append({"directory": directory, "title": title, "id": session_id})
+        info = OpencodeSessionInfo(id=session_id, directory=directory, title=title or "")
+        self.session_lookup[session_id] = {
+            "id": session_id,
+            "directory": directory,
+            "title": title or "",
+        }
+        return info
+
+    def get_session(self, session_id: str, *, directory: str | None = None) -> dict[str, Any]:
+        if self.get_session_raises is not None:
+            raise self.get_session_raises
+        if session_id not in self.session_lookup:
+            raise OpencodeHttpError(
+                status=404,
+                body=f'NotFoundError: Session not found: {session_id}',
+                url=f"{self.base_url}/session/{session_id}",
+            )
+        return dict(self.session_lookup[session_id])
+
+    def session_status(self, *, directory: str | None = None) -> dict[str, dict[str, Any]]:
+        return dict(self.statuses)
+
+    def send_prompt_async(
+        self,
+        session_id: str,
+        *,
+        prompt_text: str,
+        directory: str | None = None,
+        agent: str | None = None,
+    ) -> None:
+        if self.send_prompt_raises is not None:
+            raise self.send_prompt_raises
+        self.prompt_calls.append({
+            "session_id": session_id,
+            "prompt_text": prompt_text,
+            "directory": directory,
+            "agent": agent,
+        })
+
+    def abort_session(self, session_id: str, *, directory: str | None = None) -> bool:
+        self.aborted_sessions.append(session_id)
+        return True
+
+    def respond_permission(
+        self,
+        session_id: str,
+        permission_id: str,
+        *,
+        response: str,
+        directory: str | None = None,
+    ) -> bool:
+        self.permission_calls.append({
+            "session_id": session_id,
+            "permission_id": permission_id,
+            "response": response,
+        })
+        return True
+
+    def stream_events(
+        self,
+        *,
+        directory: str | None = None,
+        stop_event: threading.Event | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        if stop_event is not None:
+            stop_event.wait()
+        return iter(())
+
+
+class StubConsumer:
+    def __init__(self) -> None:
+        self.registered: list[str] = []
+        self.unregistered: list[str] = []
+        self.aborted: list[str] = []
+        self.session_log_paths: dict[str, Path] = {}
+        self.start_count = 0
+        self.stop_count = 0
+        self._states: dict[str, CompletionState] = {}
+
+    def start(self) -> None:
+        self.start_count += 1
+
+    def stop(self) -> None:
+        self.stop_count += 1
+
+    def register_session(self, session_id: str, *, event_log_path: Path | None = None) -> CompletionState:
+        self.registered.append(session_id)
+        if event_log_path is not None:
+            self.session_log_paths[session_id] = event_log_path
+        state = self._states.setdefault(session_id, CompletionState(sessionID=session_id))
+        return state
+
+    def unregister_session(self, session_id: str) -> None:
+        self.unregistered.append(session_id)
+        self._states.pop(session_id, None)
+
+    def get_state(self, session_id: str) -> CompletionState | None:
+        return self._states.get(session_id)
+
+    def mark_aborted(self, session_id: str) -> None:
+        self.aborted.append(session_id)
+        state = self._states.get(session_id)
+        if state is not None:
+            state.aborted = True
+            state.event.set()
+
+    def complete_idle(self, session_id: str) -> None:
+        state = self._states[session_id]
+        state.event.set()
+
+    def complete_error(self, session_id: str, message: str) -> None:
+        state = self._states[session_id]
+        state.error_message = message
+        state.event.set()
+
+
+@pytest.fixture
+def runner_factory(tmp_path: Path):
+    def _make(
+        client: FakeOpencodeClient | None = None,
+        consumer: StubConsumer | None = None,
+        *,
+        permission_response: str | None = None,
+    ) -> tuple[OmoHttpRunner, FakeOpencodeClient, StubConsumer]:
+        client_obj = client or FakeOpencodeClient()
+        consumer_obj = consumer or StubConsumer()
+
+        class _StubServerManager:
+            def __init__(self) -> None:
+                self.shutdown_called = False
+
+            def get_server_for_repo(self, repo_path: Path) -> str:
+                return client_obj.base_url
+
+            def shutdown_all(self) -> None:
+                self.shutdown_called = True
+
+        runner = OmoHttpRunner(
+            tmp_path / "runs",
+            server_manager=_StubServerManager(),  # type: ignore[arg-type]
+            client_factory=lambda _base_url: client_obj,
+            consumer_factory=lambda _client, _log_path, _resp: consumer_obj,
+            permission_response=permission_response,
+        )
+        return runner, client_obj, consumer_obj
+
+    return _make
+
+
+def test_launch_creates_session_then_submits_prompt_async(runner_factory, tmp_path: Path) -> None:
+    runner, client, consumer = runner_factory()
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
+
+    session = runner.launch(tmp_path, job, "Investigate Issue #1.")
+
+    assert client.created_sessions and client.created_sessions[0]["directory"] == str(tmp_path)
+    assert client.prompt_calls and client.prompt_calls[0]["session_id"] == client.created_sessions[0]["id"]
+    assert client.prompt_calls[0]["prompt_text"] == "ultrawork\n\nInvestigate Issue #1."
+    assert session.omx_session_id == client.created_sessions[0]["id"]
+    assert consumer.registered == [session.omx_session_id]
+    assert Path(session.prompt_path).read_text(encoding="utf-8") == "ultrawork\n\nInvestigate Issue #1."
+
+
+def test_launch_does_not_double_prefix_when_prompt_already_starts_with_ultrawork(runner_factory, tmp_path: Path) -> None:
+    runner, client, _ = runner_factory()
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
+
+    runner.launch(tmp_path, job, "ultrawork already leading")
+
+    assert client.prompt_calls[0]["prompt_text"] == "ultrawork already leading"
+
+
+def test_resume_validates_session_then_sends_prompt(runner_factory, tmp_path: Path) -> None:
+    runner, client, consumer = runner_factory()
+    client.session_lookup["ses_existingone1234"] = {"id": "ses_existingone1234", "directory": str(tmp_path)}
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=2)
+
+    session = runner.resume(tmp_path, job, "Continue work", "ses_existingone1234")
+
+    assert session.omx_session_id == "ses_existingone1234"
+    assert client.prompt_calls[0]["session_id"] == "ses_existingone1234"
+    assert client.prompt_calls[0]["prompt_text"] == "ultrawork\n\nContinue work"
+    assert consumer.registered == ["ses_existingone1234"]
+
+
+def test_resume_raises_rollout_missing_when_session_404(runner_factory, tmp_path: Path) -> None:
+    runner, client, _ = runner_factory()
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=2)
+    client.get_session_raises = OpencodeHttpError(
+        status=404,
+        body='NotFoundError: Session not found: ses_zzz',
+        url="http://test-server/session/ses_zzz",
+    )
+
+    with pytest.raises(RolloutMissingError):
+        runner.resume(tmp_path, job, "Continue", "ses_zzz")
+
+
+def test_wait_returns_when_consumer_marks_idle(runner_factory, tmp_path: Path) -> None:
+    runner, _, consumer = runner_factory()
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=3)
+
+    session = runner.launch(tmp_path, job, "hello")
+
+    consumer.complete_idle(session.omx_session_id)
+    runner.wait(session.runtime_handle, timeout_seconds=2)
+
+
+def test_wait_raises_transient_capacity_error_from_session_error(runner_factory, tmp_path: Path) -> None:
+    runner, _, consumer = runner_factory()
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=4)
+
+    session = runner.launch(tmp_path, job, "hi")
+    consumer.complete_error(session.omx_session_id, "Selected model is at capacity, retry later.")
+
+    with pytest.raises(TransientCapacityError):
+        runner.wait(session.runtime_handle, timeout_seconds=2)
+
+
+def test_wait_raises_rollout_missing_error_from_session_error(runner_factory, tmp_path: Path) -> None:
+    client = FakeOpencodeClient()
+    client.session_lookup["ses_doomedaa1234"] = {"id": "ses_doomedaa1234", "directory": str(tmp_path)}
+    runner, _, consumer = runner_factory(client=client)
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=5)
+
+    session = runner.resume(tmp_path, job, "go", "ses_doomedaa1234")
+    consumer.complete_error(session.omx_session_id, "Session not found: ses_doomedaa1234")
+
+    with pytest.raises(RolloutMissingError):
+        runner.wait(session.runtime_handle, timeout_seconds=2)
+
+
+def test_wait_times_out_when_completion_state_never_settles(runner_factory, tmp_path: Path) -> None:
+    runner, _, _ = runner_factory()
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=6)
+
+    session = runner.launch(tmp_path, job, "hi")
+
+    with pytest.raises(TimeoutError):
+        runner.wait(session.runtime_handle, timeout_seconds=0.1)
+
+
+def test_close_session_aborts_and_unregisters(runner_factory, tmp_path: Path) -> None:
+    runner, client, consumer = runner_factory()
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=7)
+
+    session = runner.launch(tmp_path, job, "hi")
+    runner.close_session(session.runtime_handle)
+
+    assert session.omx_session_id in client.aborted_sessions
+    assert session.omx_session_id in consumer.unregistered
+
+
+def test_get_session_id_returns_id_after_launch(runner_factory, tmp_path: Path) -> None:
+    runner, _, _ = runner_factory()
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=8)
+
+    session = runner.launch(tmp_path, job, "hi")
+
+    assert runner.get_session_id(session.runtime_handle) == session.omx_session_id
+
+
+def test_can_resume_accepts_ses_prefixed_ids(runner_factory, tmp_path: Path) -> None:
+    runner, _, _ = runner_factory()
+
+    assert runner.can_resume("ses_25afdf9c7ffekN3dovMQw6meL2") is True
+    assert runner.can_resume("019da16a-565d-7c81-98c9-4b7ff38a3f9b") is False
+    assert runner.can_resume("") is False
+
+
+def test_send_prompt_failure_unregisters_session_state(runner_factory, tmp_path: Path) -> None:
+    client = FakeOpencodeClient()
+    client.send_prompt_raises = RuntimeError("network blip")
+    runner, _, consumer = runner_factory(client=client)
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=9)
+
+    with pytest.raises(RuntimeError, match="network blip"):
+        runner.launch(tmp_path, job, "hi")
+
+    assert consumer.registered and consumer.unregistered == consumer.registered
+
+
+def test_runner_writes_request_log_for_inspection(runner_factory, tmp_path: Path) -> None:
+    runner, _, _ = runner_factory()
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=10)
+
+    session = runner.launch(tmp_path, job, "Investigate Issue #10.")
+
+    request_payload = json.loads(Path(session.script_path).read_text(encoding="utf-8"))
+    assert request_payload["session_id"] == session.omx_session_id
+    assert request_payload["prompt_text"] == "ultrawork\n\nInvestigate Issue #10."
+
+
+def test_event_consumer_auto_grants_permission_with_default_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeOpencodeClient()
+    consumer = OpencodeEventConsumer(client)  # type: ignore[arg-type]
+    consumer._handle_event({
+        "type": "permission.updated",
+        "properties": {"id": "perm_xyz", "sessionID": "ses_a"},
+    })
+
+    assert client.permission_calls == [
+        {"session_id": "ses_a", "permission_id": "perm_xyz", "response": "once"},
+    ]
+
+
+def test_event_consumer_marks_idle_event_completes_state() -> None:
+    client = FakeOpencodeClient()
+    consumer = OpencodeEventConsumer(client)  # type: ignore[arg-type]
+    state = consumer.register_session("ses_target")
+
+    consumer._handle_event({"type": "session.idle", "properties": {"sessionID": "ses_target"}})
+
+    assert state.event.is_set()
+    assert state.error_message is None
+
+
+def test_event_consumer_records_error_message_on_session_error() -> None:
+    client = FakeOpencodeClient()
+    consumer = OpencodeEventConsumer(client)  # type: ignore[arg-type]
+    state = consumer.register_session("ses_err")
+
+    consumer._handle_event({
+        "type": "session.error",
+        "properties": {
+            "sessionID": "ses_err",
+            "error": {"name": "ApiError", "data": {"message": "model is currently overloaded"}},
+        },
+    })
+
+    assert state.event.is_set()
+    assert state.error_message == "model is currently overloaded"
+
+
+def test_event_consumer_uses_explicit_permission_response_argument() -> None:
+    client = FakeOpencodeClient()
+    consumer = OpencodeEventConsumer(client, permission_response="always")  # type: ignore[arg-type]
+    consumer._handle_event({
+        "type": "permission.updated",
+        "properties": {"id": "perm_y", "sessionID": "ses_b"},
+    })
+
+    assert client.permission_calls[0]["response"] == "always"
+
+
+def test_event_consumer_writes_jsonl_event_log(tmp_path: Path) -> None:
+    client = FakeOpencodeClient()
+    log_path = tmp_path / "events.jsonl"
+    consumer = OpencodeEventConsumer(client, event_log_path=log_path)  # type: ignore[arg-type]
+
+    consumer._handle_event({"type": "session.idle", "properties": {"sessionID": "ses_log"}})
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["type"] == "session.idle"
+    assert payload["properties"]["sessionID"] == "ses_log"
+
+
+def test_event_consumer_routes_per_session_events_to_registered_log(tmp_path: Path) -> None:
+    client = FakeOpencodeClient()
+    default_log = tmp_path / "default.jsonl"
+    consumer = OpencodeEventConsumer(client, event_log_path=default_log)  # type: ignore[arg-type]
+    session_log = tmp_path / "alpha.jsonl"
+    consumer.register_session("ses_alpha", event_log_path=session_log)
+
+    consumer._handle_event({"type": "session.idle", "properties": {"sessionID": "ses_alpha"}})
+    consumer._handle_event({"type": "session.idle", "properties": {"sessionID": "ses_unrelated"}})
+
+    alpha_lines = session_log.read_text(encoding="utf-8").splitlines()
+    default_lines = default_log.read_text(encoding="utf-8").splitlines()
+    assert len(alpha_lines) == 1
+    assert json.loads(alpha_lines[0])["properties"]["sessionID"] == "ses_alpha"
+    sids_in_default = [json.loads(line)["properties"].get("sessionID") for line in default_lines]
+    assert "ses_alpha" in sids_in_default
+    assert "ses_unrelated" in sids_in_default
+
+
+def test_event_consumer_extracts_session_id_from_nested_info_payload(tmp_path: Path) -> None:
+    client = FakeOpencodeClient()
+    default_log = tmp_path / "default.jsonl"
+    consumer = OpencodeEventConsumer(client, event_log_path=default_log)  # type: ignore[arg-type]
+    child_log = tmp_path / "child.jsonl"
+    consumer.register_session("ses_child", event_log_path=child_log)
+
+    consumer._handle_event({
+        "type": "session.created",
+        "properties": {"info": {"id": "ses_child", "parentID": "ses_parent"}},
+    })
+
+    child_lines = child_log.read_text(encoding="utf-8").splitlines()
+    assert len(child_lines) == 1
+
+
+def test_event_consumer_unregister_clears_per_session_log_routing(tmp_path: Path) -> None:
+    client = FakeOpencodeClient()
+    default_log = tmp_path / "default.jsonl"
+    consumer = OpencodeEventConsumer(client, event_log_path=default_log)  # type: ignore[arg-type]
+    session_log = tmp_path / "alpha.jsonl"
+    consumer.register_session("ses_alpha", event_log_path=session_log)
+    consumer.unregister_session("ses_alpha")
+
+    consumer._handle_event({"type": "session.idle", "properties": {"sessionID": "ses_alpha"}})
+
+    assert not session_log.exists() or session_log.read_text(encoding="utf-8") == ""
+    assert default_log.exists() and "ses_alpha" in default_log.read_text(encoding="utf-8")
+
+
+def test_server_manager_returns_external_url_without_spawning(tmp_path: Path) -> None:
+    manager = OpencodeServerManager(
+        tmp_path / "runs",
+        external_server_url="http://external.test:9999",
+    )
+
+    assert manager.get_server_for_repo(tmp_path) == "http://external.test:9999"
+
+
+def test_server_manager_raises_when_repo_path_missing(tmp_path: Path) -> None:
+    true_bin = "/usr/bin/true" if Path("/usr/bin/true").exists() else "/bin/true"
+    manager = OpencodeServerManager(tmp_path / "runs", opencode_bin=true_bin)
+    missing = tmp_path / "nope"
+
+    with pytest.raises(OpencodeServerError, match="does not exist"):
+        manager.get_server_for_repo(missing)
+
+
+def test_server_manager_raises_when_subprocess_exits_before_ready(tmp_path: Path) -> None:
+    false_bin = "/usr/bin/false" if Path("/usr/bin/false").exists() else "/bin/false"
+    manager = OpencodeServerManager(
+        tmp_path / "runs",
+        opencode_bin=false_bin,
+        ready_timeout_seconds=2.0,
+    )
+
+    with pytest.raises(OpencodeServerError):
+        manager.get_server_for_repo(tmp_path)
+
+
+def test_opencode_client_extract_sse_data_handles_multi_line_data() -> None:
+    text = "data: foo\ndata: bar"
+
+    assert OpencodeClient._extract_sse_data(text) == "foo\nbar"
+
+
+def test_opencode_client_extract_sse_data_returns_none_when_no_data_lines() -> None:
+    text = "event: ping\nretry: 1000"
+
+    assert OpencodeClient._extract_sse_data(text) is None
+
+
+def test_opencode_client_build_url_appends_query_string() -> None:
+    client = OpencodeClient("http://x.test/")
+    url = client._build_url("/session", {"directory": "/tmp/repo"})
+
+    assert url == "http://x.test/session?directory=%2Ftmp%2Frepo"
+
+
+def test_opencode_client_respond_permission_swallows_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = OpencodeClient("http://x.test")
+
+    def fake_request(method: str, path: str, *, query: dict | None = None, body: dict | None = None, expect_json: bool = True):
+        del method, path, query, body, expect_json
+        raise OpencodeHttpError(status=404, body="not found", url="http://x.test")
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    assert client.respond_permission("ses_a", "perm_z", response="once") is False
+
+
+def test_opencode_client_respond_permission_rejects_invalid_response() -> None:
+    client = OpencodeClient("http://x.test")
+
+    with pytest.raises(ValueError, match="invalid permission response"):
+        client.respond_permission("ses_a", "perm_b", response="bogus")
+
+
+def test_dani_service_runs_issue_request_through_omo_http_runner_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from typing import cast
+
+    from dani.github import GitHubCLI
+    from dani.models import DaniConfig, NormalizedEvent
+    from dani.opencode_http import OpencodeServerManager
+    from dani.service import DaniService
+    from dani.storage import JsonStorage
+    from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI
+
+    github_stub = FakeGitHubCLI()
+    fake_client = FakeOpencodeClient()
+    stub_consumer = StubConsumer()
+
+    class _StubServerManager(OpencodeServerManager):
+        def get_server_for_repo(self, repo_path: Path) -> str:
+            return fake_client.base_url
+
+        def shutdown_all(self) -> None:
+            return None
+
+    monkeypatch.delenv("DANI_OMO_LEGACY_SUBPROCESS", raising=False)
+
+    config = DaniConfig(
+        data_dir=tmp_path / ".dani",
+        webhook_secret="unit-test-secret",
+        agent_runtime="omo",
+    )
+    storage = JsonStorage(config)
+
+    runner = OmoHttpRunner(
+        config.run_dir,
+        server_manager=_StubServerManager(config.run_dir),
+        client_factory=lambda _base_url: fake_client,
+        consumer_factory=lambda _client, _log, _resp: stub_consumer,
+    )
+
+    def _post_signature_after_launch(*, session_id: str, prompt_text: str, **_: Any) -> None:
+        signature = next(
+            (line for line in prompt_text.splitlines() if line.startswith("<!-- dani:")),
+            None,
+        )
+        if signature is not None:
+            github_stub.issue_comment_map.setdefault(("acme/demo", 99), []).append({"body": signature})
+
+        def _settle() -> None:
+            time.sleep(0.05)
+            stub_consumer.complete_idle(session_id)
+
+        threading.Thread(target=_settle, daemon=True).start()
+
+    original_send = fake_client.send_prompt_async
+
+    def _instrumented_send(session_id: str, *, prompt_text: str, directory: str | None = None, agent: str | None = None) -> None:
+        original_send(session_id, prompt_text=prompt_text, directory=directory, agent=agent)
+        _post_signature_after_launch(session_id=session_id, prompt_text=prompt_text)
+
+    fake_client.send_prompt_async = _instrumented_send  # type: ignore[method-assign]
+
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github_stub),
+        dev_syncer=FakeGitDevSyncer(),
+        omx_runner=runner,
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    assert isinstance(service.omx_runner, OmoHttpRunner)
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=99,
+            actor_login="human",
+            payload={},
+            body="Investigate runtime selection over HTTP",
+            title="HTTP runtime smoke",
+        )
+    )
+    service.wait_for_idle()
+
+    job = storage.list_jobs()[0]
+    assert job.status == "completed", f"expected completed, got {job.status} / {job.metadata!r}"
+
+    sessions = storage.list_sessions()
+    assert len(sessions) == 1
+    assert sessions[0].omx_session_id == fake_client.created_sessions[0]["id"]
+    assert fake_client.prompt_calls[0]["prompt_text"].startswith("ultrawork\n\n")

--- a/tests/test_omo_http_runner.py
+++ b/tests/test_omo_http_runner.py
@@ -57,7 +57,7 @@ class FakeOpencodeClient:
         if session_id not in self.session_lookup:
             raise OpencodeHttpError(
                 status=404,
-                body=f'NotFoundError: Session not found: {session_id}',
+                body=f"NotFoundError: Session not found: {session_id}",
                 url=f"{self.base_url}/session/{session_id}",
             )
         return dict(self.session_lookup[session_id])
@@ -118,6 +118,7 @@ class StubConsumer:
         self.unregistered: list[str] = []
         self.aborted: list[str] = []
         self.session_log_paths: dict[str, Path] = {}
+        self.session_directories: dict[str, str] = {}
         self.start_count = 0
         self.stop_count = 0
         self._states: dict[str, CompletionState] = {}
@@ -128,10 +129,18 @@ class StubConsumer:
     def stop(self) -> None:
         self.stop_count += 1
 
-    def register_session(self, session_id: str, *, event_log_path: Path | None = None) -> CompletionState:
+    def register_session(
+        self,
+        session_id: str,
+        *,
+        directory: str | None = None,
+        event_log_path: Path | None = None,
+    ) -> CompletionState:
         self.registered.append(session_id)
         if event_log_path is not None:
             self.session_log_paths[session_id] = event_log_path
+        if directory is not None:
+            self.session_directories[session_id] = directory
         state = self._states.setdefault(session_id, CompletionState(sessionID=session_id))
         return state
 
@@ -206,7 +215,9 @@ def test_launch_creates_session_then_submits_prompt_async(runner_factory, tmp_pa
     assert Path(session.prompt_path).read_text(encoding="utf-8") == "ultrawork\n\nInvestigate Issue #1."
 
 
-def test_launch_does_not_double_prefix_when_prompt_already_starts_with_ultrawork(runner_factory, tmp_path: Path) -> None:
+def test_launch_does_not_double_prefix_when_prompt_already_starts_with_ultrawork(
+    runner_factory, tmp_path: Path
+) -> None:
     runner, client, _ = runner_factory()
     job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
 
@@ -233,7 +244,7 @@ def test_resume_raises_rollout_missing_when_session_404(runner_factory, tmp_path
     job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=2)
     client.get_session_raises = OpencodeHttpError(
         status=404,
-        body='NotFoundError: Session not found: ses_zzz',
+        body="NotFoundError: Session not found: ses_zzz",
         url="http://test-server/session/ses_zzz",
     )
 
@@ -451,6 +462,79 @@ def test_event_consumer_unregister_clears_per_session_log_routing(tmp_path: Path
     assert default_log.exists() and "ses_alpha" in default_log.read_text(encoding="utf-8")
 
 
+class _DirectoryTrackingFakeClient(FakeOpencodeClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.stream_events_calls: list[str | None] = []
+        self.session_status_calls: list[str | None] = []
+
+    def stream_events(
+        self,
+        *,
+        directory: str | None = None,
+        stop_event: threading.Event | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        self.stream_events_calls.append(directory)
+        if stop_event is not None:
+            stop_event.wait()
+        return iter(())
+
+    def session_status(self, *, directory: str | None = None) -> dict[str, dict[str, Any]]:
+        self.session_status_calls.append(directory)
+        return super().session_status(directory=directory)
+
+
+def test_event_consumer_spawns_sse_listener_per_registered_directory(tmp_path: Path) -> None:
+    client = _DirectoryTrackingFakeClient()
+    consumer = OpencodeEventConsumer(client)  # type: ignore[arg-type]
+    consumer.start()
+    repo_a = str(tmp_path / "repo-a")
+    repo_b = str(tmp_path / "repo-b")
+    try:
+        consumer.register_session("ses_alpha", directory=repo_a)
+        consumer.register_session("ses_beta", directory=repo_b)
+        consumer.register_session("ses_alpha_followup", directory=repo_a)
+        time.sleep(0.15)
+    finally:
+        consumer.stop()
+
+    directories_listened = set(client.stream_events_calls)
+    assert repo_a in directories_listened
+    assert repo_b in directories_listened
+    assert client.stream_events_calls.count(repo_a) == 1, (
+        "should reuse the SSE listener for a directory that has multiple registered sessions"
+    )
+
+
+def test_event_consumer_does_not_listen_for_directoryless_registration() -> None:
+    client = _DirectoryTrackingFakeClient()
+    consumer = OpencodeEventConsumer(client)  # type: ignore[arg-type]
+    consumer.start()
+    try:
+        consumer.register_session("ses_nodir")
+        time.sleep(0.1)
+    finally:
+        consumer.stop()
+
+    assert client.stream_events_calls == []
+
+
+def test_event_consumer_auto_grant_forwards_directory_to_client(tmp_path: Path) -> None:
+    client = FakeOpencodeClient()
+    consumer = OpencodeEventConsumer(client)  # type: ignore[arg-type]
+    repo_perm = str(tmp_path / "repo-perm")
+    consumer.register_session("ses_perm", directory=repo_perm)
+
+    consumer._handle_event({
+        "type": "permission.updated",
+        "properties": {"id": "perm_a", "sessionID": "ses_perm"},
+    })
+
+    assert client.permission_calls == [
+        {"session_id": "ses_perm", "permission_id": "perm_a", "response": "once"},
+    ]
+
+
 def test_server_manager_returns_external_url_without_spawning(tmp_path: Path) -> None:
     manager = OpencodeServerManager(
         tmp_path / "runs",
@@ -495,15 +579,17 @@ def test_opencode_client_extract_sse_data_returns_none_when_no_data_lines() -> N
 
 def test_opencode_client_build_url_appends_query_string() -> None:
     client = OpencodeClient("http://x.test/")
-    url = client._build_url("/session", {"directory": "/tmp/repo"})
+    url = client._build_url("/session", {"directory": "/private/var/repo"})
 
-    assert url == "http://x.test/session?directory=%2Ftmp%2Frepo"
+    assert url == "http://x.test/session?directory=%2Fprivate%2Fvar%2Frepo"
 
 
 def test_opencode_client_respond_permission_swallows_404(monkeypatch: pytest.MonkeyPatch) -> None:
     client = OpencodeClient("http://x.test")
 
-    def fake_request(method: str, path: str, *, query: dict | None = None, body: dict | None = None, expect_json: bool = True):
+    def fake_request(
+        method: str, path: str, *, query: dict | None = None, body: dict | None = None, expect_json: bool = True
+    ):
         del method, path, query, body, expect_json
         raise OpencodeHttpError(status=404, body="not found", url="http://x.test")
 
@@ -574,7 +660,9 @@ def test_dani_service_runs_issue_request_through_omo_http_runner_end_to_end(
 
     original_send = fake_client.send_prompt_async
 
-    def _instrumented_send(session_id: str, *, prompt_text: str, directory: str | None = None, agent: str | None = None) -> None:
+    def _instrumented_send(
+        session_id: str, *, prompt_text: str, directory: str | None = None, agent: str | None = None
+    ) -> None:
         original_send(session_id, prompt_text=prompt_text, directory=directory, agent=agent)
         _post_signature_after_launch(session_id=session_id, prompt_text=prompt_text)
 

--- a/tests/test_omo_http_runner.py
+++ b/tests/test_omo_http_runner.py
@@ -201,25 +201,44 @@ def runner_factory(tmp_path: Path):
     return _make
 
 
-def test_launch_creates_session_then_submits_prompt_async(runner_factory, tmp_path: Path) -> None:
+def test_launch_implementation_stage_prepends_ultrawork_prefix(runner_factory, tmp_path: Path) -> None:
     runner, client, consumer = runner_factory()
-    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
+    job = JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=1)
 
-    session = runner.launch(tmp_path, job, "Investigate Issue #1.")
+    session = runner.launch(tmp_path, job, "Implement Issue #1.")
 
     assert client.created_sessions and client.created_sessions[0]["directory"] == str(tmp_path)
     assert client.prompt_calls and client.prompt_calls[0]["session_id"] == client.created_sessions[0]["id"]
-    assert client.prompt_calls[0]["prompt_text"] == "ultrawork\n\nInvestigate Issue #1."
+    assert client.prompt_calls[0]["prompt_text"] == "ultrawork\n\nImplement Issue #1."
     assert session.omx_session_id == client.created_sessions[0]["id"]
     assert consumer.registered == [session.omx_session_id]
-    assert Path(session.prompt_path).read_text(encoding="utf-8") == "ultrawork\n\nInvestigate Issue #1."
+    assert Path(session.prompt_path).read_text(encoding="utf-8") == "ultrawork\n\nImplement Issue #1."
+
+
+def test_launch_issue_request_stage_skips_ultrawork_prefix(runner_factory, tmp_path: Path) -> None:
+    runner, client, _ = runner_factory()
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
+
+    runner.launch(tmp_path, job, "Investigate Issue #1.")
+
+    assert client.prompt_calls[0]["prompt_text"] == "Investigate Issue #1."
+
+
+def test_launch_issue_followup_stage_skips_ultrawork_prefix(runner_factory, tmp_path: Path) -> None:
+    runner, client, _ = runner_factory()
+    client.session_lookup["ses_already1234"] = {"id": "ses_already1234", "directory": str(tmp_path)}
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=2)
+
+    runner.resume(tmp_path, job, "Refine plan based on follow-up.", "ses_already1234")
+
+    assert client.prompt_calls[0]["prompt_text"] == "Refine plan based on follow-up."
 
 
 def test_launch_does_not_double_prefix_when_prompt_already_starts_with_ultrawork(
     runner_factory, tmp_path: Path
 ) -> None:
     runner, client, _ = runner_factory()
-    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
+    job = JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=1)
 
     runner.launch(tmp_path, job, "ultrawork already leading")
 
@@ -229,7 +248,7 @@ def test_launch_does_not_double_prefix_when_prompt_already_starts_with_ultrawork
 def test_resume_validates_session_then_sends_prompt(runner_factory, tmp_path: Path) -> None:
     runner, client, consumer = runner_factory()
     client.session_lookup["ses_existingone1234"] = {"id": "ses_existingone1234", "directory": str(tmp_path)}
-    job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=2)
+    job = JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=2)
 
     session = runner.resume(tmp_path, job, "Continue work", "ses_existingone1234")
 
@@ -358,13 +377,13 @@ def test_send_prompt_failure_unregisters_session_state(runner_factory, tmp_path:
 
 def test_runner_writes_request_log_for_inspection(runner_factory, tmp_path: Path) -> None:
     runner, _, _ = runner_factory()
-    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=10)
+    job = JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=10)
 
-    session = runner.launch(tmp_path, job, "Investigate Issue #10.")
+    session = runner.launch(tmp_path, job, "Implement Issue #10.")
 
     request_payload = json.loads(Path(session.script_path).read_text(encoding="utf-8"))
     assert request_payload["session_id"] == session.omx_session_id
-    assert request_payload["prompt_text"] == "ultrawork\n\nInvestigate Issue #10."
+    assert request_payload["prompt_text"] == "ultrawork\n\nImplement Issue #10."
 
 
 def test_event_consumer_auto_grants_permission_with_default_once(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -719,4 +738,6 @@ def test_dani_service_runs_issue_request_through_omo_http_runner_end_to_end(
     sessions = storage.list_sessions()
     assert len(sessions) == 1
     assert sessions[0].omx_session_id == fake_client.created_sessions[0]["id"]
-    assert fake_client.prompt_calls[0]["prompt_text"].startswith("ultrawork\n\n")
+    assert not fake_client.prompt_calls[0]["prompt_text"].startswith("ultrawork"), (
+        "issue_request is a planning stage; ultrawork prefix must not be auto-prepended"
+    )

--- a/tests/test_omo_live.py
+++ b/tests/test_omo_live.py
@@ -124,10 +124,10 @@ def test_live_opencode_resume_continues_prior_session(tmp_path: Path, live_repo:
     )
 
 
-def test_live_opencode_ultrawork_prefix_accepted(tmp_path: Path, live_repo: Path) -> None:
+def test_live_opencode_ultrawork_prefix_accepted_for_implementation_stage(tmp_path: Path, live_repo: Path) -> None:
     runner = OmoRunner(run_dir=tmp_path / "runs")
     job_cls = _import_job_record()
-    job = job_cls(repo_full_name="live/demo", stage="issue_request", issue_number=3)
+    job = job_cls(repo_full_name="live/demo", stage="implementation", issue_number=3)
 
     prompt = "Reply with exactly the words 'ulw live ok' and stop immediately. Do not use tools. Do not enter any loop."
     session = runner.launch(live_repo, job, prompt)
@@ -146,9 +146,29 @@ def test_live_opencode_ultrawork_prefix_accepted(tmp_path: Path, live_repo: Path
     assert "ses_" in stdout_text, f"opencode stdout missing sessionID events; stderr preview: {stderr_text[:400]!r}"
 
 
+def test_live_opencode_skips_ultrawork_for_planning_issue_request_stage(tmp_path: Path, live_repo: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    job_cls = _import_job_record()
+    job = job_cls(repo_full_name="live/demo", stage="issue_request", issue_number=4)
+
+    prompt = "Reply with exactly the words 'plan only' and stop immediately. Do not use tools. Do not enter any loop."
+    session = runner.launch(live_repo, job, prompt)
+
+    prompt_text = Path(session.prompt_path).read_text(encoding="utf-8")
+    assert not prompt_text.startswith("ultrawork"), (
+        f"planning stage must not auto-prefix ultrawork; got {prompt_text[:60]!r}"
+    )
+    assert prompt_text == prompt, "planning prompt must be passed through verbatim"
+
+    try:
+        runner.wait(session.runtime_handle, timeout_seconds=240)
+    finally:
+        runner.close_session(session.runtime_handle)
+
+
 def test_live_opencode_http_runner_launch_completes_through_server(tmp_path: Path, live_repo: Path) -> None:
     runner = OmoHttpRunner(run_dir=tmp_path / "runs")
-    job = JobRecord(repo_full_name="live/demo", stage="issue_request", issue_number=10)
+    job = JobRecord(repo_full_name="live/demo", stage="implementation", issue_number=10)
 
     prompt = "Reply with exactly the words 'http live ok' and stop immediately. Do not use tools."
     session = runner.launch(live_repo, job, prompt)
@@ -175,7 +195,7 @@ def test_live_opencode_http_runner_launch_completes_through_server(tmp_path: Pat
 
 def test_live_opencode_http_runner_resume_continues_prior_session(tmp_path: Path, live_repo: Path) -> None:
     runner = OmoHttpRunner(run_dir=tmp_path / "runs")
-    launch_job = JobRecord(repo_full_name="live/demo", stage="issue_request", issue_number=11)
+    launch_job = JobRecord(repo_full_name="live/demo", stage="implementation", issue_number=11)
 
     launch_prompt = (
         "Remember this exact keyword for later: AMBER_FALCON_4291. Reply only with the word 'ok' and stop immediately."
@@ -189,7 +209,7 @@ def test_live_opencode_http_runner_resume_continues_prior_session(tmp_path: Path
     first_id = launch_session.omx_session_id
     assert first_id is not None and first_id.startswith("ses_")
 
-    resume_job = JobRecord(repo_full_name="live/demo", stage="issue_followup", issue_number=11)
+    resume_job = JobRecord(repo_full_name="live/demo", stage="implementation", issue_number=11)
     resume_prompt = (
         "What was the keyword I told you earlier in this conversation? Reply with only the keyword and nothing else."
     )

--- a/tests/test_omo_live.py
+++ b/tests/test_omo_live.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from dani.models import JobRecord
+from dani.omo_http_runner import OmoHttpRunner
 from dani.omo_runner import OmoRunner
 
 LIVE_FLAG = "DANI_OMO_LIVE"
@@ -142,3 +144,69 @@ def test_live_opencode_ultrawork_prefix_accepted(tmp_path: Path, live_repo: Path
     stdout_text = Path(session.stdout_path).read_text(encoding="utf-8", errors="replace")
     stderr_text = Path(session.stderr_path).read_text(encoding="utf-8", errors="replace")
     assert "ses_" in stdout_text, f"opencode stdout missing sessionID events; stderr preview: {stderr_text[:400]!r}"
+
+
+def test_live_opencode_http_runner_launch_completes_through_server(tmp_path: Path, live_repo: Path) -> None:
+    runner = OmoHttpRunner(run_dir=tmp_path / "runs")
+    job = JobRecord(repo_full_name="live/demo", stage="issue_request", issue_number=10)
+
+    prompt = "Reply with exactly the words 'http live ok' and stop immediately. Do not use tools."
+    session = runner.launch(live_repo, job, prompt)
+
+    try:
+        runner.wait(session.runtime_handle, timeout_seconds=240)
+    finally:
+        runner.close_session(session.runtime_handle)
+        runner.shutdown()
+
+    assert session.omx_session_id is not None and session.omx_session_id.startswith("ses_"), (
+        f"expected captured opencode session id from HTTP runner, got {session.omx_session_id!r}"
+    )
+    prompt_text = Path(session.prompt_path).read_text(encoding="utf-8")
+    assert prompt_text.startswith("ultrawork\n\n"), f"expected ultrawork-prefixed prompt, got {prompt_text[:60]!r}"
+
+    events_text = Path(session.stdout_path).read_text(encoding="utf-8", errors="replace") if session.stdout_path else ""
+    assert any(
+        json.loads(line).get("type") == "session.idle"
+        for line in events_text.splitlines()
+        if line.strip().startswith("{")
+    ), f"expected at least one session.idle event in HTTP event log; tail: {events_text[-400:]!r}"
+
+
+def test_live_opencode_http_runner_resume_continues_prior_session(tmp_path: Path, live_repo: Path) -> None:
+    runner = OmoHttpRunner(run_dir=tmp_path / "runs")
+    launch_job = JobRecord(repo_full_name="live/demo", stage="issue_request", issue_number=11)
+
+    launch_prompt = (
+        "Remember this exact keyword for later: AMBER_FALCON_4291. Reply only with the word 'ok' and stop immediately."
+    )
+    launch_session = runner.launch(live_repo, launch_job, launch_prompt)
+    try:
+        runner.wait(launch_session.runtime_handle, timeout_seconds=240)
+    finally:
+        runner.close_session(launch_session.runtime_handle)
+
+    first_id = launch_session.omx_session_id
+    assert first_id is not None and first_id.startswith("ses_")
+
+    resume_job = JobRecord(repo_full_name="live/demo", stage="issue_followup", issue_number=11)
+    resume_prompt = (
+        "What was the keyword I told you earlier in this conversation? Reply with only the keyword and nothing else."
+    )
+    resume_session = runner.resume(live_repo, resume_job, resume_prompt, first_id)
+    try:
+        runner.wait(resume_session.runtime_handle, timeout_seconds=240)
+    finally:
+        runner.close_session(resume_session.runtime_handle)
+        runner.shutdown()
+
+    assert resume_session.omx_session_id == first_id
+
+    events_text = (
+        Path(resume_session.stdout_path).read_text(encoding="utf-8", errors="replace")
+        if resume_session.stdout_path
+        else ""
+    )
+    assert "AMBER_FALCON_4291" in events_text, (
+        f"resume did not continue prior session — keyword missing from event log; tail: {events_text[-400:]!r}"
+    )

--- a/tests/test_omo_live.py
+++ b/tests/test_omo_live.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from dani.omo_runner import OmoRunner
+
+LIVE_FLAG = "DANI_OMO_LIVE"
+LIVE_FLAG_VALUES = {"1", "true", "yes", "on"}
+pytestmark = pytest.mark.skipif(
+    os.environ.get(LIVE_FLAG, "").strip().lower() not in LIVE_FLAG_VALUES or shutil.which("opencode") is None,
+    reason=(
+        f"Live opencode tests are opt-in: set {LIVE_FLAG}=1 and install the `opencode` binary. "
+        "These tests spawn real opencode subprocesses and consume model tokens."
+    ),
+)
+
+
+@pytest.fixture
+def live_repo(tmp_path: Path) -> Path:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo_path, check=True)  # noqa: S607
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-q", "-m", "init"],  # noqa: S607
+        cwd=repo_path,
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "dani-live",
+            "GIT_AUTHOR_EMAIL": "dani-live@example.com",
+            "GIT_COMMITTER_NAME": "dani-live",
+            "GIT_COMMITTER_EMAIL": "dani-live@example.com",
+        },
+    )
+    return repo_path
+
+
+def _import_job_record():
+    from dani.models import JobRecord
+
+    return JobRecord
+
+
+def test_live_opencode_launch_emits_session_id_and_completes(tmp_path: Path, live_repo: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    job_cls = _import_job_record()
+    job = job_cls(repo_full_name="live/demo", stage="issue_request", issue_number=1)
+
+    prompt = "Reply with exactly the words 'dani live ok' and stop immediately. Do not use tools."
+    session = runner.launch(live_repo, job, prompt)
+
+    try:
+        runner.wait(session.runtime_handle, timeout_seconds=240)
+    finally:
+        runner.close_session(session.runtime_handle)
+
+    assert session.stdout_path is not None and session.stderr_path is not None
+    stdout_text = Path(session.stdout_path).read_text(encoding="utf-8", errors="replace")
+    stderr_text = Path(session.stderr_path).read_text(encoding="utf-8", errors="replace")
+
+    session_ids = [
+        json.loads(line).get("sessionID")
+        for line in stdout_text.splitlines()
+        if line.strip().startswith("{") and '"sessionID"' in line
+    ]
+    session_ids = [sid for sid in session_ids if isinstance(sid, str) and sid.startswith("ses_")]
+    assert session_ids, f"opencode stdout never contained a sessionID event; stderr preview: {stderr_text[:400]!r}"
+
+    assert session.omx_session_id is not None, (
+        "launch() should have captured the session id during its pre-wait poll; "
+        f"stdout bytes={len(stdout_text)}, stderr bytes={len(stderr_text)}"
+    )
+    assert session.omx_session_id == session_ids[0]
+
+
+def test_live_opencode_resume_continues_prior_session(tmp_path: Path, live_repo: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    job_cls = _import_job_record()
+    launch_job = job_cls(repo_full_name="live/demo", stage="issue_request", issue_number=2)
+
+    launch_prompt = (
+        "Remember this exact keyword for later: CRIMSON_MOOSE_7361. Reply only with the word 'ok' and stop immediately."
+    )
+    launch_session = runner.launch(live_repo, launch_job, launch_prompt)
+    try:
+        runner.wait(launch_session.runtime_handle, timeout_seconds=240)
+    finally:
+        runner.close_session(launch_session.runtime_handle)
+
+    first_id = launch_session.omx_session_id
+    if first_id is None:
+        first_id = runner.get_session_id(launch_session.runtime_handle)
+    assert first_id is not None and first_id.startswith("ses_"), (
+        f"expected captured session id after launch, got {first_id!r}"
+    )
+
+    resume_job = job_cls(repo_full_name="live/demo", stage="issue_followup", issue_number=2)
+    resume_prompt = (
+        "What was the keyword I told you earlier in this conversation? Reply with only the keyword and nothing else."
+    )
+    resume_session = runner.resume(live_repo, resume_job, resume_prompt, first_id)
+
+    try:
+        runner.wait(resume_session.runtime_handle, timeout_seconds=240)
+    finally:
+        runner.close_session(resume_session.runtime_handle)
+
+    resume_script_text = Path(resume_session.script_path).read_text(encoding="utf-8")
+    assert f"opencode run --session {first_id} --format json --dangerously-skip-permissions" in resume_script_text
+
+    assert resume_session.stdout_path is not None
+    resume_stdout = Path(resume_session.stdout_path).read_text(encoding="utf-8", errors="replace")
+    assert "CRIMSON_MOOSE_7361" in resume_stdout, (
+        "resume did not continue prior session — keyword missing from opencode reply; "
+        f"stdout tail: {resume_stdout[-400:]!r}"
+    )
+
+
+def test_live_opencode_ultrawork_prefix_accepted(tmp_path: Path, live_repo: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    job_cls = _import_job_record()
+    job = job_cls(repo_full_name="live/demo", stage="issue_request", issue_number=3)
+
+    prompt = "Reply with exactly the words 'ulw live ok' and stop immediately. Do not use tools. Do not enter any loop."
+    session = runner.launch(live_repo, job, prompt)
+
+    prompt_text = Path(session.prompt_path).read_text(encoding="utf-8")
+    assert prompt_text.startswith("ultrawork\n\n"), f"expected ultrawork-prefixed prompt, got {prompt_text[:60]!r}"
+
+    try:
+        runner.wait(session.runtime_handle, timeout_seconds=240)
+    finally:
+        runner.close_session(session.runtime_handle)
+
+    assert session.stdout_path is not None and session.stderr_path is not None
+    stdout_text = Path(session.stdout_path).read_text(encoding="utf-8", errors="replace")
+    stderr_text = Path(session.stderr_path).read_text(encoding="utf-8", errors="replace")
+    assert "ses_" in stdout_text, f"opencode stdout missing sessionID events; stderr preview: {stderr_text[:400]!r}"

--- a/tests/test_omo_runner.py
+++ b/tests/test_omo_runner.py
@@ -1,0 +1,899 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dani.errors import RolloutMissingError, TransientCapacityError
+from dani.omo_runner import OmoRunner
+
+
+def test_build_script_uses_opencode_run(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    script = runner._build_script(repo_path=tmp_path / "repo", prompt_path=tmp_path / "prompt.txt")
+
+    assert "opencode run --format json --dangerously-skip-permissions" in script
+    assert "cd " in script
+
+
+def test_build_resume_script_uses_opencode_session_flag(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    script = runner._build_resume_script(
+        repo_path=tmp_path / "repo",
+        prompt_path=tmp_path / "prompt.txt",
+        opencode_session_id="ses_abc123",
+    )
+
+    assert "opencode run --session ses_abc123 --format json --dangerously-skip-permissions" in script
+
+
+def test_build_script_honours_custom_binary(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs", opencode_bin="/usr/local/bin/opencode")
+    script = runner._build_script(repo_path=tmp_path / "repo", prompt_path=tmp_path / "prompt.txt")
+
+    assert "/usr/local/bin/opencode run --format json" in script
+
+
+def test_session_id_from_stdout_parses_sessionid_field(tmp_path: Path) -> None:
+    stdout_path = tmp_path / "stdout.log"
+    stdout_path.write_text(
+        json.dumps({
+            "type": "step_start",
+            "timestamp": 1776528793789,
+            "sessionID": "ses_25ea1f4beffeDiVTHAxqiPJa4G",
+            "part": {"type": "step-start"},
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+
+    assert runner._session_id_from_stdout(stdout_path) == "ses_25ea1f4beffeDiVTHAxqiPJa4G"
+
+
+def test_session_id_from_stdout_ignores_malformed_lines(tmp_path: Path) -> None:
+    stdout_path = tmp_path / "stdout.log"
+    stdout_path.write_text(
+        "\n".join([
+            "not-json",
+            json.dumps({"type": "noise", "other": "value"}),
+            json.dumps({"type": "text", "sessionID": "ses_realone123"}),
+        ])
+        + "\n",
+        encoding="utf-8",
+    )
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+
+    assert runner._session_id_from_stdout(stdout_path) == "ses_realone123"
+
+
+def test_session_id_from_stdout_returns_none_when_no_event(tmp_path: Path) -> None:
+    stdout_path = tmp_path / "stdout.log"
+    stdout_path.write_text("", encoding="utf-8")
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+
+    assert runner._session_id_from_stdout(stdout_path) is None
+
+
+def test_capture_session_id_polls_until_visible(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    stdout_path = runs_dir / "stdout.log"
+    stdout_path.write_text(
+        json.dumps({"type": "step_start", "sessionID": "ses_polled"}) + "\n",
+        encoding="utf-8",
+    )
+    runner = OmoRunner(run_dir=runs_dir)
+
+    result = runner._capture_session_id(stdout_path=stdout_path, poll_interval=0.01, timeout_seconds=0.05)
+
+    assert result == "ses_polled"
+
+
+def test_capture_session_id_returns_none_on_timeout(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    stdout_path = runs_dir / "stdout.log"
+    stdout_path.write_text("", encoding="utf-8")
+    runner = OmoRunner(run_dir=runs_dir)
+
+    result = runner._capture_session_id(stdout_path=stdout_path, poll_interval=0.01, timeout_seconds=0.03)
+
+    assert result is None
+
+
+def test_close_session_terminates_active_process(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    stdout_path = tmp_path / "stdout.log"
+    stderr_path = tmp_path / "stderr.log"
+    stdout_path.write_text("", encoding="utf-8")
+    stderr_path.write_text("", encoding="utf-8")
+    stdout_file = stdout_path.open("w", encoding="utf-8")
+    stderr_file = stderr_path.open("w", encoding="utf-8")
+
+    process = type(
+        "Process",
+        (),
+        {
+            "poll": lambda self: None,
+            "terminate": lambda self: None,
+            "wait": lambda self, timeout=None: 0,
+            "kill": lambda self: None,
+        },
+    )()
+    runner._processes["runtime-123"] = (process, stdout_file, stderr_file)
+
+    runner.close_session("runtime-123")
+
+    assert stdout_file.closed
+    assert stderr_file.closed
+    assert runner._processes == {}
+
+
+def test_close_session_skips_missing_process(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    runner.close_session("runtime-123")
+
+
+def test_wait_raises_rollout_missing_error_when_stderr_mentions_session_not_found(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    runtime_handle = "runtime-missing"
+    runtime_dir = runner.run_dir / runtime_handle
+    runtime_dir.mkdir(parents=True)
+    stdout_path = runtime_dir / "stdout.log"
+    stderr_path = runtime_dir / "stderr.log"
+    stdout_path.write_text("", encoding="utf-8")
+    stderr_path.write_text("Error: Session not found: ses_missing123", encoding="utf-8")
+    stdout_file = stdout_path.open("w", encoding="utf-8")
+    stderr_file = stderr_path.open("a", encoding="utf-8")
+    process = type(
+        "Process",
+        (),
+        {
+            "poll": lambda self: 1,
+            "terminate": lambda self: None,
+            "wait": lambda self, timeout=None: 1,
+            "kill": lambda self: None,
+        },
+    )()
+    runner._processes[runtime_handle] = (process, stdout_file, stderr_file)
+
+    try:
+        with pytest.raises(RolloutMissingError, match="Session not found"):
+            runner.wait(runtime_handle)
+    finally:
+        stdout_file.close()
+        stderr_file.close()
+
+
+def test_wait_raises_transient_capacity_when_stderr_matches_pattern(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    runtime_handle = "runtime-capacity"
+    runtime_dir = runner.run_dir / runtime_handle
+    runtime_dir.mkdir(parents=True)
+    stdout_path = runtime_dir / "stdout.log"
+    stderr_path = runtime_dir / "stderr.log"
+    stdout_path.write_text("", encoding="utf-8")
+    stderr_path.write_text("Selected model is at capacity, retrying...", encoding="utf-8")
+    stdout_file = stdout_path.open("w", encoding="utf-8")
+    stderr_file = stderr_path.open("a", encoding="utf-8")
+    process = type(
+        "Process",
+        (),
+        {
+            "poll": lambda self: 1,
+            "terminate": lambda self: None,
+            "wait": lambda self, timeout=None: 1,
+            "kill": lambda self: None,
+        },
+    )()
+    runner._processes[runtime_handle] = (process, stdout_file, stderr_file)
+
+    try:
+        with pytest.raises(TransientCapacityError):
+            runner.wait(runtime_handle)
+    finally:
+        stdout_file.close()
+        stderr_file.close()
+
+
+def test_launch_writes_prompt_file_with_exact_prompt_content(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from dani.models import JobRecord
+
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    captured_prompts: list[str] = []
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        captured_prompts.append(prompt_file.read_text(encoding="utf-8"))
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(runner, "_capture_session_id", lambda **kwargs: None)
+
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
+    runner.launch(tmp_path / "repo", job, "HELLO EXACT PROMPT BODY 12345")
+
+    assert captured_prompts == ["ultrawork\n\nHELLO EXACT PROMPT BODY 12345"]
+
+
+def test_resume_writes_prompt_file_with_exact_prompt_content(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from dani.models import JobRecord
+
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    captured_prompts: list[str] = []
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        captured_prompts.append(prompt_file.read_text(encoding="utf-8"))
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=1)
+    runner.resume(tmp_path / "repo", job, "RESUME EXACT PROMPT 67890", "ses_persisted")
+
+    assert captured_prompts == ["ultrawork\n\nRESUME EXACT PROMPT 67890"]
+
+
+def test_get_session_id_returns_parsed_id_from_stdout_log(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    runtime_handle = "dani-issue_request-xyz"
+    runtime_dir = runner.run_dir / runtime_handle
+    runtime_dir.mkdir(parents=True)
+    stdout_path = runtime_dir / "stdout.log"
+    stdout_path.write_text(
+        json.dumps({"type": "step_start", "sessionID": "ses_postwaitrecovered01"}) + "\n",
+        encoding="utf-8",
+    )
+
+    assert runner.get_session_id(runtime_handle) == "ses_postwaitrecovered01"
+
+
+def test_get_session_id_returns_none_when_stdout_missing(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    assert runner.get_session_id("dani-issue_request-missing") is None
+
+
+def test_omx_runner_get_session_id_returns_none(tmp_path: Path) -> None:
+    from dani.omx_runner import OmxRunner
+
+    omx = OmxRunner(run_dir=tmp_path / "omx-runs")
+    assert omx.get_session_id("any-handle") is None
+
+
+def test_dani_service_recovers_late_session_id_from_omo_runner_after_wait(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """issue_request runs; _capture_session_id times out; wait() completes; service re-queries runner and updates storage."""
+    from typing import cast
+
+    from dani.github import GitHubCLI
+    from dani.models import DaniConfig, NormalizedEvent
+    from dani.service import DaniService
+    from dani.storage import JsonStorage
+    from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    github_stub = FakeGitHubCLI()
+    late_session_id = "ses_latecapture000000000abcdef"
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        prompt_body = prompt_file.read_text(encoding="utf-8")
+
+        stdout_path = Path(kwargs["stdout"].name)
+        stderr_path = Path(kwargs["stderr"].name)
+        stdout_path.write_text(
+            json.dumps({"type": "step_start", "sessionID": late_session_id}) + "\n",
+            encoding="utf-8",
+        )
+        stderr_path.write_text("", encoding="utf-8")
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+
+        signature = next(
+            (fragment for fragment in prompt_body.splitlines() if fragment.startswith("<!-- dani:")),
+            None,
+        )
+        if signature is not None:
+            github_stub.issue_comment_map.setdefault(("acme/demo", 77), []).append({"body": signature})
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "dani.omo_runner.OmoRunner._capture_session_id",
+        lambda self, **kwargs: None,
+    )
+
+    config = DaniConfig(
+        data_dir=tmp_path / ".dani",
+        webhook_secret="unit-test-secret",
+        agent_runtime="omo",
+    )
+    storage = JsonStorage(config)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github_stub),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=77,
+            actor_login="human",
+            payload={},
+            body="Simulate slow session-id emission",
+            title="Late-capture smoke",
+        )
+    )
+    service.wait_for_idle()
+
+    sessions = storage.list_sessions()
+    assert sessions
+    assert sessions[0].omx_session_id == late_session_id, (
+        "service must re-query runner post-wait and update session with late-arriving id"
+    )
+
+
+def test_build_agent_runner_factory_returns_omo_runner(tmp_path: Path) -> None:
+    from dani.agent_runner import build_agent_runner
+
+    runner = build_agent_runner("omo", tmp_path / "runs")
+
+    assert isinstance(runner, OmoRunner)
+
+
+def test_build_agent_runner_factory_returns_omx_runner_by_default(tmp_path: Path) -> None:
+    from dani.agent_runner import build_agent_runner
+    from dani.omx_runner import OmxRunner
+
+    runner = build_agent_runner("omx", tmp_path / "runs")
+
+    assert isinstance(runner, OmxRunner)
+
+
+def test_build_agent_runner_rejects_unknown_runtime(tmp_path: Path) -> None:
+    from dani.agent_runner import build_agent_runner
+
+    with pytest.raises(ValueError, match="unknown agent runtime"):
+        build_agent_runner("nonsense", tmp_path / "runs")
+
+
+def test_omo_runner_always_prepends_ultrawork_prefix(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from dani.models import JobRecord
+
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    captured_prompts: list[str] = []
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        captured_prompts.append(prompt_file.read_text(encoding="utf-8"))
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(runner, "_capture_session_id", lambda **kwargs: None)
+
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
+    runner.launch(tmp_path / "repo", job, "Investigate Issue #33.")
+
+    assert captured_prompts == ["ultrawork\n\nInvestigate Issue #33."]
+
+
+def test_omo_runner_does_not_double_prefix_when_prompt_already_starts_with_ultrawork(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from dani.models import JobRecord
+
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    captured_prompts: list[str] = []
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        captured_prompts.append(prompt_file.read_text(encoding="utf-8"))
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(runner, "_capture_session_id", lambda **kwargs: None)
+
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
+    runner.launch(tmp_path / "repo", job, "ultrawork already leading")
+
+    assert captured_prompts == ["ultrawork already leading"]
+
+
+def test_omo_runner_resume_also_applies_ultrawork_prefix(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from dani.models import JobRecord
+
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    captured_prompts: list[str] = []
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        captured_prompts.append(prompt_file.read_text(encoding="utf-8"))
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=1)
+    runner.resume(tmp_path / "repo", job, "Continue fixing", "ses_persisted_omo")
+
+    assert captured_prompts == ["ultrawork\n\nContinue fixing"]
+
+
+def test_dani_service_instantiates_omo_runner_when_config_agent_runtime_is_omo(tmp_path: Path) -> None:
+    from dani.models import DaniConfig
+    from dani.service import DaniService
+
+    config = DaniConfig(
+        data_dir=tmp_path / ".dani",
+        webhook_secret="unit-test-secret",
+        agent_runtime="omo",
+    )
+    service = DaniService(config)
+
+    assert isinstance(service.omx_runner, OmoRunner)
+
+
+def test_dani_service_defaults_to_omx_runner_for_backward_compat(tmp_path: Path) -> None:
+    from dani.models import DaniConfig
+    from dani.omx_runner import OmxRunner
+    from dani.service import DaniService
+
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret="unit-test-secret")
+    service = DaniService(config)
+
+    assert isinstance(service.omx_runner, OmxRunner)
+
+
+def test_dani_service_runs_issue_request_through_omo_runner_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from typing import cast
+
+    from dani.github import GitHubCLI
+    from dani.models import DaniConfig, NormalizedEvent
+    from dani.service import DaniService
+    from dani.storage import JsonStorage
+    from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    github_stub = FakeGitHubCLI()
+    captured_scripts: list[str] = []
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        captured_scripts.append(script_text)
+        stdout_path = Path(kwargs["stdout"].name)
+        stderr_path = Path(kwargs["stderr"].name)
+        import json as _json
+
+        session_id = "ses_stubbedomo1234567890abcdef"
+        event = {"type": "step_start", "timestamp": 0, "sessionID": session_id, "part": {"type": "step-start"}}
+        stdout_path.write_text(_json.dumps(event) + "\n", encoding="utf-8")
+        stderr_path.write_text("", encoding="utf-8")
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        prompt_body = prompt_file.read_text(encoding="utf-8")
+        signature = next(
+            (fragment for fragment in prompt_body.splitlines() if fragment.startswith("<!-- dani:")),
+            None,
+        )
+        if signature is not None:
+            github_stub.issue_comment_map.setdefault(("acme/demo", 99), []).append({"body": signature})
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+
+    config = DaniConfig(
+        data_dir=tmp_path / ".dani",
+        webhook_secret="unit-test-secret",
+        agent_runtime="omo",
+    )
+    storage = JsonStorage(config)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github_stub),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    assert isinstance(service.omx_runner, OmoRunner)
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=99,
+            actor_login="human",
+            payload={},
+            body="Investigate runtime selection",
+            title="Runtime selection smoke",
+        )
+    )
+    service.wait_for_idle()
+
+    job = storage.list_jobs()[0]
+    assert job.status == "completed", f"expected completed, got {job.status} / {job.metadata!r}"
+    assert captured_scripts, "expected at least one opencode run invocation"
+    assert "opencode run --format json --dangerously-skip-permissions" in captured_scripts[0]
+
+    sessions = storage.list_sessions()
+    assert len(sessions) == 1
+    assert sessions[0].omx_session_id == "ses_stubbedomo1234567890abcdef"
+
+
+def test_dani_service_resumes_opencode_session_on_issue_followup_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """issue_opened -> persisted sessionID -> issue_comment -> OmoRunner.resume with --session flag."""
+    from typing import cast
+
+    from dani.github import GitHubCLI
+    from dani.models import DaniConfig, NormalizedEvent
+    from dani.service import DaniService
+    from dani.storage import JsonStorage
+    from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    github_stub = FakeGitHubCLI()
+    scripts_executed: list[str] = []
+    prompts_executed: list[str] = []
+    captured_session_id = "ses_resumechain0000000000abcd"
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        scripts_executed.append(script_text)
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        prompt_body = prompt_file.read_text(encoding="utf-8")
+        prompts_executed.append(prompt_body)
+
+        stdout_path = Path(kwargs["stdout"].name)
+        stderr_path = Path(kwargs["stderr"].name)
+        import json as _json
+
+        event = {"type": "step_start", "timestamp": 0, "sessionID": captured_session_id, "part": {}}
+        stdout_path.write_text(_json.dumps(event) + "\n", encoding="utf-8")
+        stderr_path.write_text("", encoding="utf-8")
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+
+        signature = next(
+            (fragment for fragment in prompt_body.splitlines() if fragment.startswith("<!-- dani:")),
+            None,
+        )
+        if signature is not None:
+            github_stub.issue_comment_map.setdefault(("acme/demo", 42), []).append({"body": signature})
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+
+    config = DaniConfig(
+        data_dir=tmp_path / ".dani",
+        webhook_secret="unit-test-secret",
+        agent_runtime="omo",
+    )
+    storage = JsonStorage(config)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github_stub),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    assert isinstance(service.omx_runner, OmoRunner)
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=42,
+            actor_login="human",
+            payload={},
+            body="Initial issue body for OMO resume chain",
+            title="OMO resume chain smoke",
+        )
+    )
+    service.wait_for_idle()
+
+    first_job = storage.list_jobs()[0]
+    assert first_job.status == "completed"
+    persisted_session = storage.list_sessions()[0]
+    assert persisted_session.omx_session_id == captured_session_id
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=42,
+            actor_login="human",
+            payload={"issue": {"body": "Initial issue body for OMO resume chain"}},
+            body="Actually also look at subsystem Y.",
+            title="OMO resume chain smoke",
+        )
+    )
+    service.wait_for_idle()
+
+    followup_jobs = [job for job in storage.list_jobs() if job.stage == "issue_followup"]
+    assert followup_jobs, "issue_followup job should have been enqueued"
+    followup_job = followup_jobs[-1]
+    assert followup_job.status == "completed", (
+        f"expected completed, got {followup_job.status} with metadata {followup_job.metadata!r}"
+    )
+    assert followup_job.metadata.get("omx_session_id") == captured_session_id
+
+    followup_scripts = [script for script in scripts_executed if "--session" in script]
+    assert followup_scripts, "resume path should have generated an opencode run --session script"
+    assert (
+        f"opencode run --session {captured_session_id} --format json --dangerously-skip-permissions"
+        in (followup_scripts[-1])
+    )
+
+    followup_sessions = [session for session in storage.list_sessions() if session.stage == "issue_followup"]
+    assert followup_sessions and followup_sessions[-1].omx_session_id == captured_session_id
+
+
+def test_dani_service_handles_opencode_session_missing_on_followup_resume(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from typing import cast
+
+    from dani.github import GitHubCLI
+    from dani.models import DaniConfig, NormalizedEvent
+    from dani.service import DaniService
+    from dani.storage import JsonStorage
+    from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI
+
+    class FakeProcess:
+        def __init__(self, exit_code: int = 0) -> None:
+            self._exit_code = exit_code
+
+        def poll(self) -> int:
+            return self._exit_code
+
+        def wait(self, timeout: float | None = None) -> int:
+            return self._exit_code
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    github_stub = FakeGitHubCLI()
+    invocation_count = {"count": 0}
+    captured_session_id = "ses_missingchain000000000ffff"
+
+    def fake_popen(cmd, **kwargs):
+        invocation_count["count"] += 1
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        prompt_body = prompt_file.read_text(encoding="utf-8")
+
+        stdout_path = Path(kwargs["stdout"].name)
+        stderr_path = Path(kwargs["stderr"].name)
+        import json as _json
+
+        if "--session" in script_text:
+            stdout_path.write_text("", encoding="utf-8")
+            stderr_path.write_text(f"Error: Session not found: {captured_session_id}\n", encoding="utf-8")
+            kwargs["stdout"].close()
+            kwargs["stderr"].close()
+            return FakeProcess(exit_code=1)
+
+        event = {"type": "step_start", "timestamp": 0, "sessionID": captured_session_id, "part": {}}
+        stdout_path.write_text(_json.dumps(event) + "\n", encoding="utf-8")
+        stderr_path.write_text("", encoding="utf-8")
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+
+        signature = next(
+            (fragment for fragment in prompt_body.splitlines() if fragment.startswith("<!-- dani:")),
+            None,
+        )
+        if signature is not None:
+            github_stub.issue_comment_map.setdefault(("acme/demo", 88), []).append({"body": signature})
+        return FakeProcess(exit_code=0)
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+
+    config = DaniConfig(
+        data_dir=tmp_path / ".dani",
+        webhook_secret="unit-test-secret",
+        agent_runtime="omo",
+    )
+    storage = JsonStorage(config)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github_stub),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=88,
+            actor_login="human",
+            payload={},
+            body="Initial",
+            title="Session-missing smoke",
+        )
+    )
+    service.wait_for_idle()
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=88,
+            actor_login="human",
+            payload={"issue": {"body": "Initial"}},
+            body="Ping",
+            title="Session-missing smoke",
+        )
+    )
+    service.wait_for_idle()
+
+    followup_jobs = [job for job in storage.list_jobs() if job.stage == "issue_followup"]
+    assert followup_jobs, "followup job should have been enqueued"
+    followup_job = followup_jobs[-1]
+    assert followup_job.status == "failed"
+    assert followup_job.metadata.get("error") == "rollout_missing"
+    warning_comments = [
+        comment
+        for comment in github_stub.issue_comment_map.get(("acme/demo", 88), [])
+        if "stage=session_lost" in comment.get("body", "")
+    ]
+    assert warning_comments, "service should have posted the session_lost warning comment"

--- a/tests/test_omo_runner.py
+++ b/tests/test_omo_runner.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from dani.agent_runner import AgentRunner
 from dani.errors import RolloutMissingError, TransientCapacityError
 from dani.omo_runner import OmoRunner
 
@@ -369,6 +370,7 @@ def test_dani_service_recovers_late_session_id_from_omo_runner_after_wait(
         storage=storage,
         github=cast(GitHubCLI, github_stub),
         dev_syncer=FakeGitDevSyncer(),
+        omx_runner=cast(AgentRunner, OmoRunner(config.run_dir)),
     )
     service.register_repo("acme/demo", str(tmp_path))
 
@@ -393,8 +395,25 @@ def test_dani_service_recovers_late_session_id_from_omo_runner_after_wait(
     )
 
 
-def test_build_agent_runner_factory_returns_omo_runner(tmp_path: Path) -> None:
+def test_build_agent_runner_factory_returns_omo_http_runner_by_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     from dani.agent_runner import build_agent_runner
+    from dani.omo_http_runner import OmoHttpRunner
+
+    monkeypatch.delenv("DANI_OMO_LEGACY_SUBPROCESS", raising=False)
+
+    runner = build_agent_runner("omo", tmp_path / "runs")
+
+    assert isinstance(runner, OmoHttpRunner)
+
+
+def test_build_agent_runner_factory_returns_legacy_omo_runner_when_env_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from dani.agent_runner import build_agent_runner
+
+    monkeypatch.setenv("DANI_OMO_LEGACY_SUBPROCESS", "1")
 
     runner = build_agent_runner("omo", tmp_path / "runs")
 
@@ -532,9 +551,32 @@ def test_omo_runner_resume_also_applies_ultrawork_prefix(monkeypatch: pytest.Mon
     assert captured_prompts == ["ultrawork\n\nContinue fixing"]
 
 
-def test_dani_service_instantiates_omo_runner_when_config_agent_runtime_is_omo(tmp_path: Path) -> None:
+def test_dani_service_instantiates_omo_http_runner_when_config_agent_runtime_is_omo(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from dani.models import DaniConfig
+    from dani.omo_http_runner import OmoHttpRunner
+    from dani.service import DaniService
+
+    monkeypatch.delenv("DANI_OMO_LEGACY_SUBPROCESS", raising=False)
+
+    config = DaniConfig(
+        data_dir=tmp_path / ".dani",
+        webhook_secret="unit-test-secret",
+        agent_runtime="omo",
+    )
+    service = DaniService(config)
+
+    assert isinstance(service.omx_runner, OmoHttpRunner)
+
+
+def test_dani_service_instantiates_legacy_omo_runner_when_env_forces_subprocess(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     from dani.models import DaniConfig
     from dani.service import DaniService
+
+    monkeypatch.setenv("DANI_OMO_LEGACY_SUBPROCESS", "1")
 
     config = DaniConfig(
         data_dir=tmp_path / ".dani",
@@ -622,6 +664,7 @@ def test_dani_service_runs_issue_request_through_omo_runner_end_to_end(
         storage=storage,
         github=cast(GitHubCLI, github_stub),
         dev_syncer=FakeGitDevSyncer(),
+        omx_runner=cast(AgentRunner, OmoRunner(config.run_dir)),
     )
     service.register_repo("acme/demo", str(tmp_path))
 
@@ -721,6 +764,7 @@ def test_dani_service_resumes_opencode_session_on_issue_followup_end_to_end(
         storage=storage,
         github=cast(GitHubCLI, github_stub),
         dev_syncer=FakeGitDevSyncer(),
+        omx_runner=cast(AgentRunner, OmoRunner(config.run_dir)),
     )
     service.register_repo("acme/demo", str(tmp_path))
 
@@ -855,6 +899,7 @@ def test_dani_service_handles_opencode_session_missing_on_followup_resume(
         storage=storage,
         github=cast(GitHubCLI, github_stub),
         dev_syncer=FakeGitDevSyncer(),
+        omx_runner=cast(AgentRunner, OmoRunner(config.run_dir)),
     )
     service.register_repo("acme/demo", str(tmp_path))
 

--- a/tests/test_omo_runner.py
+++ b/tests/test_omo_runner.py
@@ -231,7 +231,7 @@ def test_launch_writes_prompt_file_with_exact_prompt_content(monkeypatch: pytest
     monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
     monkeypatch.setattr(runner, "_capture_session_id", lambda **kwargs: None)
 
-    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
+    job = JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=1)
     runner.launch(tmp_path / "repo", job, "HELLO EXACT PROMPT BODY 12345")
 
     assert captured_prompts == ["ultrawork\n\nHELLO EXACT PROMPT BODY 12345"]
@@ -268,7 +268,7 @@ def test_resume_writes_prompt_file_with_exact_prompt_content(monkeypatch: pytest
 
     monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
 
-    job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=1)
+    job = JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=1)
     runner.resume(tmp_path / "repo", job, "RESUME EXACT PROMPT 67890", "ses_persisted")
 
     assert captured_prompts == ["ultrawork\n\nRESUME EXACT PROMPT 67890"]
@@ -436,12 +436,7 @@ def test_build_agent_runner_rejects_unknown_runtime(tmp_path: Path) -> None:
         build_agent_runner("nonsense", tmp_path / "runs")
 
 
-def test_omo_runner_always_prepends_ultrawork_prefix(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    from dani.models import JobRecord
-
-    runner = OmoRunner(run_dir=tmp_path / "runs")
-    captured_prompts: list[str] = []
-
+def _install_fake_omo_popen(monkeypatch: pytest.MonkeyPatch, captured_prompts: list[str]) -> None:
     class FakeProcess:
         def poll(self) -> int:
             return 0
@@ -466,12 +461,50 @@ def test_omo_runner_always_prepends_ultrawork_prefix(monkeypatch: pytest.MonkeyP
         return FakeProcess()
 
     monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+
+
+def test_omo_runner_implementation_stage_prepends_ultrawork_prefix(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from dani.models import JobRecord
+
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    captured_prompts: list[str] = []
+    _install_fake_omo_popen(monkeypatch, captured_prompts)
+
+    job = JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=1)
+    runner.launch(tmp_path / "repo", job, "Implement feature.")
+
+    assert captured_prompts == ["ultrawork\n\nImplement feature."]
+
+
+def test_omo_runner_issue_request_stage_skips_ultrawork_prefix(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from dani.models import JobRecord
+
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    captured_prompts: list[str] = []
+    _install_fake_omo_popen(monkeypatch, captured_prompts)
     monkeypatch.setattr(runner, "_capture_session_id", lambda **kwargs: None)
 
     job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
     runner.launch(tmp_path / "repo", job, "Investigate Issue #33.")
 
-    assert captured_prompts == ["ultrawork\n\nInvestigate Issue #33."]
+    assert captured_prompts == ["Investigate Issue #33."]
+
+
+def test_omo_runner_issue_followup_stage_skips_ultrawork_prefix_on_resume(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from dani.models import JobRecord
+
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    captured_prompts: list[str] = []
+    _install_fake_omo_popen(monkeypatch, captured_prompts)
+
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=1)
+    runner.resume(tmp_path / "repo", job, "Refine plan from follow-up", "ses_persisted_omo")
+
+    assert captured_prompts == ["Refine plan from follow-up"]
 
 
 def test_omo_runner_does_not_double_prefix_when_prompt_already_starts_with_ultrawork(
@@ -481,71 +514,24 @@ def test_omo_runner_does_not_double_prefix_when_prompt_already_starts_with_ultra
 
     runner = OmoRunner(run_dir=tmp_path / "runs")
     captured_prompts: list[str] = []
+    _install_fake_omo_popen(monkeypatch, captured_prompts)
 
-    class FakeProcess:
-        def poll(self) -> int:
-            return 0
-
-        def wait(self, timeout: float | None = None) -> int:
-            return 0
-
-        def terminate(self) -> None:
-            return None
-
-        def kill(self) -> None:
-            return None
-
-    def fake_popen(cmd, **kwargs):
-        script_path = Path(cmd[0])
-        script_text = script_path.read_text(encoding="utf-8")
-        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
-        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
-        captured_prompts.append(prompt_file.read_text(encoding="utf-8"))
-        kwargs["stdout"].close()
-        kwargs["stderr"].close()
-        return FakeProcess()
-
-    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
-    monkeypatch.setattr(runner, "_capture_session_id", lambda **kwargs: None)
-
-    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
+    job = JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=1)
     runner.launch(tmp_path / "repo", job, "ultrawork already leading")
 
     assert captured_prompts == ["ultrawork already leading"]
 
 
-def test_omo_runner_resume_also_applies_ultrawork_prefix(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_omo_runner_resume_implementation_stage_applies_ultrawork_prefix(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     from dani.models import JobRecord
 
     runner = OmoRunner(run_dir=tmp_path / "runs")
     captured_prompts: list[str] = []
+    _install_fake_omo_popen(monkeypatch, captured_prompts)
 
-    class FakeProcess:
-        def poll(self) -> int:
-            return 0
-
-        def wait(self, timeout: float | None = None) -> int:
-            return 0
-
-        def terminate(self) -> None:
-            return None
-
-        def kill(self) -> None:
-            return None
-
-    def fake_popen(cmd, **kwargs):
-        script_path = Path(cmd[0])
-        script_text = script_path.read_text(encoding="utf-8")
-        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
-        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
-        captured_prompts.append(prompt_file.read_text(encoding="utf-8"))
-        kwargs["stdout"].close()
-        kwargs["stderr"].close()
-        return FakeProcess()
-
-    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
-
-    job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=1)
+    job = JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=1)
     runner.resume(tmp_path / "repo", job, "Continue fixing", "ses_persisted_omo")
 
     assert captured_prompts == ["ultrawork\n\nContinue fixing"]

--- a/tests/test_omx_runner.py
+++ b/tests/test_omx_runner.py
@@ -4,6 +4,9 @@ import json
 import time
 from pathlib import Path
 
+import pytest
+
+from dani.errors import RolloutMissingError
 from dani.omx_runner import OmxRunner
 from dani.signatures import build_signature
 
@@ -102,3 +105,37 @@ def test_build_resume_script_uses_omx_exec_resume(tmp_path: Path) -> None:
     )
 
     assert "omx exec resume session-123 --dangerously-bypass-approvals-and-sandbox" in script
+
+
+def test_wait_raises_rollout_missing_error_when_resume_stderr_mentions_no_rollout_found(tmp_path: Path) -> None:
+    runner = OmxRunner(run_dir=tmp_path / "runs")
+    runtime_handle = "runtime-123"
+    runtime_dir = runner.run_dir / runtime_handle
+    runtime_dir.mkdir(parents=True)
+    stdout_path = tmp_path / "stdout.log"
+    stderr_path = runtime_dir / "stderr.log"
+    stdout_path.write_text("", encoding="utf-8")
+    stderr_path.write_text(
+        "Error: thread/resume failed: no rollout found for thread id 019d6829",
+        encoding="utf-8",
+    )
+    stdout_file = stdout_path.open("w", encoding="utf-8")
+    stderr_file = stderr_path.open("a", encoding="utf-8")
+    process = type(
+        "Process",
+        (),
+        {
+            "poll": lambda self: 1,
+            "terminate": lambda self: None,
+            "wait": lambda self, timeout=None: 1,
+            "kill": lambda self: None,
+        },
+    )()
+    runner._processes[runtime_handle] = (process, stdout_file, stderr_file)
+
+    try:
+        with pytest.raises(RolloutMissingError, match="no rollout found"):
+            runner.wait(runtime_handle)
+    finally:
+        stdout_file.close()
+        stderr_file.close()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -242,6 +242,85 @@ def test_issue_request_prompt_includes_existing_discussion_history() -> None:
     assert "Earlier context" in prompt
 
 
+def _issue_request_context() -> dict[str, object]:
+    return {
+        "repo": "acme/demo",
+        "local_path": "workspace/demo",
+        "issue_number": 7,
+        "issue_title": "Need a bot",
+        "issue_body": "Implement it",
+        "discussion": "",
+        "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
+    }
+
+
+def _issue_followup_context() -> dict[str, object]:
+    return {
+        "repo": "acme/demo",
+        "local_path": "workspace/demo",
+        "issue_number": 7,
+        "issue_title": "Need a bot",
+        "issue_body": "Implement it",
+        "comment_body": "User clarification",
+        "signature": "<!-- dani:stage=issue_followup;job=abc;issue=7 -->",
+    }
+
+
+def test_issue_request_prompt_declares_planning_only_role() -> None:
+    prompt = render_prompt("issue_request", _issue_request_context())
+
+    assert "PLANNING AGENT" in prompt
+    assert "DO NOT write code" in prompt
+    assert "your session ENDS" in prompt
+    assert "/approve" in prompt
+    assert "NEW, SEPARATE agent session" in prompt
+
+
+def test_issue_request_prompt_forbids_self_handoff_promises() -> None:
+    prompt = render_prompt("issue_request", _issue_request_context())
+
+    assert 'Do NOT promise to "create a PR"' in prompt
+    assert "the implementation agent will" in prompt
+    assert "does not inherit your reasoning trace" in prompt
+
+
+def test_issue_request_prompt_checklist_mentions_approve_gate_and_open_questions() -> None:
+    prompt = render_prompt("issue_request", _issue_request_context())
+
+    assert "Open questions for the human" in prompt
+    assert 'implementation starts only after a human comment containing "/approve"' in prompt
+
+
+def test_issue_followup_prompt_declares_planning_only_role() -> None:
+    prompt = render_prompt("issue_followup", _issue_followup_context())
+
+    assert "PLANNING AGENT" in prompt
+    assert "DO NOT write code" in prompt
+    assert "/approve" in prompt
+    assert "NEW, SEPARATE agent session" in prompt
+
+
+def test_issue_followup_prompt_forbids_self_handoff_promises() -> None:
+    prompt = render_prompt("issue_followup", _issue_followup_context())
+
+    assert 'Do NOT promise to "create a PR"' in prompt
+    assert "the implementation agent will" in prompt
+
+
+def test_issue_followup_prompt_keeps_signature_on_own_line() -> None:
+    prompt = render_prompt("issue_followup", _issue_followup_context())
+
+    signature_lines = [line for line in prompt.splitlines() if line.startswith("<!-- dani:")]
+    assert signature_lines, "issue_followup must emit the signature on its own line for downstream parsers"
+
+
+def test_issue_followup_prompt_for_omo_does_not_replace_ralph_substring() -> None:
+    prompt = render_prompt("issue_followup", _issue_followup_context(), runtime="omo")
+
+    assert "$ralph" not in prompt
+    assert "$code-review" not in prompt
+
+
 def test_review_round_prompt_requires_code_review_and_verification() -> None:
     prompt = render_prompt(
         "review_round",

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -77,6 +77,7 @@ def test_issue_request_prompt_uses_gh_instructions() -> None:
             "issue_number": 7,
             "issue_title": "Need a bot",
             "issue_body": "Implement it",
+            "discussion": "",
             "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
         },
     )
@@ -94,12 +95,31 @@ def test_issue_request_prompt_requires_ai_summary_and_expected_outcome() -> None
             "issue_number": 7,
             "issue_title": "Need a bot",
             "issue_body": "Implement it",
+            "discussion": "",
             "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
         },
     )
 
     assert "AI-understood issue summary" in prompt
     assert "Expected Outcome" in prompt
+
+
+def test_issue_request_prompt_includes_existing_discussion_history() -> None:
+    prompt = render_prompt(
+        "issue_request",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "[human]\nEarlier context",
+            "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
+        },
+    )
+
+    assert "Existing issue discussion history" in prompt
+    assert "Earlier context" in prompt
 
 
 def test_review_round_prompt_requires_code_review_and_verification() -> None:
@@ -120,6 +140,30 @@ def test_review_round_prompt_requires_code_review_and_verification() -> None:
     assert "actual verification" in prompt.lower()
     assert "concrete evidence appropriate for what you verified" in prompt
     assert "gh pr comment 5 --repo acme/demo --body-file <review-comment.md>" in prompt
+
+
+def test_review_round_prompt_for_external_contribution_mentions_contributor_ownership() -> None:
+    prompt = render_prompt(
+        "review_round",
+        {
+            "repo": "acme/demo",
+            "pr_number": 5,
+            "pr_title": "Feature",
+            "pr_body": "Body",
+            "discussion": "history",
+            "round_number": 2,
+            "round_total": 10,
+            "review_mode_note": (
+                "This is an external contribution PR. The contributor owns any follow-up implementation. "
+                "If the PR is ready to merge, include /approve in your review comment so dani can run the final verdict pass."
+            ),
+            "signature": "<!-- dani:stage=review_round;job=abc;pr=5;round=2 -->",
+        },
+    )
+
+    assert "2 / 10" in prompt
+    assert "external contribution pr" in prompt.lower()
+    assert "/approve" in prompt
 
 
 def test_final_verdict_prompt_contains_both_signatures() -> None:
@@ -183,3 +227,23 @@ def test_merge_conflict_resolution_prompt_requires_recheck_without_direct_merge(
     assert "Do not merge the PR yourself" in prompt
     assert "stage=merge_conflict_resolution" in prompt
     assert "gh pr comment 5 --repo acme/demo --body-file <merge-conflict-comment.md>" in prompt
+
+
+def test_human_escalation_prompt_mentions_review_limit_and_signature() -> None:
+    prompt = render_prompt(
+        "human_escalation",
+        {
+            "repo": "acme/demo",
+            "pr_number": 5,
+            "pr_title": "Feature",
+            "pr_body": "Body",
+            "discussion": "history",
+            "review_limit": 10,
+            "signature": "<!-- dani:stage=human_escalation;job=abc;pr=5 -->",
+        },
+    )
+
+    assert "10" in prompt
+    assert "human maintainer" in prompt.lower()
+    assert "gh pr comment 5 --repo acme/demo --body-file <human-escalation.md>" in prompt
+    assert "stage=human_escalation" in prompt

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -23,6 +23,51 @@ def test_implementation_prompt_keeps_ralph_literal() -> None:
     assert "<!-- dani:stage=implementation;job=abc;issue=7 -->" in prompt
 
 
+def test_implementation_prompt_for_omo_replaces_ralph_with_ultrawork() -> None:
+    prompt = render_prompt(
+        "implementation",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "approved",
+            "pr_context": "",
+            "pr_number": "",
+            "dev_branch": "dev",
+            "signature": "<!-- dani:stage=implementation;job=abc;issue=7 -->",
+            "signature_instructions": "Use this signature in the PR body:\n<!-- dani:stage=implementation;job=abc;issue=7 -->",
+        },
+        runtime="omo",
+    )
+
+    assert "$ralph" not in prompt
+    assert "ultrawork" in prompt
+
+
+def test_implementation_prompt_for_omx_explicit_runtime_still_keeps_ralph() -> None:
+    prompt = render_prompt(
+        "implementation",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "approved",
+            "pr_context": "",
+            "pr_number": "",
+            "dev_branch": "dev",
+            "signature": "<!-- dani:stage=implementation;job=abc;issue=7 -->",
+            "signature_instructions": "Use this signature in the PR body:\n<!-- dani:stage=implementation;job=abc;issue=7 -->",
+        },
+        runtime="omx",
+    )
+
+    assert "$ralph" in prompt
+
+
 def test_implementation_prompt_prefers_push_over_pr_edit_for_existing_pr() -> None:
     prompt = render_prompt(
         "implementation",
@@ -104,6 +149,81 @@ def test_issue_request_prompt_requires_ai_summary_and_expected_outcome() -> None
     assert "Expected Outcome" in prompt
 
 
+def test_issue_request_prompt_demands_evidence_based_plan() -> None:
+    prompt = render_prompt(
+        "issue_request",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "",
+            "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
+        },
+    )
+
+    assert "Evidence-based implementation plan" in prompt
+    assert "Concise implementation plan" not in prompt
+
+
+def test_issue_request_prompt_instructs_research_before_planning() -> None:
+    prompt = render_prompt(
+        "issue_request",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "",
+            "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
+        },
+    )
+
+    lowered = prompt.lower()
+    assert "search the codebase" in lowered or "explore the codebase" in lowered
+    assert "external" in lowered
+    assert "official docs" in lowered or "documentation" in lowered
+
+
+def test_issue_request_prompt_allows_explicit_not_found_statement() -> None:
+    prompt = render_prompt(
+        "issue_request",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "",
+            "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
+        },
+    )
+
+    lowered = prompt.lower()
+    assert "no existing reusable code found" in lowered
+    assert "no suitable external library found" in lowered
+
+
+def test_issue_request_prompt_specifies_citation_format() -> None:
+    prompt = render_prompt(
+        "issue_request",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "",
+            "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
+        },
+    )
+
+    assert "path/to/file.py:line" in prompt
+    assert "URL" in prompt
+
+
 def test_issue_request_prompt_includes_existing_discussion_history() -> None:
     prompt = render_prompt(
         "issue_request",
@@ -140,6 +260,44 @@ def test_review_round_prompt_requires_code_review_and_verification() -> None:
     assert "actual verification" in prompt.lower()
     assert "concrete evidence appropriate for what you verified" in prompt
     assert "gh pr comment 5 --repo acme/demo --body-file <review-comment.md>" in prompt
+
+
+def test_review_round_prompt_for_omo_delegates_to_momus_plan_critic() -> None:
+    prompt = render_prompt(
+        "review_round",
+        {
+            "repo": "acme/demo",
+            "pr_number": 5,
+            "pr_title": "Feature",
+            "pr_body": "Body",
+            "discussion": "history",
+            "round_number": 2,
+            "signature": "<!-- dani:stage=review_round;job=abc;pr=5;round=2 -->",
+        },
+        runtime="omo",
+    )
+
+    assert "$code-review" not in prompt
+    assert "Momus-Plan-Critic" in prompt
+    assert "subagent" in prompt.lower()
+
+
+def test_review_round_prompt_for_omo_does_not_mention_ralph_command() -> None:
+    prompt = render_prompt(
+        "review_round",
+        {
+            "repo": "acme/demo",
+            "pr_number": 5,
+            "pr_title": "Feature",
+            "pr_body": "Body",
+            "discussion": "history",
+            "round_number": 2,
+            "signature": "<!-- dani:stage=review_round;job=abc;pr=5;round=2 -->",
+        },
+        runtime="omo",
+    )
+
+    assert "$ralph" not in prompt
 
 
 def test_review_round_prompt_for_external_contribution_mentions_contributor_ownership() -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -154,6 +154,28 @@ def test_failed_job_releases_lock() -> None:
     ]
 
 
+def test_superseded_job_releases_lock() -> None:
+    """A superseded locked job releases the issue lock so other issues can proceed."""
+    execution_order: list[tuple[int, str, str]] = []
+    lock = threading.Lock()
+
+    def handler(job: JobRecord) -> None:
+        with lock:
+            execution_order.append((job.issue_number, job.stage, job.status))  # type: ignore[arg-type]
+        if job.issue_number == 1:
+            job.status = "superseded"
+
+    manager = RepoQueueManager(handler)
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=1))
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=2))
+    manager.join_all()
+
+    assert execution_order == [
+        (1, "implementation", "queued"),
+        (2, "implementation", "queued"),
+    ]
+
+
 def test_handler_exception_releases_lock() -> None:
     """If the handler raises an unhandled exception, the issue lock is still released."""
     execution_order: list[tuple[int, str]] = []

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -6,10 +6,10 @@ from unittest.mock import patch
 
 import pytest
 
+from dani.agent_runner import AgentRunner
 from dani.errors import TransientCapacityError, check_transient_capacity_error
 from dani.github import GitHubCLI
 from dani.models import DaniConfig, NormalizedEvent
-from dani.omx_runner import OmxRunner
 from dani.service import RETRY_BACKOFF_SECONDS, DaniService
 from dani.storage import JsonStorage
 from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI, FakeOmxRunner
@@ -30,7 +30,7 @@ def make_service(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(OmxRunner, omx_runner),
+        omx_runner=cast(AgentRunner, omx_runner),
         dev_syncer=dev_syncer or FakeGitDevSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -187,3 +187,33 @@ def test_transient_error_with_side_effect_already_posted_completes(mock_sleep: o
     assert job.metadata.get("note") == "side_effect_already_posted"
     # Should NOT have retried — only 1 launch
     assert len(omx_runner.launches) == 1
+
+
+@patch("dani.service.time.sleep")
+def test_restart_issue_request_with_stale_signed_comments_does_not_false_complete_on_transient(
+    mock_sleep: object, tmp_path: Path
+) -> None:
+    service, github, _ = make_service(tmp_path)
+    stale_signature = "<!-- dani:stage=issue_request;job=stale-job;issue=11 -->"
+    github.add_issue_signature("acme/demo", 11, stale_signature)
+
+    original_launch = service.omx_runner.launch
+
+    def launch_without_new_side_effect(repo_path: Path, job, prompt: str):
+        session = original_launch(repo_path, job, prompt)
+        github.issue_comment_map[("acme/demo", 11)] = [{"body": stale_signature}]
+        return session
+
+    service.omx_runner.launch = launch_without_new_side_effect  # type: ignore[assignment]
+
+    def wait_that_always_fails(runtime_handle: str, **kwargs: object) -> None:
+        raise TransientCapacityError(_CAPACITY_MSG, _CAPACITY_MSG)
+
+    service.omx_runner.wait = wait_that_always_fails  # type: ignore[assignment]
+
+    service.handle_event(_issue_event())
+    service.wait_for_idle()
+
+    job = service.storage.list_jobs()[0]
+    assert job.status == "failed"
+    assert job.metadata.get("note") != "side_effect_already_posted"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -92,3 +92,43 @@ def test_github_webhook_endpoint_queues_dev_sync_on_main_push(tmp_path: Path) ->
 
     assert response.status_code == 200
     assert response.json()["stage"] == "dev_sync"
+
+
+def test_github_webhook_endpoint_dedupes_duplicate_external_pr_delivery(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    github = FakeGitHubCLI()
+    omx_runner = FakeOmxRunner(github)
+    service = DaniService(
+        config, storage=JsonStorage(config), github=cast(GitHubCLI, github), omx_runner=cast(OmxRunner, omx_runner)
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+    client = TestClient(create_app(service))
+    payload = {
+        "action": "synchronize",
+        "repository": {"full_name": "acme/demo"},
+        "sender": {"login": "contributor"},
+        "pull_request": {
+            "number": 21,
+            "title": "Feature/#21",
+            "body": "Implements #21",
+            "base": {"ref": "dev"},
+            "head": {"ref": "feature/#21", "sha": "sha-21-2"},
+        },
+    }
+    body = json.dumps(payload).encode("utf-8")
+    headers = {
+        "x-github-event": "pull_request",
+        "x-github-delivery": "delivery-21",
+        "x-hub-signature-256": _signature(TEST_SECRET, body),
+    }
+
+    first = client.post("/webhook", content=body, headers=headers)
+    second = client.post("/webhook", content=body, headers=headers)
+    service.wait_for_idle()
+
+    assert first.status_code == 200
+    assert first.json()["stage"] == "review_round"
+    assert second.status_code == 200
+    assert second.json() == {"status": "ignored", "reason": "duplicate_external_pr_event"}
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=21)
+    assert [job.review_round for job in review_jobs] == [1]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,10 +6,10 @@ from typing import cast
 
 from fastapi.testclient import TestClient
 
+from dani.agent_runner import AgentRunner
 from dani.git_sync import DevSyncOutcome
 from dani.github import GitHubCLI
 from dani.models import DaniConfig
-from dani.omx_runner import OmxRunner
 from dani.server import create_app
 from dani.service import DaniService
 from dani.storage import JsonStorage
@@ -28,7 +28,7 @@ def test_github_webhook_endpoint_accepts_valid_signature(tmp_path: Path) -> None
     github = FakeGitHubCLI()
     omx_runner = FakeOmxRunner(github)
     service = DaniService(
-        config, storage=JsonStorage(config), github=cast(GitHubCLI, github), omx_runner=cast(OmxRunner, omx_runner)
+        config, storage=JsonStorage(config), github=cast(GitHubCLI, github), omx_runner=cast(AgentRunner, omx_runner)
     )
     service.register_repo("acme/demo", str(tmp_path))
     client = TestClient(create_app(service))
@@ -65,7 +65,7 @@ def test_github_webhook_endpoint_queues_dev_sync_on_main_push(tmp_path: Path) ->
         config,
         storage=JsonStorage(config),
         github=cast(GitHubCLI, github),
-        omx_runner=cast(OmxRunner, omx_runner),
+        omx_runner=cast(AgentRunner, omx_runner),
         dev_syncer=FakeSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))
@@ -99,7 +99,7 @@ def test_github_webhook_endpoint_dedupes_duplicate_external_pr_delivery(tmp_path
     github = FakeGitHubCLI()
     omx_runner = FakeOmxRunner(github)
     service = DaniService(
-        config, storage=JsonStorage(config), github=cast(GitHubCLI, github), omx_runner=cast(OmxRunner, omx_runner)
+        config, storage=JsonStorage(config), github=cast(GitHubCLI, github), omx_runner=cast(AgentRunner, omx_runner)
     )
     service.register_repo("acme/demo", str(tmp_path))
     client = TestClient(create_app(service))

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1676,6 +1676,63 @@ def test_dani_retarget_comment_received_back_is_ignored_no_action(tmp_path: Path
     assert result == {"status": "ignored", "reason": "retarget_request_no_action"}
 
 
+def test_release_pr_from_dev_to_main_is_silently_ignored_no_retarget_comment(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=18,
+            actor_login="maintainer",
+            payload={},
+            body="Release dev into main",
+            title="Release PR",
+            base_branch="main",
+            head_branch="dev",
+            is_pull_request=True,
+        )
+    )
+
+    assert result == {"status": "ignored", "reason": "release_loop_excluded"}
+    assert github.pr_comment_map.get(("acme/demo", 18), []) == [], (
+        "release PR (dev -> main) must not trigger a retarget comment"
+    )
+
+
+def test_external_fork_pr_to_dev_proceeds_to_review_round(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=19,
+            actor_login="outside-contributor",
+            payload={"pull_request": {"head": {"sha": "fork-sha-19"}}},
+            body="Fixes a bug in the docs\n\nCloses #42",
+            title="Docs fix from fork",
+            base_branch="dev",
+            head_branch="fix/docs",
+            commit_sha="fork-sha-19",
+            is_pull_request=True,
+        )
+    )
+
+    assert result.get("status") == "queued"
+    assert result.get("stage") == "review_round"
+    assert github.pr_comment_map.get(("acme/demo", 19), []) == [], (
+        "external PR already targeting dev must not get a retarget comment"
+    )
+    jobs = [job for job in service.storage.list_jobs() if job.pr_number == 19]
+    assert jobs, "external fork PR to dev should enqueue a review_round job"
+    assert jobs[0].metadata.get("external_contribution") is True, (
+        "external fork PR must be flagged external_contribution=True in job metadata"
+    )
+
+
 def test_main_push_queues_dev_sync(tmp_path: Path) -> None:
     dev_syncer = FakeGitDevSyncer()
     service, _, _ = make_service(tmp_path, dev_syncer=dev_syncer)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1539,8 +1539,8 @@ def test_bootstrap_repo_skips_issues_with_existing_issue_request_signature(tmp_p
     assert only_job.stage == "issue_request"
 
 
-def test_pull_request_opened_to_main_is_ignored(tmp_path: Path) -> None:
-    service, _, _ = make_service(tmp_path)
+def test_external_pr_to_main_posts_retarget_comment_and_is_ignored(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
 
     result = service.handle_event(
         NormalizedEvent(
@@ -1558,7 +1558,122 @@ def test_pull_request_opened_to_main_is_ignored(tmp_path: Path) -> None:
         )
     )
 
+    assert result == {"status": "ignored", "reason": "non_dev_target_branch"}
+    posted = github.pr_comment_map.get(("acme/demo", 13), [])
+    assert len(posted) == 1
+    assert "<!-- dani:stage=retarget_request;pr=13 -->" in posted[0]["body"]
+    assert "`dev`" in posted[0]["body"]
+    assert "`main`" in posted[0]["body"]
+
+
+def test_external_pr_to_non_dev_feature_branch_posts_retarget_comment(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=14,
+            actor_login="contributor",
+            payload={},
+            body="some body",
+            title="External feature PR",
+            base_branch="feature/legacy",
+            head_branch="contributor:fix",
+            is_pull_request=True,
+        )
+    )
+
+    assert result == {"status": "ignored", "reason": "non_dev_target_branch"}
+    posted = github.pr_comment_map.get(("acme/demo", 14), [])
+    assert len(posted) == 1
+    assert "`feature/legacy`" in posted[0]["body"]
+
+
+def test_external_pr_retarget_comment_is_idempotent_across_resyncs(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    base_event = NormalizedEvent(
+        kind="pull_request_opened",
+        repo_full_name="acme/demo",
+        action="opened",
+        number=15,
+        actor_login="contributor",
+        payload={},
+        body="contribution",
+        title="External PR",
+        base_branch="main",
+        head_branch="contributor:fix",
+        is_pull_request=True,
+    )
+
+    service.handle_event(base_event)
+    sync_event = NormalizedEvent(
+        kind="pull_request_opened",
+        repo_full_name="acme/demo",
+        action="synchronize",
+        number=15,
+        actor_login="contributor",
+        payload={},
+        body="contribution",
+        title="External PR",
+        base_branch="main",
+        head_branch="contributor:fix",
+        is_pull_request=True,
+    )
+    service.handle_event(sync_event)
+    service.handle_event(sync_event)
+
+    posted = github.pr_comment_map.get(("acme/demo", 15), [])
+    assert len(posted) == 1, f"retarget comment must post exactly once across re-fires; got {len(posted)} comments"
+
+
+def test_agent_managed_pr_to_main_does_not_post_retarget_comment(tmp_path: Path) -> None:
+    from dani.signatures import build_signature as _build_sig
+
+    service, github, _ = make_service(tmp_path)
+    agent_signature = _build_sig(stage="implementation", job="agent-job", issue=99, pr=16)
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=16,
+            actor_login="dani-bot",
+            payload={},
+            body=f"Implementation PR\n\n{agent_signature}",
+            title="Agent PR to main (defensive)",
+            base_branch="main",
+            head_branch="feature/#99",
+            is_pull_request=True,
+        )
+    )
+
     assert result == {"status": "ignored", "reason": "release_loop_excluded"}
+    posted = github.pr_comment_map.get(("acme/demo", 16), [])
+    assert posted == [], "agent-managed PR to main must not get the retarget comment"
+
+
+def test_dani_retarget_comment_received_back_is_ignored_no_action(tmp_path: Path) -> None:
+    from dani.signatures import build_signature as _build_sig
+
+    service, _, _ = make_service(tmp_path)
+    retarget_sig = _build_sig(stage="retarget_request", pr=17)
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=17,
+            actor_login="dani-bot",
+            payload={},
+            body=f"Thanks for the contribution!\n\n{retarget_sig}",
+            title="External PR",
+            is_pull_request=True,
+        )
+    )
+
+    assert result == {"status": "ignored", "reason": "retarget_request_no_action"}
 
 
 def test_main_push_queues_dev_sync(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,8 +1,10 @@
+import threading
 from pathlib import Path
 from typing import cast
 
 import pytest
 
+from dani.errors import RolloutMissingError
 from dani.github import GitHubCLI
 from dani.models import DaniConfig, JobRecord, NormalizedEvent
 from dani.omx_runner import OmxRunner
@@ -14,13 +16,36 @@ from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI, FakeOmxRunner
 TEST_SECRET = "unit-test-secret"
 
 
+def add_exact_review_signature(github: FakeGitHubCLI, job: JobRecord) -> None:
+    signature_fields: dict[str, str | int] = {
+        "stage": "review_round",
+        "job": job.id,
+        "pr": int(job.pr_number or 0),
+        "round": job.review_round or 1,
+    }
+    if job.issue_number is not None:
+        signature_fields["issue"] = int(job.issue_number)
+    github.add_pr_signature(
+        job.repo_full_name,
+        int(job.pr_number or 0),
+        build_signature(**signature_fields),
+    )
+
+
 def make_service(
     tmp_path: Path, *, dev_syncer: FakeGitDevSyncer | None = None
 ) -> tuple[DaniService, FakeGitHubCLI, FakeOmxRunner]:
+    class ExactReviewSignatureOmxRunner(FakeOmxRunner):
+        def launch(self, repo_path: Path, job: JobRecord, prompt: str):
+            session = super().launch(repo_path, job, prompt)
+            if job.stage == "review_round" and job.issue_number is not None:
+                add_exact_review_signature(self.github, job)
+            return session
+
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
-    omx_runner = FakeOmxRunner(github)
+    omx_runner = ExactReviewSignatureOmxRunner(github)
     service = DaniService(
         config,
         storage=storage,
@@ -30,6 +55,47 @@ def make_service(
     )
     service.register_repo("acme/demo", str(tmp_path))
     return service, github, omx_runner
+
+
+def make_pr_event(
+    *,
+    pr_number: int,
+    action: str,
+    body: str,
+    actor_login: str = "contributor",
+    commit_sha: str | None = None,
+    delivery_id: str | None = None,
+) -> NormalizedEvent:
+    head_sha = commit_sha or f"sha-{pr_number}-{action}"
+    return NormalizedEvent(
+        kind="pull_request_opened",
+        repo_full_name="acme/demo",
+        action=action,
+        number=pr_number,
+        actor_login=actor_login,
+        payload={"pull_request": {"head": {"sha": head_sha}}},
+        body=body,
+        title=f"Feature/#{pr_number}",
+        base_branch="dev",
+        head_branch=f"feature/#{pr_number}",
+        commit_sha=head_sha,
+        is_pull_request=True,
+        delivery_id=delivery_id,
+    )
+
+
+def make_pr_comment_event(*, pr_number: int, body: str, actor_login: str = "agent") -> NormalizedEvent:
+    return NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=pr_number,
+        actor_login=actor_login,
+        payload={},
+        body=body,
+        title=f"Feature/#{pr_number}",
+        is_pull_request=True,
+    )
 
 
 def test_issue_request_persists_omx_session_id(tmp_path: Path) -> None:
@@ -51,6 +117,29 @@ def test_issue_request_persists_omx_session_id(tmp_path: Path) -> None:
 
     session = service.storage.list_sessions()[0]
     assert session.omx_session_id == "omx-" + session.job_id
+
+
+def test_issue_request_verification_requires_exact_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_request", issue_number=21)
+    expected_signature = build_signature(stage="issue_request", job=job.id, issue=21)
+    github.add_issue_signature("acme/demo", 21, build_signature(stage="issue_request", job="stale-job", issue=21))
+    github.add_issue_signature("acme/demo", 21, expected_signature)
+
+    service._verify_side_effect(repo, job)
+
+
+def test_issue_request_verification_rejects_stale_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_request", issue_number=21)
+    github.add_issue_signature("acme/demo", 21, build_signature(stage="issue_request", job="stale-job", issue=21))
+
+    with pytest.raises(RuntimeError, match="issue-request-comment-missing"):
+        service._verify_side_effect(repo, job)
 
 
 def test_issue_opened_queues_issue_request(tmp_path: Path) -> None:
@@ -136,6 +225,307 @@ def test_general_issue_comment_without_existing_issue_session_is_ignored(tmp_pat
     assert omx_runner.resumes == []
 
 
+def test_issue_followup_verification_requires_exact_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_followup", issue_number=31)
+    expected_signature = build_signature(stage="issue_followup", job=job.id, issue=31)
+    github.add_issue_signature("acme/demo", 31, build_signature(stage="issue_followup", job="stale-job", issue=31))
+    github.add_issue_signature("acme/demo", 31, expected_signature)
+
+    service._verify_side_effect(repo, job)
+
+
+def test_issue_followup_verification_rejects_stale_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_followup", issue_number=31)
+    github.add_issue_signature("acme/demo", 31, build_signature(stage="issue_followup", job="stale-job", issue=31))
+
+    with pytest.raises(RuntimeError, match="issue-followup-comment-missing"):
+        service._verify_side_effect(repo, job)
+
+
+def test_issue_followup_rollout_missing_marks_job_failed_and_posts_restart_warning(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=33,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    omx_runner.set_resume_failure(
+        RolloutMissingError(
+            "thread/resume failed: no rollout found for thread id 019d6829",
+            "no rollout found",
+        )
+    )
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=33,
+            actor_login="human",
+            payload={"issue": {"body": "Need automation"}},
+            body="Please continue.",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    job = service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=33)[0]
+    assert job.status == "failed"
+    assert job.metadata["error"] == "rollout_missing"
+    assert "thread/resume failed" in job.metadata["error_detail"]
+
+    warning_signature = build_signature(stage="session_lost", issue=33)
+    warning_comments = github.find_comments_by_signature(
+        "acme/demo", 33, kind="issue", signature_fragment=warning_signature
+    )
+    assert len(warning_comments) == 1
+    assert "dani restart-issue acme/demo 33" in warning_comments[0]["body"]
+    latest_comment = github.latest_signature_comment("acme/demo", 33, kind="issue")
+    assert latest_comment is not None
+    assert latest_comment[1]["stage"] == "session_lost"
+    assert latest_comment[1]["issue"] == "33"
+
+
+def test_issue_followup_rollout_missing_warning_comment_is_posted_only_once(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=34,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+    omx_runner.set_resume_failure(
+        RolloutMissingError(
+            "thread/resume failed: no rollout found for thread id 019d6829",
+            "no rollout found",
+        )
+    )
+
+    event = NormalizedEvent(
+        kind="issue_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=34,
+        actor_login="human",
+        payload={"issue": {"body": "Need automation"}},
+        body="Please continue.",
+        title="Need automation",
+    )
+
+    service.handle_event(event)
+    service.wait_for_idle()
+    service.handle_event(event)
+    service.wait_for_idle()
+
+    warning_comments = github.find_comments_by_signature(
+        "acme/demo",
+        34,
+        kind="issue",
+        signature_fragment=build_signature(stage="session_lost", issue=34),
+    )
+    assert len(warning_comments) == 1
+    matching_keys = [
+        key
+        for key in service.storage.snapshot()["processed_events"]["keys"]
+        if "stage=session_lost" in key and "issue=34" in key
+    ]
+    assert len(matching_keys) == 1
+    failed_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=34)
+    assert len(failed_jobs) == 2
+    assert all(job.status == "failed" for job in failed_jobs)
+
+
+def test_issue_followup_rollout_missing_retries_warning_after_comment_post_failure(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=35,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+    omx_runner.set_resume_failure(
+        RolloutMissingError(
+            "thread/resume failed: no rollout found for thread id 019d6829",
+            "no rollout found",
+        )
+    )
+
+    original_create_issue_comment = github.create_issue_comment
+    attempts = 0
+
+    def flaky_create_issue_comment(repo_full_name: str, issue_number: int, body: str) -> dict[str, object]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            msg = "temporary GitHub failure"
+            raise RuntimeError(msg)
+        return original_create_issue_comment(repo_full_name, issue_number, body)
+
+    github.create_issue_comment = flaky_create_issue_comment  # type: ignore[assignment]
+
+    event = NormalizedEvent(
+        kind="issue_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=35,
+        actor_login="human",
+        payload={"issue": {"body": "Need automation"}},
+        body="Please continue.",
+        title="Need automation",
+    )
+
+    service.handle_event(event)
+    service.wait_for_idle()
+    service.handle_event(event)
+    service.wait_for_idle()
+
+    warning_comments = github.find_comments_by_signature(
+        "acme/demo",
+        35,
+        kind="issue",
+        signature_fragment=build_signature(stage="session_lost", issue=35),
+    )
+    assert attempts == 2
+    assert len(warning_comments) == 1
+    matching_keys = [
+        key
+        for key in service.storage.snapshot()["processed_events"]["keys"]
+        if "stage=session_lost" in key and "issue=35" in key
+    ]
+    assert len(matching_keys) == 1
+
+
+def test_restart_issue_supersedes_existing_jobs_and_enqueues_new_issue_request(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    service.queue_manager.submit = lambda job: None  # type: ignore[assignment]
+    stale_request = JobRecord(
+        repo_full_name="acme/demo",
+        stage="issue_request",
+        issue_number=41,
+        status="completed",
+        metadata={"title": "Restart me", "body": "Original body"},
+    )
+    stale_followup = JobRecord(
+        repo_full_name="acme/demo",
+        stage="issue_followup",
+        issue_number=41,
+        status="failed",
+        metadata={"omx_session_id": "omx-stale", "title": "Restart me", "body": "Original body"},
+    )
+    untouched = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=99, status="completed")
+    service.storage.create_job(stale_request)
+    service.storage.create_job(stale_followup)
+    service.storage.create_job(untouched)
+    github.issue_comment_map[("acme/demo", 41)] = [
+        {"body": "Earlier user context", "user": {"login": "human"}},
+        {"body": "Earlier dani reply", "user": {"login": "dani"}},
+    ]
+
+    new_job = service.restart_issue("acme/demo", 41)
+
+    refreshed_request = service.storage.get_job(stale_request.id)
+    refreshed_followup = service.storage.get_job(stale_followup.id)
+    untouched_job = service.storage.get_job(untouched.id)
+    assert refreshed_request is not None and refreshed_request.status == "superseded"
+    assert refreshed_followup is not None and refreshed_followup.status == "superseded"
+    assert untouched_job is not None and untouched_job.status == "completed"
+    assert new_job.stage == "issue_request"
+    assert new_job.status == "queued"
+    assert new_job.issue_number == 41
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    prompt = service._build_prompt(repo, new_job)
+    assert "Earlier user context" in prompt
+    assert "Earlier dani reply" in prompt
+
+
+def test_issue_comment_with_ignore_signature_is_ignored_before_followup(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=36,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=36,
+            actor_login="human",
+            payload={"issue": {"body": "Need automation"}},
+            body="Please ignore this.\n<!-- dani:stage=ignore -->",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "comment_opt_out"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=36) == []
+    assert omx_runner.resumes == []
+
+
+def test_issue_comment_with_ignore_command_overrides_approve(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=37,
+            actor_login="human",
+            payload={"issue": {"body": "context"}},
+            body="/approve\n/dani ignore",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "comment_opt_out"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", issue_number=37) == []
+    assert omx_runner.launches == []
+
+
 def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
     service, _, omx_runner = make_service(tmp_path)
     event = NormalizedEvent(
@@ -210,6 +600,344 @@ def test_pr_opened_from_implementation_signature_queues_review_round(tmp_path: P
     assert result["stage"] == "review_round"
     assert review_jobs[0].review_round == 1
     assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_external_pr_opened_queues_review_round(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == [1]
+    assert review_jobs[0].metadata["external_contribution"] is True
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_external_pr_new_commit_queues_another_review_round(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+
+    result = service.handle_event(make_pr_event(pr_number=88, action="synchronize", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == [1, 2]
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_duplicate_external_pr_activity_event_is_ignored(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21", commit_sha="sha-1"))
+    service.wait_for_idle()
+
+    first = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-2")
+    )
+    service.wait_for_idle()
+    duplicate = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-2")
+    )
+    service.wait_for_idle()
+
+    assert first["stage"] == "review_round"
+    assert duplicate == {"status": "ignored", "reason": "duplicate_external_pr_event"}
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == [1, 2]
+    assert len(omx_runner.launches) == 2
+
+
+def test_duplicate_external_pr_activity_does_not_consume_review_limit(tmp_path: Path) -> None:
+    service, _, _ = make_service(tmp_path)
+    for round_number in range(1, 10):
+        service.storage.create_job(
+            JobRecord(
+                repo_full_name="acme/demo",
+                stage="review_round",
+                pr_number=88,
+                review_round=round_number,
+                metadata={"external_contribution": True},
+                status="completed",
+            )
+        )
+
+    first = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-10")
+    )
+    service.wait_for_idle()
+    duplicate = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-10")
+    )
+    service.wait_for_idle()
+
+    assert first["stage"] == "review_round"
+    assert duplicate == {"status": "ignored", "reason": "duplicate_external_pr_event"}
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs if job.metadata.get("external_contribution")] == list(range(1, 11))
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
+
+
+def test_external_pr_fallback_dedupe_key_is_repo_scoped(tmp_path: Path) -> None:
+    service, _, _ = make_service(tmp_path)
+    service.register_repo("acme/other", str(tmp_path))
+
+    first = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="synchronize",
+            number=88,
+            actor_login="contributor",
+            payload={"pull_request": {"head": {"sha": "shared-sha"}}},
+            body="Implements #21",
+            title="Feature/#21",
+            base_branch="dev",
+            head_branch="feature/#21",
+            commit_sha="shared-sha",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    second = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/other",
+            action="synchronize",
+            number=88,
+            actor_login="contributor",
+            payload={"pull_request": {"head": {"sha": "shared-sha"}}},
+            body="Implements #21",
+            title="Feature/#21",
+            base_branch="dev",
+            head_branch="feature/#21",
+            commit_sha="shared-sha",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    assert first["stage"] == "review_round"
+    assert second["stage"] == "review_round"
+    assert [
+        job.review_round for job in service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round")
+    ] == [1]
+    assert [
+        job.review_round for job in service.storage.find_jobs(repo_full_name="acme/other", stage="review_round")
+    ] == [1]
+
+
+def test_external_pr_review_requested_queues_review_round(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(make_pr_event(pr_number=91, action="review_requested", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_external_review_comment_does_not_queue_implementation(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+    review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
+
+    result = service.handle_event(
+        make_pr_comment_event(
+            pr_number=88,
+            body=build_signature(stage="review_round", job=review_job.id, pr=88, round=1),
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "updated", "stage": "review_round"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
+    assert len(omx_runner.launches) == 1
+    assert github.merged == []
+
+
+def test_external_review_approve_comment_queues_final_verdict(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+    review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
+
+    result = service.handle_event(
+        make_pr_comment_event(
+            pr_number=88,
+            body=f"/approve\n{build_signature(stage='review_round', job=review_job.id, pr=88, round=1)}",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result["stage"] == "final_verdict"
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
+    assert len(service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=88)) == 1
+    assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+    assert github.merged == []
+
+
+def test_external_final_verdict_approve_merges_without_implementation_job(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        make_pr_comment_event(
+            pr_number=88,
+            body=build_signature(stage="final_verdict", job="verdict-1", pr=88, verdict="APPROVE"),
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "merged", "pr_number": 88}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
+    assert omx_runner.launches == []
+    assert github.merged == [("acme/demo", 88)]
+
+
+def test_external_pr_escalates_after_ten_review_passes(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    for _ in range(10):
+        service.storage.create_job(
+            JobRecord(
+                repo_full_name="acme/demo",
+                stage="review_round",
+                pr_number=88,
+                metadata={"external_contribution": True},
+                status="completed",
+            )
+        )
+
+    result = service.handle_event(make_pr_event(pr_number=88, action="synchronize", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "human_escalation"
+    escalation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)
+    assert len(escalation_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "human_escalation"
+
+
+def test_external_review_comment_queues_human_escalation_on_tenth_completed_pass(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    for round_number in range(1, 11):
+        action = "opened" if round_number == 1 else "synchronize"
+        result = service.handle_event(
+            make_pr_event(pr_number=88, action=action, body="Implements #21", commit_sha=f"sha-{round_number}")
+        )
+        service.wait_for_idle()
+
+        assert result["stage"] == "review_round"
+        review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
+        comment_result = service.handle_event(
+            make_pr_comment_event(
+                pr_number=88,
+                body=build_signature(stage="review_round", job=review_job.id, pr=88, round=round_number),
+            )
+        )
+        service.wait_for_idle()
+
+        if round_number < 10:
+            assert comment_result == {"status": "updated", "stage": "review_round"}
+            assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
+            continue
+
+        assert comment_result["stage"] == "human_escalation"
+
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == list(range(1, 11))
+    assert all(job.status == "completed" for job in review_jobs)
+
+    escalation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)
+    assert len(escalation_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "human_escalation"
+
+    post_limit = service.handle_event(
+        make_pr_event(
+            pr_number=88,
+            action="synchronize",
+            body="Implements #21",
+            commit_sha="sha-11",
+        )
+    )
+    service.wait_for_idle()
+
+    assert post_limit == {"status": "ignored", "reason": "human_review_required"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88) == review_jobs
+    assert len(service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)) == 1
+
+
+def test_external_pr_unique_activity_never_queues_an_eleventh_automated_review(tmp_path: Path) -> None:
+    class BlockingOmxRunner(FakeOmxRunner):
+        def __init__(self, github: FakeGitHubCLI) -> None:
+            super().__init__(github)
+            self.review_started = threading.Event()
+            self.release_review = threading.Event()
+
+        def launch(self, repo_path: Path, job: JobRecord, prompt: str):
+            session = super().launch(repo_path, job, prompt)
+            if job.stage == "review_round":
+                add_exact_review_signature(self.github, job)
+            return session
+
+        def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
+            if (
+                runtime_handle.startswith("runtime-")
+                and self.launches
+                and self.launches[-1]["job"].stage == "review_round"
+            ):
+                self.review_started.set()
+                self.release_review.wait(timeout=timeout_seconds)
+
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    github = FakeGitHubCLI()
+    omx_runner = BlockingOmxRunner(github)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github),
+        omx_runner=cast(OmxRunner, omx_runner),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    opened = service.handle_event(
+        make_pr_event(pr_number=88, action="opened", body="Implements #21", commit_sha="sha-1")
+    )
+    assert opened["stage"] == "review_round"
+    assert omx_runner.review_started.wait(timeout=1)
+
+    results = []
+    for round_number in range(2, 12):
+        results.append(
+            service.handle_event(
+                make_pr_event(
+                    pr_number=88,
+                    action="synchronize",
+                    body="Implements #21",
+                    commit_sha=f"sha-{round_number}",
+                )
+            )
+        )
+
+    assert all(result["stage"] == "review_round" for result in results[:9])
+    assert results[9] == {"status": "ignored", "reason": "external_review_limit_pending"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
+
+    omx_runner.release_review.set()
+    service.wait_for_idle()
+
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == list(range(1, 11))
+    assert all(job.status == "completed" for job in review_jobs)
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88) == review_jobs
+    assert [job.review_round for job in review_jobs] == list(range(1, 11))
 
 
 def test_review_chain_reaches_verdict_and_merges_on_approve(tmp_path: Path) -> None:
@@ -343,6 +1071,53 @@ def test_approve_verdict_with_merge_conflict_queues_resolution_job(tmp_path: Pat
     assert github.merged == []
 
 
+def test_approve_verdict_with_merge_conflict_reuses_tracked_issue_number_without_pr_body_reference(
+    tmp_path: Path,
+) -> None:
+    service, github, _ = make_service(tmp_path)
+    github.merge_conflicts.add(("acme/demo", 77))
+    service.storage.create_job(
+        JobRecord(
+            repo_full_name="acme/demo",
+            stage="review_round",
+            issue_number=5,
+            pr_number=77,
+            review_round=1,
+            status="completed",
+        )
+    )
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "No issue reference in body",
+        title="Feature without issue in body",
+        head_branch="feature/no-issue",
+        base_branch="dev",
+    )
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=77,
+            actor_login="agent",
+            payload={},
+            body=build_signature(stage="final_verdict", job="verdict-1", pr=77, verdict="APPROVE"),
+            title="Feature without issue in body",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    resolution_jobs = service.storage.find_jobs(
+        repo_full_name="acme/demo", stage="merge_conflict_resolution", pr_number=77
+    )
+    assert result["stage"] == "merge_conflict_resolution"
+    assert resolution_jobs[0].issue_number == 5
+    assert resolution_jobs[0].metadata["head_branch"] == "feature/no-issue"
+
+
 def test_merge_conflict_resolution_comment_queues_final_verdict_retry(tmp_path: Path) -> None:
     service, github, omx_runner = make_service(tmp_path)
     pr_body = "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->"
@@ -377,6 +1152,41 @@ def test_merge_conflict_resolution_comment_queues_final_verdict_retry(tmp_path: 
     assert verdict_jobs[0].metadata["title"] == "Feature/#5"
     assert verdict_jobs[0].metadata["body"] == pr_body
     assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+
+
+def test_duplicate_merge_conflict_resolution_event_is_ignored(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->",
+        title="Feature/#5",
+        head_branch="Feature/#5",
+        base_branch="dev",
+    )
+    event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="merge_conflict_resolution", job="resolve-1", pr=77),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+
+    first = service.handle_event(event)
+    service.wait_for_idle()
+    second = service.handle_event(event)
+    service.wait_for_idle()
+
+    verdict_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=77)
+    assert first["status"] == "queued"
+    assert second == {"status": "ignored", "reason": "duplicate_agent_event"}
+    assert len(verdict_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+    assert omx_runner.launches[-1]["job"].pr_number == 77
 
 
 def test_merge_conflict_resolution_requires_its_own_signed_comment(tmp_path: Path) -> None:
@@ -488,6 +1298,95 @@ def test_final_verdict_verification_rejects_unrelated_signed_comment(tmp_path: P
 
     with pytest.raises(RuntimeError, match="final-verdict-comment-missing"):
         service._verify_side_effect(repo, job)
+
+
+def test_duplicate_final_verdict_event_is_ignored(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.merge_conflicts.add(("acme/demo", 77))
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->",
+        title="Feature/#5",
+        head_branch="Feature/#5",
+        base_branch="dev",
+    )
+    event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="final_verdict", job="verdict-1", pr=77, verdict="APPROVE"),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+
+    first = service.handle_event(event)
+    service.wait_for_idle()
+    second = service.handle_event(event)
+    service.wait_for_idle()
+
+    resolution_jobs = service.storage.find_jobs(
+        repo_full_name="acme/demo", stage="merge_conflict_resolution", pr_number=77
+    )
+    assert first["status"] == "queued"
+    assert second == {"status": "ignored", "reason": "duplicate_agent_event"}
+    assert len(resolution_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "merge_conflict_resolution"
+    assert omx_runner.launches[-1]["job"].pr_number == 77
+
+
+def test_final_verdict_transient_failure_allows_redelivery(tmp_path: Path) -> None:
+    """A transient merge failure must not poison redelivery — the retry must succeed."""
+    from github.GithubException import GithubException
+
+    service, github, _omx_runner = make_service(tmp_path)
+    service.storage.create_job(
+        JobRecord(
+            repo_full_name="acme/demo",
+            stage="review_round",
+            issue_number=5,
+            pr_number=77,
+            review_round=1,
+            status="completed",
+        )
+    )
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->",
+        title="Feature/#5",
+        head_branch="feature/5",
+        base_branch="dev",
+    )
+    original_merge = github.merge_pull_request
+
+    def boom(repo_full_name: str, pr_number: int) -> None:
+        raise GithubException(500, {"message": "GitHub outage"}, {})
+
+    github.merge_pull_request = boom  # type: ignore[assignment]
+    event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="final_verdict", job="verdict-1", pr=77, verdict="APPROVE"),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+
+    with pytest.raises(GithubException):
+        service.handle_event(event)
+
+    # Restore normal merge and redeliver the same event
+    github.merge_pull_request = original_merge  # type: ignore[assignment]
+    result = service.handle_event(event)
+    assert result["status"] == "merged"
+    assert ("acme/demo", 77) in github.merged
 
 
 def test_bootstrap_repo_queues_existing_open_issues(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4,10 +4,10 @@ from typing import cast
 
 import pytest
 
+from dani.agent_runner import AgentRunner
 from dani.errors import RolloutMissingError
 from dani.github import GitHubCLI
 from dani.models import DaniConfig, JobRecord, NormalizedEvent
-from dani.omx_runner import OmxRunner
 from dani.service import DaniService
 from dani.signatures import build_signature
 from dani.storage import JsonStorage
@@ -50,7 +50,7 @@ def make_service(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(OmxRunner, omx_runner),
+        omx_runner=cast(AgentRunner, omx_runner),
         dev_syncer=dev_syncer or FakeGitDevSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))
@@ -902,7 +902,7 @@ def test_external_pr_unique_activity_never_queues_an_eleventh_automated_review(t
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(OmxRunner, omx_runner),
+        omx_runner=cast(AgentRunner, omx_runner),
         dev_syncer=FakeGitDevSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -237,6 +237,115 @@ def test_issue_followup_verification_requires_exact_signature(tmp_path: Path) ->
     service._verify_side_effect(repo, job)
 
 
+def test_issue_comment_with_unresumable_prior_session_falls_back_to_fresh_issue_request(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from dani.models import SessionRecord
+
+    service, _, omx_runner = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+
+    legacy_session_id = "019da0f4-6ef1-7923-811f-57eb3e93bd8e"
+    legacy_session = SessionRecord(
+        repo_full_name=repo.full_name,
+        stage="issue_request",
+        runtime_handle="runtime-legacy",
+        prompt_path=str(tmp_path / "legacy-prompt.txt"),
+        script_path=str(tmp_path / "legacy.sh"),
+        worktree_path=str(tmp_path),
+        job_id="legacy-job-id",
+        issue_number=731,
+        omx_session_id=legacy_session_id,
+    )
+    service.storage.create_session(legacy_session)
+
+    monkeypatch.setattr(
+        omx_runner,
+        "can_resume",
+        lambda session_id: bool(session_id) and not session_id.startswith("019d"),
+    )
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=731,
+            actor_login="human",
+            payload={"issue": {"body": "fallback comment"}},
+            body="this is a fresh comment on a legacy issue",
+            title="Legacy followup",
+        )
+    )
+    service.wait_for_idle()
+
+    request_jobs = [
+        job for job in service.storage.list_jobs() if job.stage == "issue_request" and job.issue_number == 731
+    ]
+    followup_jobs = [
+        job for job in service.storage.list_jobs() if job.stage == "issue_followup" and job.issue_number == 731
+    ]
+    assert request_jobs, "expected a fresh issue_request to be enqueued when prior session id is non-resumable"
+    assert not followup_jobs, "must NOT enqueue an issue_followup against an un-resumable session id"
+    assert not omx_runner.resumes, "runner.resume must not be invoked when can_resume returned False"
+    assert any(launch["job"].issue_number == 731 for launch in omx_runner.launches), (
+        "runner.launch must run a fresh session for the legacy issue"
+    )
+
+
+def test_issue_comment_with_resumable_prior_session_still_resumes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from dani.models import SessionRecord
+
+    service, _, omx_runner = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+
+    resumable_session_id = "ses_25ad70836ffemLP2sYPAkGq8hd"
+    resumable_session = SessionRecord(
+        repo_full_name=repo.full_name,
+        stage="issue_request",
+        runtime_handle="runtime-resumable",
+        prompt_path=str(tmp_path / "prompt.txt"),
+        script_path=str(tmp_path / "run.sh"),
+        worktree_path=str(tmp_path),
+        job_id="resumable-job-id",
+        issue_number=732,
+        omx_session_id=resumable_session_id,
+    )
+    service.storage.create_session(resumable_session)
+
+    monkeypatch.setattr(
+        omx_runner,
+        "can_resume",
+        lambda session_id: bool(session_id) and session_id.startswith("ses_"),
+    )
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=732,
+            actor_login="human",
+            payload={"issue": {"body": "resume me"}},
+            body="continue please",
+            title="Resumable followup",
+        )
+    )
+    service.wait_for_idle()
+
+    followup_jobs = [
+        job for job in service.storage.list_jobs() if job.stage == "issue_followup" and job.issue_number == 732
+    ]
+    assert followup_jobs, "expected an issue_followup job when prior session id is resumable"
+    assert any(resume["omx_session_id"] == resumable_session_id for resume in omx_runner.resumes), (
+        "runner.resume must be invoked with the resumable session id"
+    )
+
+
 def test_issue_followup_verification_rejects_stale_signature(tmp_path: Path) -> None:
     service, github, _ = make_service(tmp_path)
     repo = service.storage.get_repo("acme/demo")

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -1,4 +1,10 @@
-from dani.signatures import build_signature, parse_signature
+from dani.signatures import (
+    build_signature,
+    has_ignore_signature,
+    is_opt_out_comment,
+    parse_agent_signature,
+    parse_signature,
+)
 
 
 def test_signature_round_trip() -> None:
@@ -9,3 +15,17 @@ def test_signature_round_trip() -> None:
         "pr": "7",
         "round": "2",
     }
+
+
+def test_has_ignore_signature_detects_ignore_stage_across_multiple_markers() -> None:
+    text = f"{build_signature(stage='review_round', job='job123', pr=7, round=2)}\n<!-- dani:stage=ignore -->"
+
+    assert has_ignore_signature(text) is True
+
+
+def test_is_opt_out_comment_accepts_dani_ignore_command() -> None:
+    assert is_opt_out_comment("Heads up\n/dani ignore") is True
+
+
+def test_parse_agent_signature_excludes_ignore_stage() -> None:
+    assert parse_agent_signature("<!-- dani:stage=ignore -->") is None

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,56 @@
+from dani.webhook import normalize_event
+
+
+def test_normalize_pull_request_synchronize_event() -> None:
+    event = normalize_event(
+        "pull_request",
+        {
+            "action": "synchronize",
+            "repository": {"full_name": "acme/demo"},
+            "sender": {"login": "contributor"},
+            "pull_request": {
+                "number": 21,
+                "title": "Feature/#21",
+                "body": "Implements #21",
+                "base": {"ref": "dev"},
+                "head": {"ref": "feature/#21", "sha": "abc123"},
+            },
+        },
+        delivery_id="delivery-1",
+    )
+
+    assert event is not None
+    assert event.kind == "pull_request_opened"
+    assert event.number == 21
+    assert event.base_branch == "dev"
+    assert event.head_branch == "feature/#21"
+    assert event.commit_sha == "abc123"
+    assert event.delivery_id == "delivery-1"
+    assert event.is_pull_request is True
+
+
+def test_normalize_pull_request_review_requested_event() -> None:
+    event = normalize_event(
+        "pull_request",
+        {
+            "action": "review_requested",
+            "repository": {"full_name": "acme/demo"},
+            "sender": {"login": "contributor"},
+            "pull_request": {
+                "number": 21,
+                "title": "Feature/#21",
+                "body": "Implements #21",
+                "base": {"ref": "dev"},
+                "head": {"ref": "feature/#21", "sha": "def456"},
+            },
+            "requested_reviewer": {"login": "maintainer"},
+        },
+    )
+
+    assert event is not None
+    assert event.kind == "pull_request_opened"
+    assert event.number == 21
+    assert event.base_branch == "dev"
+    assert event.head_branch == "feature/#21"
+    assert event.commit_sha == "def456"
+    assert event.is_pull_request is True


### PR DESCRIPTION
## Summary

The previous `omo` runtime spawned a fresh `opencode run` subprocess per agent turn. When the agent dispatched subagents (oh-my-openagent's `task` tool), the parent subprocess was getting torn down before the turn finished, dropping the session and forcing dani to retry from scratch.

This PR makes `omo` drive opencode through its long-lived `opencode serve` HTTP backend instead. Each repo gets a cached server process (lazily spawned with `cwd=<repo>`) and `OmoHttpRunner` talks to it over HTTP for session create / `prompt_async` / abort / permission auto-grant, watching SSE `session.idle` events for completion with a `/session/status` polling fallback. **Subagents now spawn as child sessions inside the same long-lived server process, so a finishing subagent no longer kills the parent.**

## Problem

`opencode run --format json --dangerously-skip-permissions <prompt>` was a one-shot subprocess. When ohmyopenagent's `task()` tool spawned a subagent inside that opencode process, lifecycle interactions occasionally tore down the parent process before the assistant message completed. dani saw a non-zero exit and retried — but session state was gone.

## Design

| Aspect | Decision | Why |
|---|---|---|
| Server lifecycle | One `opencode serve` per repo (lazy, cached) | Avoids unproven cross-repo directory-isolation risk; matches dani's per-repo queue model. `DANI_OPENCODE_SERVER_URL` overrides for shared single-server setups (e.g. pm2). |
| Completion detection | `prompt_async` + SSE `session.idle` (with `/session/status` polling fallback for SSE gaps) | Keeps `launch()`/`resume()` non-blocking and decouples correctness from one HTTP socket surviving 30+ minutes. |
| Permission auto-grant | SSE `permission.updated` listener responds with `"once"` (configurable via `DANI_OPENCODE_PERMISSION_RESPONSE`) | Replaces `--dangerously-skip-permissions`; defaults to tighter scope than `"always"`. |
| Process supervision | Best-effort `atexit` + `start_new_session=True` for the spawned `opencode serve` | macOS has no reliable parent-die-child-die primitive; explicit `runner.shutdown()` and atexit are the right hygiene. |
| HTTP transport | stdlib `urllib` + custom SSE parsing | Zero new dependencies. |
| Backwards compatibility | Legacy `opencode run` subprocess kept behind `DANI_OMO_LEGACY_SUBPROCESS=1` env flag | Emergency rollback path. |
| Public interface | `AgentRunner` Protocol unchanged | `launch()`/`resume()` still non-blocking, `wait()` is still where errors surface, `RolloutMissingError`/`TransientCapacityError` semantics preserved. |
| Per-job debugging | Each session keeps its own `events.jsonl`/`prompt.txt`/`request.json` under `run_dir` | Consumer routes events by `sessionID` to per-session log paths so debugging one job stays clean even when the server hosts many sessions. |

## What changed

**New (`dani/opencode_http/`):**
- `client.py` — narrow stdlib HTTP client (session CRUD, `prompt_async`, abort, permissions, SSE event stream).
- `server_manager.py` — per-repo `opencode serve` cache with stdout-line ready detection (`listening on (http://\S+)`) + atexit + SIGTERM/SIGKILL graceful shutdown.
- `event_consumer.py` — background SSE thread with reconnect backoff + status-poll fallback; auto-grants `permission.updated` events; routes events to per-session log paths so each dani job has its own clean event log.
- `task_handle.py` — `HttpTaskHandle` implementing the existing `ManagedProcess` shape over the SSE-driven completion future.

**New (`dani/omo_http_runner.py`):**
- `OmoHttpRunner` implementing `AgentRunner`. `launch()` creates the session and submits `prompt_async`; `wait()` blocks on the SSE-driven completion future and maps `Session not found:` → `RolloutMissingError` + `at capacity` / `currently overloaded` → `TransientCapacityError`.

**Updated (`dani/agent_runner.py`):**
- Factory returns `OmoHttpRunner` by default for `omo`; `DANI_OMO_LEGACY_SUBPROCESS=1` falls back to the legacy `OmoRunner`.

**Tests:**
- `tests/test_omo_http_runner.py` — 30 new tests covering client, server manager, event consumer (per-session log routing + permission auto-grant + error mapping), task handle, runner end-to-end with fake client/consumer, and a full service-level e2e test.
- `tests/test_omo_runner.py` — existing 30+ subprocess-runner unit tests preserved; the four service-level e2e tests now inject the legacy `OmoRunner` explicitly so they keep exercising the subprocess path.
- `tests/test_omo_live.py` — 2 new opt-in (`DANI_OMO_LIVE=1`) live tests against real `opencode serve` (launch + resume continuity).

**Tooling:**
- `scripts/dev/verify_http_runner_live.py` — reproducible end-to-end live verification script.

## Verification

Pipeline status:
- `make check` — green (ruff, ruff-format, ty zero diagnostics, deptry zero issues).
- `make test` — 191 passed, 5 skipped (opt-in live tests).

Live verification (`scripts/dev/verify_http_runner_live.py`, total 35.8s):
- **TEST 1 — server lifecycle (3.4s):** spawned `opencode serve --port 0` → bound to `http://127.0.0.1:59364`, parsed URL from stdout, created/aborted session, server stayed alive after abort, clean SIGTERM shutdown.
- **TEST 2 — session management (12.1s):** launch → `session.idle` observed → resume on same `ses_*` ID → resume reply contained the prior turn's keyword, proving server-side session memory carried over. **Bug found and fixed mid-run:** per-session event log routing was broken (all sessions on a shared server were dumping events into the FIRST session's log file). Fixed `OpencodeEventConsumer.register_session(event_log_path=...)` to route events by `sessionID` to per-session logs.
- **TEST 3 — ultrawork + oh-my-openagent subagents (20.2s):** parent session launched, server reachable BEFORE wait, parent + 1 subagent completed in 17.4s, **server STILL reachable AFTER subagent run** (HTTP 200 on `/path`), 1 child `session.created` event with `parentID` matching parent observed in event log, both parent and child reached `session.idle`. **The user's original observation is empirically validated**: HTTP-server backend prevents subagent-induced parent termination.

## Configuration / env vars

- `DANI_OPENCODE_SERVER_URL` (optional) — attach every repo to one external `opencode serve` (e.g. one pm2 process). Sessions stay scoped per repo via `?directory=<path>` query.
- `DANI_OPENCODE_PERMISSION_RESPONSE` (optional, default `once`) — `once` / `always` / `reject`.
- `DANI_OMO_LEGACY_SUBPROCESS=1` (optional) — fall back to the legacy `opencode run` subprocess implementation.
- `OPENCODE_SERVER_PASSWORD` (optional) — forwarded to the spawned server and used for HTTP basic auth on every request.

## Rollback

Set `DANI_OMO_LEGACY_SUBPROCESS=1` to revert to the previous behavior. No code rollback needed.

## Out of scope

- A single shared multi-repo server is supported via `DANI_OPENCODE_SERVER_URL` and live-tested at the session-creation level (per-session `directory` scoping confirmed). Heavy concurrent cross-repo load with subagents was **not** stress-tested live; per-repo servers (the default) are the safer ops choice. Future work can collapse to one shared server if desired.