### PR TITLE
[codex] Add Claude-limit runtime fallback from OMO to OMX

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,3 +124,19 @@ Before you submit a pull request, check that it meets these guidelines:
 
 2. If the pull request adds functionality, the docs should be updated.
    Put your new functionality into a function with a docstring, and add the feature to the list in `README.md`.
+
+## External contribution PR review process
+
+For PRs opened by external contributors, `dani` follows a lighter event-driven review loop:
+
+1. A maintainer review runs when the PR is opened.
+2. If changes are requested, the contributor owns the follow-up implementation.
+3. `dani` reviews again only when the PR changes meaningfully, such as:
+   - a new commit (`synchronize`)
+   - a renewed review request
+   - another PR-open style re-entry event (`reopened`, `ready_for_review`)
+   - duplicate webhook deliveries are ignored, using the GitHub delivery id when available and a PR activity fallback key otherwise
+   - once all remaining automated review passes are already queued or running, extra PR-activity events are coalesced until one of those passes finishes
+4. The merge bar stays the same as the existing verdict session: requirements must be met, real verification must pass, and the PR must be approveable.
+5. Only completed automated review passes count toward escalation, but queued/running passes still reserve the remaining review budget.
+6. If automated review reaches 10 completed passes without approval, `dani` immediately escalates the PR to a human maintainer for a manual decision.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Simple GitHub webhook -> OMX automation loop.
 - Workflows for:
   - issue request report
   - `/approve` implementation
-  - 3 review rounds for PRs
+  - 3 review rounds for agent-authored PRs
+  - event-driven, duplicate-delivery-safe re-review for external contributor PRs
   - final verdict + auto-merge on APPROVE
 
 ## Environment

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # dani
 
-Simple GitHub webhook -> OMX automation loop.
+Simple GitHub webhook -> agent automation loop. Supports two pluggable agent
+runtimes: **Oh-My-Codex (`omx`, default)** and **Oh-My-OpenAgents (`omo`,
+opt-in)**.
 
 ## What v1 includes
 - Typer CLI
 - FastAPI webhook server
 - Registered repos only
 - Repo-serial / cross-repo parallel job handling
-- non-interactive `omx exec` / `omx exec resume` launches
+- Pluggable agent runtime: non-interactive `omx exec` / `omx exec resume` (default)
+  or `opencode run --session <id>` (Oh-My-OpenAgents)
 - Separate prompt templates in `dani/prompts.py`
 - Workflows for:
   - issue request report
@@ -17,16 +20,37 @@ Simple GitHub webhook -> OMX automation loop.
   - final verdict + auto-merge on APPROVE
 
 ## Environment
-Required local tools:
+Required local tools (at least one depending on the selected runtime):
 - `git`
-- `omx`
+- `omx` — required when `DANI_AGENT_RUNTIME=omx` (default)
+- `opencode` — required when `DANI_AGENT_RUNTIME=omo`
 
 Required environment variables:
 - `DANI_WEBHOOK_SECRET`
 - `DANI_GITHUB_TOKEN` (preferred) or `GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_PAT`
 
+Optional environment variables:
+- `DANI_AGENT_RUNTIME` — selects the agent backend. Accepted values:
+  - `omx` / `oh-my-codex` / `codex` (default)
+  - `omo` / `oh-my-openagents` / `oh-my-openagent` / `opencode`
+
+When `DANI_AGENT_RUNTIME=omo` is selected, dani automatically prefixes every
+opencode prompt with the `ultrawork` keyword so oh-my-openagents' ultrawork
+loop mode is always active, and runtime-specific prompt substitutions swap
+codex-only shell commands (`$ralph`, `$code-review`) for their opencode
+equivalents (ultrawork mode and the Momus-Plan-Critic subagent respectively).
+
 ## Codex/OMX trust prerequisite
 Before dani can reliably launch or resume OMX/Codex sessions for a repository, that repository directory should be trusted by Codex at least once. In practice, run `omx exec 'hello'` or `codex exec 'hello'` once from the target repo and accept the trust prompt before using dani automation there. Otherwise a trust prompt can block session startup or resume.
+
+## Oh-My-OpenAgents (opencode) prerequisite
+When running with `DANI_AGENT_RUNTIME=omo`, dani launches sessions through
+`opencode run --format json --dangerously-skip-permissions <prompt>` and resumes
+them with `opencode run --session <id> ...`. Install `opencode` (the
+`oh-my-openagent` plugin is loaded automatically when configured in
+`~/.config/opencode/opencode.json`) and make sure the target repository
+directory is trusted at least once via `opencode run 'hello'` before pointing
+dani at it.
 
 ## CLI
 ```bash
@@ -42,7 +66,7 @@ State is stored under `~/.dani/` by default:
 - `jobs.json`
 - `sessions.json`
 - `events.jsonl`
-- `runs/` for generated OMX prompt/script artifacts
+- `runs/` for generated agent-runtime prompt/script artifacts (omx or omo)
 
 
 ## GitHub surfaces

--- a/dani/agent_runner.py
+++ b/dani/agent_runner.py
@@ -5,6 +5,16 @@ from typing import Protocol, TextIO, runtime_checkable
 
 from dani.models import JobRecord, SessionRecord
 
+RUNTIME_ALIASES: dict[str, str] = {
+    "omx": "omx",
+    "oh-my-codex": "omx",
+    "codex": "omx",
+    "omo": "omo",
+    "oh-my-openagents": "omo",
+    "oh-my-openagent": "omo",
+    "opencode": "omo",
+}
+
 
 class ManagedProcess(Protocol):
     def poll(self) -> object: ...
@@ -51,15 +61,23 @@ class AgentRunner(Protocol):
     def get_session_id(self, runtime_handle: str) -> str | None: ...
 
 
+def normalize_runtime(runtime: str | None) -> str:
+    normalized = (runtime or "omx").strip().lower()
+    if normalized in RUNTIME_ALIASES:
+        return RUNTIME_ALIASES[normalized]
+    msg = f"unknown agent runtime: {runtime!r} (expected 'omx' or 'omo')"
+    raise ValueError(msg)
+
+
 def build_agent_runner(runtime: str, run_dir: Path) -> AgentRunner:
     """Factory returning the AgentRunner matching *runtime* (``omx`` or ``omo``)."""
     from dani.omo_runner import OmoRunner
     from dani.omx_runner import OmxRunner
 
-    normalized = (runtime or "omx").strip().lower()
-    if normalized in {"omx", "oh-my-codex", "codex"}:
+    normalized = normalize_runtime(runtime)
+    if normalized == "omx":
         return OmxRunner(run_dir)
-    if normalized in {"omo", "oh-my-openagents", "oh-my-openagent", "opencode"}:
+    if normalized == "omo":
         return OmoRunner(run_dir)
     msg = f"unknown agent runtime: {runtime!r} (expected 'omx' or 'omo')"
     raise ValueError(msg)

--- a/dani/agent_runner.py
+++ b/dani/agent_runner.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, TextIO, runtime_checkable
+
+from dani.models import JobRecord, SessionRecord
+
+
+class ManagedProcess(Protocol):
+    def poll(self) -> object: ...
+    def terminate(self) -> None: ...
+    def wait(self, timeout: float | None = None) -> object: ...
+    def kill(self) -> None: ...
+
+
+ProcessEntry = tuple[ManagedProcess, TextIO, TextIO]
+
+
+@runtime_checkable
+class AgentRunner(Protocol):
+    """Protocol every dani agent runtime adapter must satisfy.
+
+    Implementations wrap an external agent CLI (omx, opencode, ...) and expose
+    a uniform interface to ``DaniService`` for launching a new agent session,
+    resuming an existing one, waiting for completion, and releasing process
+    resources.
+    """
+
+    run_dir: Path
+
+    def launch(self, repo_path: Path, job: JobRecord, prompt: str) -> SessionRecord: ...
+
+    def resume(
+        self,
+        repo_path: Path,
+        job: JobRecord,
+        prompt: str,
+        omx_session_id: str,
+    ) -> SessionRecord: ...
+
+    def wait(
+        self,
+        runtime_handle: str,
+        *,
+        poll_interval: float = 0.5,
+        timeout_seconds: float = 1800,
+    ) -> None: ...
+
+    def close_session(self, runtime_handle: str) -> None: ...
+
+    def get_session_id(self, runtime_handle: str) -> str | None: ...
+
+
+def build_agent_runner(runtime: str, run_dir: Path) -> AgentRunner:
+    """Factory returning the AgentRunner matching *runtime* (``omx`` or ``omo``)."""
+    from dani.omo_runner import OmoRunner
+    from dani.omx_runner import OmxRunner
+
+    normalized = (runtime or "omx").strip().lower()
+    if normalized in {"omx", "oh-my-codex", "codex"}:
+        return OmxRunner(run_dir)
+    if normalized in {"omo", "oh-my-openagents", "oh-my-openagent", "opencode"}:
+        return OmoRunner(run_dir)
+    msg = f"unknown agent runtime: {runtime!r} (expected 'omx' or 'omo')"
+    raise ValueError(msg)

--- a/dani/cli.py
+++ b/dani/cli.py
@@ -24,7 +24,14 @@ DEV_BRANCH_OPTION = typer.Option("dev", help="Development branch name.")
 
 def build_config(data_dir: Path, host: str = "127.0.0.1", port: int = 8787) -> DaniConfig:
     secret = os.environ.get("DANI_WEBHOOK_SECRET", "")
-    return DaniConfig(data_dir=data_dir, webhook_secret=secret, host=host, port=port)
+    agent_runtime = os.environ.get("DANI_AGENT_RUNTIME", "omx")
+    return DaniConfig(
+        data_dir=data_dir,
+        webhook_secret=secret,
+        host=host,
+        port=port,
+        agent_runtime=agent_runtime,
+    )
 
 
 def build_service(data_dir: Path, host: str = "127.0.0.1", port: int = 8787) -> DaniService:

--- a/dani/cli.py
+++ b/dani/cli.py
@@ -78,3 +78,16 @@ def show_state(data_dir: Path = DATA_DIR_OPTION) -> None:
     """Print current dani state."""
     service = build_service(data_dir=data_dir)
     typer.echo(json.dumps(service.state_snapshot(), ensure_ascii=False, indent=2))
+
+
+@app.command("restart-issue")
+def restart_issue(
+    repo_full_name: str = FULL_NAME_ARGUMENT,
+    issue_number: int = typer.Argument(..., help="Issue number"),
+    data_dir: Path = DATA_DIR_OPTION,
+) -> None:
+    """Supersede stale issue jobs, run a fresh issue_request, and wait for completion."""
+    service = build_service(data_dir=data_dir)
+    job = service.restart_issue(repo_full_name, issue_number)
+    service.wait_for_idle()
+    typer.echo(json.dumps(job.to_dict(), ensure_ascii=False, indent=2))

--- a/dani/errors.py
+++ b/dani/errors.py
@@ -1,11 +1,27 @@
 from __future__ import annotations
 
 import re
+from datetime import datetime, timedelta, timezone
+
+SESSION_LIMIT_RETRY_AFTER = timedelta(hours=5)
+WEEKLY_LIMIT_RETRY_AFTER = timedelta(days=7)
 
 TRANSIENT_CAPACITY_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"Selected model is at capacity", re.IGNORECASE),
     re.compile(r"model is currently overloaded", re.IGNORECASE),
 ]
+
+CLAUDE_WEEKLY_LIMIT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"Opus weekly limit reached", re.IGNORECASE),
+    re.compile(r"weekly limit reached", re.IGNORECASE),
+]
+
+CLAUDE_SESSION_LIMIT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"Claude usage limit reached", re.IGNORECASE),
+    re.compile(r"Approaching usage limit", re.IGNORECASE),
+]
+
+RESET_HINT_PATTERN = re.compile(r"reset(?:s)?\s+(?:at|on)\s+(?P<hint>[^\n.]+)", re.IGNORECASE)
 
 ROLLOUT_MISSING_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"thread/resume failed", re.IGNORECASE),
@@ -31,6 +47,25 @@ class TransientCapacityError(Exception):
         self.pattern = pattern
 
 
+class ClaudeUsageLimitError(Exception):
+    """Raised when Claude usage limits require rerouting away from OMO/Claude."""
+
+    def __init__(
+        self,
+        message: str,
+        pattern: str,
+        limit_type: str,
+        *,
+        reset_hint: str | None = None,
+        suggested_retry_at: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.pattern = pattern
+        self.limit_type = limit_type
+        self.reset_hint = reset_hint
+        self.suggested_retry_at = suggested_retry_at
+
+
 class RolloutMissingError(Exception):
     """Raised when a resume target rollout/session can no longer be found.
 
@@ -52,6 +87,34 @@ def check_transient_capacity_error(stderr_text: str) -> None:
             raise TransientCapacityError(match.group(0), pattern.pattern)
 
 
+def check_claude_usage_limit_error(stderr_text: str) -> None:
+    """Raise ``ClaudeUsageLimitError`` if *stderr_text* contains a known Claude usage-limit signal."""
+    observed_at = datetime.now(tz=timezone.utc)
+    reset_hint = _extract_reset_hint(stderr_text)
+
+    for pattern in CLAUDE_WEEKLY_LIMIT_PATTERNS:
+        match = pattern.search(stderr_text)
+        if match:
+            raise ClaudeUsageLimitError(
+                match.group(0),
+                pattern.pattern,
+                "weekly",
+                reset_hint=reset_hint,
+                suggested_retry_at=(observed_at + WEEKLY_LIMIT_RETRY_AFTER).isoformat(),
+            )
+
+    for pattern in CLAUDE_SESSION_LIMIT_PATTERNS:
+        match = pattern.search(stderr_text)
+        if match:
+            raise ClaudeUsageLimitError(
+                match.group(0),
+                pattern.pattern,
+                "session_window",
+                reset_hint=reset_hint,
+                suggested_retry_at=(observed_at + SESSION_LIMIT_RETRY_AFTER).isoformat(),
+            )
+
+
 def check_rollout_missing_error(stderr_text: str) -> None:
     """Raise ``RolloutMissingError`` if *stderr_text* matches known OMX missing-rollout patterns."""
     for pattern in ROLLOUT_MISSING_PATTERNS:
@@ -66,3 +129,11 @@ def check_opencode_session_missing_error(stderr_text: str) -> None:
         match = pattern.search(stderr_text)
         if match:
             raise RolloutMissingError(stderr_text.strip() or match.group(0), pattern.pattern)
+
+
+def _extract_reset_hint(text: str) -> str | None:
+    match = RESET_HINT_PATTERN.search(text)
+    if match is None:
+        return None
+    hint = match.group("hint").strip()
+    return hint or None

--- a/dani/errors.py
+++ b/dani/errors.py
@@ -7,9 +7,22 @@ TRANSIENT_CAPACITY_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"model is currently overloaded", re.IGNORECASE),
 ]
 
+ROLLOUT_MISSING_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"thread/resume failed", re.IGNORECASE),
+    re.compile(r"no rollout found", re.IGNORECASE),
+]
+
 
 class TransientCapacityError(Exception):
     """Raised when an OMX session fails due to a transient model-capacity issue."""
+
+    def __init__(self, message: str, pattern: str) -> None:
+        super().__init__(message)
+        self.pattern = pattern
+
+
+class RolloutMissingError(Exception):
+    """Raised when a resume target rollout/session can no longer be found."""
 
     def __init__(self, message: str, pattern: str) -> None:
         super().__init__(message)
@@ -22,3 +35,11 @@ def check_transient_capacity_error(stderr_text: str) -> None:
         match = pattern.search(stderr_text)
         if match:
             raise TransientCapacityError(match.group(0), pattern.pattern)
+
+
+def check_rollout_missing_error(stderr_text: str) -> None:
+    """Raise ``RolloutMissingError`` if *stderr_text* matches known missing-rollout patterns."""
+    for pattern in ROLLOUT_MISSING_PATTERNS:
+        match = pattern.search(stderr_text)
+        if match:
+            raise RolloutMissingError(stderr_text.strip() or match.group(0), pattern.pattern)

--- a/dani/errors.py
+++ b/dani/errors.py
@@ -12,9 +12,19 @@ ROLLOUT_MISSING_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"no rollout found", re.IGNORECASE),
 ]
 
+# Patterns emitted by `opencode run --session ...` when the requested session
+# has been deleted/expired. Derived from the CLI source:
+#   "Session not found: ..." and related error text surfaced via the
+#   opencode run JSON event stream / stderr.
+OPENCODE_SESSION_MISSING_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"[Ss]ession not found", re.IGNORECASE),
+    re.compile(r"[Ss]ession does not exist", re.IGNORECASE),
+    re.compile(r"[Nn]o session with id", re.IGNORECASE),
+]
+
 
 class TransientCapacityError(Exception):
-    """Raised when an OMX session fails due to a transient model-capacity issue."""
+    """Raised when an agent session fails due to a transient model-capacity issue."""
 
     def __init__(self, message: str, pattern: str) -> None:
         super().__init__(message)
@@ -22,7 +32,12 @@ class TransientCapacityError(Exception):
 
 
 class RolloutMissingError(Exception):
-    """Raised when a resume target rollout/session can no longer be found."""
+    """Raised when a resume target rollout/session can no longer be found.
+
+    This error is runtime-agnostic: the OMX (codex) runner raises it when the
+    codex rollout file is gone; the OMO (opencode) runner raises it when
+    ``opencode run --session <id>`` reports the session no longer exists.
+    """
 
     def __init__(self, message: str, pattern: str) -> None:
         super().__init__(message)
@@ -38,8 +53,16 @@ def check_transient_capacity_error(stderr_text: str) -> None:
 
 
 def check_rollout_missing_error(stderr_text: str) -> None:
-    """Raise ``RolloutMissingError`` if *stderr_text* matches known missing-rollout patterns."""
+    """Raise ``RolloutMissingError`` if *stderr_text* matches known OMX missing-rollout patterns."""
     for pattern in ROLLOUT_MISSING_PATTERNS:
+        match = pattern.search(stderr_text)
+        if match:
+            raise RolloutMissingError(stderr_text.strip() or match.group(0), pattern.pattern)
+
+
+def check_opencode_session_missing_error(stderr_text: str) -> None:
+    """Raise ``RolloutMissingError`` if *stderr_text* matches known opencode session-missing patterns."""
+    for pattern in OPENCODE_SESSION_MISSING_PATTERNS:
         match = pattern.search(stderr_text)
         if match:
             raise RolloutMissingError(stderr_text.strip() or match.group(0), pattern.pattern)

--- a/dani/github.py
+++ b/dani/github.py
@@ -8,10 +8,11 @@ from typing import Any
 from github import Auth, Github
 from github.GithubException import GithubException
 
-from dani.signatures import parse_signature
+from dani.signatures import is_opt_out_comment, parse_agent_signature
 
 TOKEN_ENV_VARS = ("DANI_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT")
 LOGGER = logging.getLogger(__name__)
+MERGE_CONFLICT_STATUSES = frozenset({405, 409, 422})
 
 
 class MergeConflictError(RuntimeError):
@@ -88,7 +89,9 @@ class GitHubCLI:
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
         for comment in reversed(comments):
-            parsed = parse_signature(comment.get("body", ""))
+            if is_opt_out_comment(comment.get("body", "")):
+                continue
+            parsed = parse_agent_signature(comment.get("body", ""))
             if parsed is not None:
                 return comment, parsed
         return None
@@ -99,7 +102,11 @@ class GitHubCLI:
         comments = (
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
-        return [comment for comment in comments if signature_fragment in (comment.get("body") or "")]
+        return [
+            comment
+            for comment in comments
+            if not is_opt_out_comment(comment.get("body", "")) and signature_fragment in (comment.get("body") or "")
+        ]
 
     def create_issue_comment(self, repo_full_name: str, issue_number: int, body: str) -> dict[str, Any]:
         issue = self._repo(repo_full_name).get_issue(issue_number)
@@ -132,7 +139,9 @@ class GitHubCLI:
         try:
             merge_status = pull_request.merge(merge_method="merge", delete_branch=False)
         except GithubException as exc:
-            raise MergeConflictError(repo_full_name, pr_number, status=exc.status, message=str(exc)) from exc
+            if exc.status in MERGE_CONFLICT_STATUSES:
+                raise MergeConflictError(repo_full_name, pr_number, status=exc.status, message=str(exc)) from exc
+            raise
         if not merge_status.merged:
             raise MergeConflictError(repo_full_name, pr_number, message=merge_status.message)
         try:

--- a/dani/models.py
+++ b/dani/models.py
@@ -94,6 +94,7 @@ class DaniConfig:
     port: int = 8787
     review_rounds: int = 3
     external_review_limit: int = 10
+    agent_runtime: str = "omx"
 
     @property
     def registry_path(self) -> Path:

--- a/dani/models.py
+++ b/dani/models.py
@@ -80,6 +80,7 @@ class NormalizedEvent:
     title: str | None = None
     base_branch: str | None = None
     head_branch: str | None = None
+    delivery_id: str | None = None
     ref: str | None = None
     commit_sha: str | None = None
     is_pull_request: bool = False
@@ -92,6 +93,7 @@ class DaniConfig:
     host: str = "127.0.0.1"
     port: int = 8787
     review_rounds: int = 3
+    external_review_limit: int = 10
 
     @property
     def registry_path(self) -> Path:

--- a/dani/models.py
+++ b/dani/models.py
@@ -6,9 +6,20 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+RUNTIME_OMX = "omx"
+RUNTIME_OMO = "omo"
+
 
 def utc_now() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
+
+
+def infer_runtime_from_session_id(session_id: str | None) -> str | None:
+    if not session_id:
+        return None
+    if session_id.startswith("ses_"):
+        return RUNTIME_OMO
+    return RUNTIME_OMX
 
 
 @dataclass(slots=True)
@@ -57,6 +68,12 @@ class SessionRecord:
     omx_session_id: str | None = None
     stdout_path: str | None = None
     stderr_path: str | None = None
+    preferred_runtime: str | None = None
+    effective_runtime: str | None = None
+    native_session_runtime: str | None = None
+    fallback_reason: str | None = None
+    bridge_source_runtime: str | None = None
+    bridge_source_session_id: str | None = None
     id: str = field(default_factory=lambda: uuid4().hex)
     status: str = "launched"
     ended_at: str | None = None
@@ -66,6 +83,14 @@ class SessionRecord:
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+def effective_session_runtime(session: SessionRecord) -> str | None:
+    if session.effective_runtime:
+        return session.effective_runtime
+    if session.native_session_runtime:
+        return session.native_session_runtime
+    return infer_runtime_from_session_id(session.omx_session_id)
 
 
 @dataclass(slots=True)

--- a/dani/omo_runner.py
+++ b/dani/omo_runner.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import TextIO
+from uuid import uuid4
+
+from dani.agent_runner import ManagedProcess
+from dani.errors import (
+    check_opencode_session_missing_error,
+    check_rollout_missing_error,
+    check_transient_capacity_error,
+)
+from dani.models import JobRecord, SessionRecord
+
+OPENCODE_BIN = "opencode"
+ULTRAWORK_PROMPT_PREFIX = "ultrawork\n\n"
+
+
+class OmoRunner:
+    """Agent runner that drives the ``opencode`` CLI (oh-my-openagents stack)."""
+
+    def __init__(
+        self,
+        run_dir: Path,
+        opencode_bin: str = OPENCODE_BIN,
+    ) -> None:
+        self.run_dir = run_dir
+        self.opencode_bin = opencode_bin
+        self._processes: dict[str, tuple[ManagedProcess, TextIO, TextIO]] = {}
+        self._lock = threading.RLock()
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+
+    def _decorated_prompt(self, prompt: str) -> str:
+        if prompt.lstrip().lower().startswith("ultrawork"):
+            return prompt
+        return f"{ULTRAWORK_PROMPT_PREFIX}{prompt}"
+
+    def launch(self, repo_path: Path, job: JobRecord, prompt: str) -> SessionRecord:
+        session_dir, prompt_path, script_path, stdout_path, stderr_path, handle = self._prepare_session_files(job)
+        prompt_path.write_text(self._decorated_prompt(prompt), encoding="utf-8")
+        script_path.write_text(
+            self._build_script(repo_path=repo_path, prompt_path=prompt_path),
+            encoding="utf-8",
+        )
+        script_path.chmod(0o755)
+        process, stdout_file, stderr_file = self._spawn(script_path, stdout_path, stderr_path)
+        with self._lock:
+            self._processes[handle] = (process, stdout_file, stderr_file)
+        omx_session_id = None
+        if job.stage == "issue_request":
+            omx_session_id = self._capture_session_id(stdout_path=stdout_path)
+        del session_dir
+        return SessionRecord(
+            repo_full_name=job.repo_full_name,
+            stage=job.stage,
+            runtime_handle=handle,
+            prompt_path=str(prompt_path),
+            script_path=str(script_path),
+            worktree_path=str(repo_path),
+            job_id=job.id,
+            issue_number=job.issue_number,
+            pr_number=job.pr_number,
+            review_round=job.review_round,
+            omx_session_id=omx_session_id,
+            stdout_path=str(stdout_path),
+            stderr_path=str(stderr_path),
+        )
+
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
+        session_dir, prompt_path, script_path, stdout_path, stderr_path, handle = self._prepare_session_files(job)
+        prompt_path.write_text(self._decorated_prompt(prompt), encoding="utf-8")
+        script_path.write_text(
+            self._build_resume_script(
+                repo_path=repo_path,
+                prompt_path=prompt_path,
+                opencode_session_id=omx_session_id,
+            ),
+            encoding="utf-8",
+        )
+        script_path.chmod(0o755)
+        process, stdout_file, stderr_file = self._spawn(script_path, stdout_path, stderr_path)
+        with self._lock:
+            self._processes[handle] = (process, stdout_file, stderr_file)
+        del session_dir
+        return SessionRecord(
+            repo_full_name=job.repo_full_name,
+            stage=job.stage,
+            runtime_handle=handle,
+            prompt_path=str(prompt_path),
+            script_path=str(script_path),
+            worktree_path=str(repo_path),
+            job_id=job.id,
+            issue_number=job.issue_number,
+            pr_number=job.pr_number,
+            review_round=job.review_round,
+            omx_session_id=omx_session_id,
+            stdout_path=str(stdout_path),
+            stderr_path=str(stderr_path),
+        )
+
+    def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
+        del poll_interval
+        with self._lock:
+            entry = self._processes.get(runtime_handle)
+        if entry is None:
+            return
+        process, _, _ = entry
+        try:
+            process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired as exc:
+            msg = f"opencode run process did not exit before timeout: {runtime_handle}"
+            raise TimeoutError(msg) from exc
+        self._check_stderr_for_transient_error(runtime_handle)
+
+    def close_session(self, runtime_handle: str) -> None:
+        with self._lock:
+            entry = self._processes.pop(runtime_handle, None)
+        if entry is None:
+            return
+        process, stdout_file, stderr_file = entry
+        try:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+        finally:
+            stdout_file.close()
+            stderr_file.close()
+
+    def get_session_id(self, runtime_handle: str) -> str | None:
+        stdout_path = self.run_dir / runtime_handle / "stdout.log"
+        return self._session_id_from_stdout(stdout_path)
+
+    def _prepare_session_files(self, job: JobRecord) -> tuple[Path, Path, Path, Path, Path, str]:
+        session_token = uuid4().hex[:10]
+        handle = f"dani-{job.stage}-{session_token}"
+        session_dir = self.run_dir / handle
+        session_dir.mkdir(parents=True, exist_ok=True)
+        prompt_path = session_dir / "prompt.txt"
+        script_path = session_dir / "run.sh"
+        stdout_path = session_dir / "stdout.log"
+        stderr_path = session_dir / "stderr.log"
+        return session_dir, prompt_path, script_path, stdout_path, stderr_path, handle
+
+    def _spawn(
+        self, script_path: Path, stdout_path: Path, stderr_path: Path
+    ) -> tuple[subprocess.Popen[bytes], TextIO, TextIO]:
+        stdout_file = stdout_path.open("w", encoding="utf-8")
+        stderr_file = stderr_path.open("w", encoding="utf-8")
+        process = subprocess.Popen(  # noqa: S603
+            [str(script_path)],
+            stdin=subprocess.DEVNULL,
+            stdout=stdout_file,
+            stderr=stderr_file,
+            start_new_session=True,
+        )
+        return process, stdout_file, stderr_file
+
+    def _build_script(self, *, repo_path: Path, prompt_path: Path) -> str:
+        quoted_repo = shlex.quote(str(repo_path))
+        quoted_prompt = shlex.quote(str(prompt_path))
+        quoted_bin = shlex.quote(self.opencode_bin)
+        return (
+            "#!/bin/sh\n"
+            "set -eu\n"
+            f"cd {quoted_repo}\n"
+            f'exec {quoted_bin} run --format json --dangerously-skip-permissions "$(cat {quoted_prompt})"\n'
+        )
+
+    def _build_resume_script(self, *, repo_path: Path, prompt_path: Path, opencode_session_id: str) -> str:
+        quoted_repo = shlex.quote(str(repo_path))
+        quoted_prompt = shlex.quote(str(prompt_path))
+        quoted_session_id = shlex.quote(opencode_session_id)
+        quoted_bin = shlex.quote(self.opencode_bin)
+        return (
+            "#!/bin/sh\n"
+            "set -eu\n"
+            f"cd {quoted_repo}\n"
+            f"exec {quoted_bin} run --session {quoted_session_id} --format json "
+            f'--dangerously-skip-permissions "$(cat {quoted_prompt})"\n'
+        )
+
+    def _check_stderr_for_transient_error(self, runtime_handle: str) -> None:
+        stderr_path = self.run_dir / runtime_handle / "stderr.log"
+        if stderr_path.exists():
+            stderr_text = stderr_path.read_text(encoding="utf-8", errors="replace")
+            check_rollout_missing_error(stderr_text)
+            check_opencode_session_missing_error(stderr_text)
+            check_transient_capacity_error(stderr_text)
+        stdout_path = self.run_dir / runtime_handle / "stdout.log"
+        if stdout_path.exists():
+            stdout_text = stdout_path.read_text(encoding="utf-8", errors="replace")
+            check_opencode_session_missing_error(stdout_text)
+            check_transient_capacity_error(stdout_text)
+
+    def _capture_session_id(
+        self,
+        *,
+        stdout_path: Path,
+        poll_interval: float = 0.5,
+        timeout_seconds: float = 45.0,
+    ) -> str | None:
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            session_id = self._session_id_from_stdout(stdout_path)
+            if session_id:
+                return session_id
+            time.sleep(poll_interval)
+        return None
+
+    def _session_id_from_stdout(self, stdout_path: Path) -> str | None:
+        if not stdout_path.exists():
+            return None
+        try:
+            text = stdout_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return None
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or not line.startswith("{"):
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            session_id = event.get("sessionID") or event.get("sessionId")
+            if isinstance(session_id, str) and session_id.startswith("ses_"):
+                return session_id
+        return None

--- a/dani/omo_runner.py
+++ b/dani/omo_runner.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 
 from dani.agent_runner import ManagedProcess
 from dani.errors import (
+    check_claude_usage_limit_error,
     check_opencode_session_missing_error,
     check_rollout_missing_error,
     check_transient_capacity_error,
@@ -52,7 +53,7 @@ class OmoRunner:
         with self._lock:
             self._processes[handle] = (process, stdout_file, stderr_file)
         omx_session_id = None
-        if job.stage == "issue_request":
+        if job.stage in {"issue_request", "issue_followup"}:
             omx_session_id = self._capture_session_id(stdout_path=stdout_path)
         del session_dir
         return SessionRecord(
@@ -194,11 +195,13 @@ class OmoRunner:
             stderr_text = stderr_path.read_text(encoding="utf-8", errors="replace")
             check_rollout_missing_error(stderr_text)
             check_opencode_session_missing_error(stderr_text)
+            check_claude_usage_limit_error(stderr_text)
             check_transient_capacity_error(stderr_text)
         stdout_path = self.run_dir / runtime_handle / "stdout.log"
         if stdout_path.exists():
             stdout_text = stdout_path.read_text(encoding="utf-8", errors="replace")
             check_opencode_session_missing_error(stdout_text)
+            check_claude_usage_limit_error(stdout_text)
             check_transient_capacity_error(stdout_text)
 
     def _capture_session_id(

--- a/dani/omx_runner.py
+++ b/dani/omx_runner.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Protocol, TextIO
 from uuid import uuid4
 
-from dani.errors import check_transient_capacity_error
+from dani.errors import check_rollout_missing_error, check_transient_capacity_error
 from dani.models import JobRecord, SessionRecord
 
 
@@ -155,6 +155,7 @@ class OmxRunner:
         if not stderr_path.exists():
             return
         stderr_text = stderr_path.read_text(encoding="utf-8", errors="replace")
+        check_rollout_missing_error(stderr_text)
         check_transient_capacity_error(stderr_text)
 
     def close_session(self, runtime_handle: str) -> None:

--- a/dani/omx_runner.py
+++ b/dani/omx_runner.py
@@ -50,7 +50,7 @@ class OmxRunner:
         with self._lock:
             self._processes[process_handle] = (process, stdout_file, stderr_file)
         omx_session_id = None
-        if job.stage == "issue_request":
+        if job.stage in {"issue_request", "issue_followup"}:
             omx_session_id = self._capture_omx_session_id(repo_path=repo_path, prompt=prompt, started_at=started_at)
         return SessionRecord(
             repo_full_name=job.repo_full_name,

--- a/dani/omx_runner.py
+++ b/dani/omx_runner.py
@@ -7,18 +7,14 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Protocol, TextIO
+from typing import TextIO
 from uuid import uuid4
 
+from dani.agent_runner import ManagedProcess
 from dani.errors import check_rollout_missing_error, check_transient_capacity_error
 from dani.models import JobRecord, SessionRecord
 
-
-class ManagedProcess(Protocol):
-    def poll(self) -> object: ...
-    def terminate(self) -> None: ...
-    def wait(self, timeout: float | None = None) -> object: ...
-    def kill(self) -> None: ...
+__all__ = ["ManagedProcess", "OmxRunner"]
 
 
 class OmxRunner:
@@ -175,6 +171,10 @@ class OmxRunner:
         finally:
             stdout_file.close()
             stderr_file.close()
+
+    def get_session_id(self, runtime_handle: str) -> str | None:
+        del runtime_handle
+        return None
 
     def _capture_omx_session_id(
         self,

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -18,14 +18,26 @@ $issue_body
 Existing issue discussion history:
 $discussion
 
+Before writing the comment, do real research — do not produce a plan from memory alone.
+Research requirements:
+- Search the codebase for existing reusable code (modules, functions, utilities, patterns) that already address part of the issue. Cite any findings as path/to/file.py:line.
+- Investigate external sources (official docs, GitHub repos, package registries, web search) for APIs or libraries that already provide the needed capability. Cite any findings as "Title - URL".
+- If nothing is reusable in-repo, state exactly: "no existing reusable code found".
+- If no suitable external dependency exists, state exactly: "no suitable external library found".
+
 Write one GitHub issue comment.
 Checklist:
 - [ ] AI-understood issue summary
 - [ ] Why this issue is needed
 - [ ] Why this issue may not be needed
 - [ ] Expected Outcome
-- [ ] Concise implementation plan
+- [ ] Evidence-based implementation plan
 - [ ] Agent Signature
+
+For the "Evidence-based implementation plan" section, report:
+- Feasibility grounded in the research above (reusable code and/or external libraries, with citations).
+- A concrete step-by-step plan that references the cited evidence (path/to/file.py:line for code, "Title - URL" for external references).
+- Any risks or assumptions surfaced by the research.
 
 Use this exact signature somewhere in the comment:
 $signature
@@ -227,7 +239,18 @@ After the push succeeds, exit.
 }
 
 
-def render_prompt(template_name: str, context: dict[str, Any]) -> str:
+# omx uses codex shell-slash commands ($ralph, $code-review); omo (opencode)
+# has neither, so the equivalent intents are swapped in post-render: ralph loop
+# -> ultrawork mode (always-on for omo), $code-review -> Momus-Plan-Critic subagent.
+_RUNTIME_SUBSTITUTIONS: dict[str, tuple[tuple[str, str], ...]] = {
+    "omo": (
+        ("$code-review", "the Momus-Plan-Critic subagent for rigorous verification"),
+        ("$ralph", "ultrawork"),
+    ),
+}
+
+
+def render_prompt(template_name: str, context: dict[str, Any], *, runtime: str = "omx") -> str:
     template = TEMPLATES[template_name]
     context = dict(context)
     context.setdefault("review_cycle", "")
@@ -238,4 +261,9 @@ def render_prompt(template_name: str, context: dict[str, Any]) -> str:
             **context,
             "signature": build_signature(stage=template_name, job_id=context.get("job_id", "unknown")),
         }
-    return template.substitute({key: "" if value is None else str(value) for key, value in context.items()})
+    rendered = template.substitute({key: "" if value is None else str(value) for key, value in context.items()})
+    substitutions = _RUNTIME_SUBSTITUTIONS.get((runtime or "omx").strip().lower())
+    if substitutions:
+        for needle, replacement in substitutions:
+            rendered = rendered.replace(needle, replacement)
+    return rendered

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -15,6 +15,9 @@ Task: review GitHub issue #$issue_number titled "$issue_title".
 Issue body:
 $issue_body
 
+Existing issue discussion history:
+$discussion
+
 Write one GitHub issue comment.
 Checklist:
 - [ ] AI-understood issue summary
@@ -90,7 +93,7 @@ After creating or updating the PR, exit.
     "review_round": Template(
         """
 You are reviewing PR #$pr_number in $repo.
-Round: $round_number / 3
+Round: $round_number / $round_total
 PR title: $pr_title
 PR body:
 $pr_body
@@ -98,6 +101,7 @@ $pr_body
 Recent discussion:
 $discussion
 
+$review_mode_note
 Use the code locally and run $$code-review before writing the review comment.
 Do real verification, not only static inspection.
 Checklist:
@@ -148,6 +152,7 @@ After posting the PR comment, exit.
     "final_verdict": Template(
         """
 You are deciding the final verdict for PR #$pr_number in $repo.
+$review_cycle
 PR title: $pr_title
 PR body:
 $pr_body
@@ -155,17 +160,40 @@ $pr_body
 Review history:
 $discussion
 
-Leave exactly one final GitHub PR comment.
+Leave exactly one GitHub PR comment for this review pass.
 Checklist:
 - [ ] Verdict: APPROVE or REJECT
 - [ ] Short reason
 - [ ] Real Result from actual verification
 - [ ] Include concrete evidence appropriate for what you verified
+- [ ] If REJECT, make the next contributor action clear
 - [ ] If APPROVE, include: $approve_signature
 - [ ] If REJECT, include: $reject_signature
 
 Post it with gh:
 gh pr comment $pr_number --repo $repo --body-file <final-verdict.md>
+
+After posting the PR comment, exit.
+        """.strip()
+    ),
+    "human_escalation": Template(
+        """
+You are escalating PR #$pr_number in $repo to a human maintainer.
+Review limit reached: $review_limit
+PR title: $pr_title
+PR body:
+$pr_body
+
+Recent review history:
+$discussion
+
+Leave exactly one GitHub PR comment that:
+- [ ] States automated review stopped after $review_limit review passes
+- [ ] Asks a human maintainer to take over triage / scope / merge judgment
+- [ ] Includes this exact signature: $signature
+
+Post it with gh:
+gh pr comment $pr_number --repo $repo --body-file <human-escalation.md>
 
 After posting the PR comment, exit.
         """.strip()
@@ -202,6 +230,9 @@ After the push succeeds, exit.
 def render_prompt(template_name: str, context: dict[str, Any]) -> str:
     template = TEMPLATES[template_name]
     context = dict(context)
+    context.setdefault("review_cycle", "")
+    context.setdefault("round_total", "3")
+    context.setdefault("review_mode_note", "")
     if template_name != "final_verdict" and "signature" not in context:
         context = {
             **context,

--- a/dani/queue.py
+++ b/dani/queue.py
@@ -85,7 +85,7 @@ class RepoQueueManager:
     def _after_job(self, repo: str, job: JobRecord) -> None:
         if not self._needs_issue_lock(job):
             return
-        if job.stage in _TERMINAL_STAGES or job.status == "failed":
+        if job.stage in _TERMINAL_STAGES or job.status in {"failed", "superseded"}:
             self._flush_deferred(repo)
 
     def _flush_deferred(self, repo: str) -> None:

--- a/dani/server.py
+++ b/dani/server.py
@@ -23,7 +23,7 @@ def create_app(service: DaniService) -> FastAPI:
         if event_name is None:
             raise HTTPException(status_code=400, detail="missing event name")
         payload = parse_body(body)
-        event = normalize_event(event_name, payload)
+        event = normalize_event(event_name, payload, delivery_id=request.headers.get("x-github-delivery"))
         if event is None:
             return {"status": "ignored", "reason": "unsupported_event"}
         return service.handle_event(event)

--- a/dani/service.py
+++ b/dani/service.py
@@ -7,14 +7,14 @@ import time
 from pathlib import Path
 from typing import Any
 
-from dani.errors import TransientCapacityError
+from dani.errors import ROLLOUT_MISSING_PATTERNS, RolloutMissingError, TransientCapacityError
 from dani.git_sync import DevSyncConflictError, GitDevSyncer
 from dani.github import GitHubCLI, MergeConflictError
 from dani.models import DaniConfig, JobRecord, NormalizedEvent, RepoConfig, SessionRecord, utc_now
 from dani.omx_runner import OmxRunner
 from dani.prompts import render_prompt
 from dani.queue import RepoQueueManager
-from dani.signatures import build_signature, parse_signature
+from dani.signatures import build_signature, is_opt_out_comment, parse_signature
 from dani.storage import JsonStorage
 
 ISSUE_REF_PATTERN = re.compile(r"#(?P<number>\d+)")
@@ -76,6 +76,26 @@ class DaniService:
     def state_snapshot(self) -> dict[str, Any]:
         return self.storage.snapshot()
 
+    def restart_issue(self, repo_full_name: str, issue_number: int) -> JobRecord:
+        repo = self.storage.get_repo(repo_full_name)
+        if repo is None:
+            msg = f"missing_repo: {repo_full_name}"
+            raise RuntimeError(msg)
+
+        for job in self.storage.find_jobs(repo_full_name=repo_full_name, issue_number=issue_number):
+            self.storage.update_job(job.id, status="superseded")
+
+        issue_metadata = self._issue_metadata(repo_full_name, issue_number)
+        return self._enqueue_job(
+            repo,
+            stage="issue_request",
+            issue_number=issue_number,
+            metadata={
+                "title": issue_metadata.get("title", f"Issue #{issue_number}"),
+                "body": issue_metadata.get("body", ""),
+            },
+        )
+
     def handle_event(self, event: NormalizedEvent) -> dict[str, Any]:
         self.storage.append_event({
             "repo_full_name": event.repo_full_name,
@@ -87,12 +107,16 @@ class DaniService:
             "title": event.title,
             "base_branch": event.base_branch,
             "head_branch": event.head_branch,
+            "delivery_id": event.delivery_id,
             "ref": event.ref,
             "commit_sha": event.commit_sha,
         })
         repo = self.storage.get_repo(event.repo_full_name)
         if repo is None or not repo.enabled:
             return {"status": "ignored", "reason": "unregistered_repo"}
+
+        if event.kind in {"issue_comment", "pull_request_comment"} and is_opt_out_comment(event.body):
+            return {"status": "ignored", "reason": "comment_opt_out"}
 
         signature = parse_signature(event.body or "")
         if signature and event.kind != "pull_request_opened":
@@ -118,7 +142,7 @@ class DaniService:
     def _handle_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         stage = signature.get("stage")
         if stage == "review_round":
-            return self._handle_review_round_agent_event(event, signature)
+            return self._handle_review_round_event(event, signature)
 
         if stage == "implementation" and event.kind == "pull_request_comment":
             return self._handle_implementation_agent_event(event, signature)
@@ -130,36 +154,6 @@ class DaniService:
             return self._handle_final_verdict_agent_event(event, signature)
 
         return {"status": "updated", "stage": stage}
-
-    def _handle_review_round_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
-        event_key = self._agent_event_key(signature, default_pr=event.number if event.is_pull_request else None)
-        if not self.storage.record_processed_event(event_key):
-            return {"status": "ignored", "reason": "duplicate_agent_event"}
-        review_round = int(signature["round"])
-        pr_number = int(signature["pr"])
-        issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
-        if issue_number is None:
-            return {"status": "ignored", "reason": "untracked_pr"}
-        repo = self.storage.get_repo(event.repo_full_name)
-        if repo is None:
-            return {"status": "ignored", "reason": "missing_repo"}
-        if not self._is_pr_open(event.repo_full_name, pr_number):
-            return {"status": "ignored", "reason": "pr_not_open"}
-        pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
-        next_job = self._enqueue_job(
-            repo,
-            stage="implementation",
-            issue_number=issue_number,
-            pr_number=pr_number,
-            review_round=review_round,
-            metadata={
-                **pr_metadata,
-                "title": (pr_metadata.get("title") or event.title or ""),
-                "review_comment_body": event.body or "",
-                "triggering_review_round": review_round,
-            },
-        )
-        return {"status": "queued", "job_id": next_job.id, "stage": next_job.stage}
 
     def _handle_implementation_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         pr_number = int(signature.get("pr") or event.number)
@@ -206,10 +200,13 @@ class DaniService:
     def _handle_merge_conflict_resolution_agent_event(
         self, event: NormalizedEvent, signature: dict[str, str]
     ) -> dict[str, Any]:
+        pr_number = int(signature["pr"])
+        event_key = self._agent_event_key(signature, default_pr=pr_number)
+        if not self.storage.record_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_agent_event"}
         repo = self.storage.get_repo(event.repo_full_name)
         if repo is None:
             return {"status": "ignored", "reason": "missing_repo"}
-        pr_number = int(signature["pr"])
         if not self._is_pr_open(event.repo_full_name, pr_number):
             return {"status": "ignored", "reason": "pr_not_open"}
         pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
@@ -230,6 +227,9 @@ class DaniService:
 
     def _handle_final_verdict_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         pr_number = int(signature["pr"])
+        event_key = self._agent_event_key(signature, default_pr=pr_number)
+        if self.storage.has_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_agent_event"}
         if not self._is_pr_open(event.repo_full_name, pr_number):
             return {"status": "ignored", "reason": "pr_not_open"}
         try:
@@ -239,10 +239,13 @@ class DaniService:
             if repo is None:
                 return {"status": "ignored", "reason": "missing_repo"}
             pull_request = self.github.get_pull_request(event.repo_full_name, pr_number)
+            issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
+            if issue_number is None:
+                issue_number = self._extract_issue_number(pull_request.get("body"))
             merge_conflict_job = self._enqueue_job(
                 repo,
                 stage="merge_conflict_resolution",
-                issue_number=self._extract_issue_number(pull_request.get("body")),
+                issue_number=issue_number,
                 pr_number=pr_number,
                 metadata={
                     "title": pull_request.get("title") or event.title or f"PR #{pr_number}",
@@ -252,8 +255,100 @@ class DaniService:
                     "conflict_reason": str(exc),
                 },
             )
+            self.storage.record_processed_event(event_key)
             return {"status": "queued", "job_id": merge_conflict_job.id, "stage": merge_conflict_job.stage}
+        self.storage.record_processed_event(event_key)
         return {"status": "merged", "pr_number": pr_number}
+
+    def _handle_review_round_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
+        event_key = self._agent_event_key(signature, default_pr=event.number if event.is_pull_request else None)
+        if not self.storage.record_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_agent_event"}
+        review_round = int(signature["round"])
+        pr_number = int(signature["pr"])
+        issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
+        if issue_number is None:
+            return {"status": "ignored", "reason": "untracked_pr"}
+        source_job = self.storage.get_job(signature.get("job", ""))
+        repo = self.storage.get_repo(event.repo_full_name)
+        if repo is None:
+            return {"status": "ignored", "reason": "missing_repo"}
+        if not self._is_pr_open(event.repo_full_name, pr_number):
+            return {"status": "ignored", "reason": "pr_not_open"}
+        pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
+        if bool(source_job and source_job.metadata.get("external_contribution")):
+            return self._handle_external_review_round_event(
+                repo,
+                event,
+                source_job=source_job,
+                pr_metadata=pr_metadata,
+                issue_number=issue_number,
+                pr_number=pr_number,
+                review_round=review_round,
+            )
+        if issue_number is None:
+            return {"status": "ignored", "reason": "untracked_pr"}
+        if not self._is_pr_open(event.repo_full_name, pr_number):
+            return {"status": "ignored", "reason": "pr_not_open"}
+        next_job = self._enqueue_job(
+            repo,
+            stage="implementation",
+            issue_number=issue_number,
+            pr_number=pr_number,
+            review_round=review_round,
+            metadata={
+                **pr_metadata,
+                "title": (pr_metadata.get("title") or event.title or ""),
+                "review_comment_body": event.body or "",
+                "triggering_review_round": review_round,
+            },
+        )
+        return {"status": "queued", "job_id": next_job.id, "stage": next_job.stage}
+
+    def _handle_external_review_round_event(
+        self,
+        repo: RepoConfig,
+        event: NormalizedEvent,
+        *,
+        source_job: JobRecord,
+        pr_metadata: dict[str, str],
+        issue_number: int | None,
+        pr_number: int,
+        review_round: int,
+    ) -> dict[str, Any]:
+        if self._is_approve_comment(event.body):
+            verdict_job = self._enqueue_job(
+                repo,
+                stage="final_verdict",
+                issue_number=issue_number,
+                pr_number=pr_number,
+                review_round=review_round,
+                metadata={
+                    **pr_metadata,
+                    "title": (pr_metadata.get("title") or event.title or ""),
+                    "external_contribution": True,
+                },
+            )
+            return {"status": "queued", "job_id": verdict_job.id, "stage": verdict_job.stage}
+
+        completed_reviews = self._completed_external_review_count(event.repo_full_name, pr_number)
+        if source_job.status != "completed":
+            completed_reviews += 1
+        if completed_reviews >= self.config.external_review_limit and not self._has_human_escalation(
+            event.repo_full_name, pr_number
+        ):
+            escalation_job = self._enqueue_external_human_escalation(
+                repo,
+                issue_number=issue_number,
+                pr_number=pr_number,
+                metadata={
+                    **pr_metadata,
+                    "title": (pr_metadata.get("title") or event.title or ""),
+                    "external_contribution": True,
+                },
+            )
+            return {"status": "queued", "job_id": escalation_job.id, "stage": escalation_job.stage}
+        return {"status": "updated", "stage": "review_round"}
 
     def _enqueue_job(
         self,
@@ -278,6 +373,11 @@ class DaniService:
         return job
 
     def _run_job(self, job: JobRecord) -> None:
+        stored_job = self.storage.get_job(job.id)
+        if stored_job is not None and stored_job.status == "superseded":
+            job.status = "superseded"
+            return
+
         repo = self.storage.get_repo(job.repo_full_name)
         if repo is None:
             self.storage.update_job(job.id, status="failed", metadata={**job.metadata, "error": "missing repo"})
@@ -393,16 +493,18 @@ class DaniService:
         attempt: int,
         retry_history: list[dict[str, str]],
     ) -> None:
-        self.storage.update_job(
-            job.id,
-            status="failed",
-            metadata={
-                **job.metadata,
-                "error": str(exc),
-                "retry_attempts": attempt - 1,
-                "retry_history": retry_history,
-            },
-        )
+        metadata = {
+            **job.metadata,
+            "error": str(exc),
+            "retry_attempts": attempt - 1,
+            "retry_history": retry_history,
+        }
+        if self._is_rollout_missing_error(exc):
+            metadata["error"] = "rollout_missing"
+            metadata["error_detail"] = str(exc)
+            with contextlib.suppress(Exception):
+                self._post_session_lost_warning(job)
+        self.storage.update_job(job.id, status="failed", metadata=metadata)
 
     def _run_dev_sync_job(self, repo: RepoConfig, job: JobRecord) -> None:
         session = None
@@ -491,6 +593,9 @@ class DaniService:
         if job.stage == "review_round":
             return self._build_review_round_prompt(repo, job, issue_number, pr_number, pr_title, pr_body)
 
+        if job.stage == "human_escalation":
+            return self._build_human_escalation_prompt(repo, job, issue_number, pr_number, pr_title, pr_body)
+
         if job.stage == "merge_conflict_resolution":
             return self._build_merge_conflict_resolution_prompt(repo, job, issue_number, pr_number, pr_title, pr_body)
 
@@ -508,6 +613,9 @@ class DaniService:
             return
         if job.stage == "review_round":
             self._verify_review_round_side_effect(repo, job)
+            return
+        if job.stage == "human_escalation":
+            self._verify_human_escalation_side_effect(repo, job)
             return
         if job.stage == "merge_conflict_resolution":
             self._verify_merge_conflict_resolution_side_effect(repo, job)
@@ -531,6 +639,7 @@ class DaniService:
                 "issue_number": issue_number,
                 "issue_title": issue_title,
                 "issue_body": issue_body,
+                "discussion": self._render_issue_discussion(repo.full_name, issue_number),
                 "signature": build_signature(stage="issue_request", job=job.id, issue=issue_number),
             },
         )
@@ -641,6 +750,7 @@ class DaniService:
         pr_discussion = self._render_pr_discussion(repo.full_name, pr_number)
         if pr_discussion:
             discussion_parts.append(pr_discussion)
+        is_external_review = bool(job.metadata.get("external_contribution"))
         return render_prompt(
             "review_round",
             {
@@ -650,6 +760,13 @@ class DaniService:
                 "pr_body": pr_body,
                 "discussion": "\n\n".join(discussion_parts),
                 "round_number": job.review_round or 1,
+                "round_total": self.config.external_review_limit if is_external_review else self.config.review_rounds,
+                "review_mode_note": (
+                    "This is an external contribution PR. The contributor owns any follow-up implementation. "
+                    "If the PR is ready to merge, include /approve in your review comment so dani can run the final verdict pass."
+                    if is_external_review
+                    else ""
+                ),
                 "signature": build_signature(**signature_fields),
             },
         )
@@ -701,6 +818,11 @@ class DaniService:
                 "pr_title": pr_title,
                 "pr_body": pr_body,
                 "discussion": "\n\n".join(discussion_parts),
+                "review_cycle": (
+                    f"Review pass: {job.review_round} / {self.config.external_review_limit}"
+                    if job.review_round and job.metadata.get("external_contribution")
+                    else ""
+                ),
                 "approve_signature": build_signature(
                     stage="final_verdict", job=job.id, pr=pr_number, verdict="APPROVE"
                 ),
@@ -708,13 +830,42 @@ class DaniService:
             },
         )
 
+    def _build_human_escalation_prompt(
+        self,
+        repo: RepoConfig,
+        job: JobRecord,
+        issue_number: int,
+        pr_number: int,
+        pr_title: str,
+        pr_body: str,
+    ) -> str:
+        discussion_parts = []
+        if issue_number:
+            discussion_parts.append(f"Related issue: #{issue_number}")
+        pr_discussion = self._render_pr_discussion(repo.full_name, pr_number)
+        if pr_discussion:
+            discussion_parts.append(pr_discussion)
+        return render_prompt(
+            "human_escalation",
+            {
+                "repo": repo.full_name,
+                "pr_number": pr_number,
+                "pr_title": pr_title,
+                "pr_body": pr_body,
+                "discussion": "\n\n".join(discussion_parts),
+                "review_limit": self.config.external_review_limit,
+                "signature": build_signature(stage="human_escalation", job=job.id, pr=pr_number),
+            },
+        )
+
     def _verify_issue_request_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
-        if self.github.latest_signature_comment(repo.full_name, int(job.issue_number or 0), kind="issue") is None:
+        signature = build_signature(stage="issue_request", job=job.id, issue=int(job.issue_number or 0))
+        if not self._has_exact_issue_signature(repo.full_name, int(job.issue_number or 0), signature):
             raise RuntimeError("issue-request-comment-missing")
 
     def _verify_issue_followup_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
-        latest_comment = self.github.latest_signature_comment(repo.full_name, int(job.issue_number or 0), kind="issue")
-        if latest_comment is None or latest_comment[1].get("stage") != "issue_followup":
+        signature = build_signature(stage="issue_followup", job=job.id, issue=int(job.issue_number or 0))
+        if not self._has_exact_issue_signature(repo.full_name, int(job.issue_number or 0), signature):
             raise RuntimeError("issue-followup-comment-missing")
 
     def _verify_implementation_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
@@ -771,9 +922,21 @@ class DaniService:
         ):
             raise RuntimeError("final-verdict-comment-missing")
 
+    def _verify_human_escalation_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
+        signature = build_signature(stage="human_escalation", job=job.id, pr=int(job.pr_number or 0))
+        if not self._has_exact_pr_signature(repo.full_name, int(job.pr_number or 0), signature):
+            raise RuntimeError("human-escalation-comment-missing")
+
     def _has_exact_pr_signature(self, repo_full_name: str, pr_number: int, signature: str) -> bool:
         return bool(
             self.github.find_comments_by_signature(repo_full_name, pr_number, kind="pr", signature_fragment=signature)
+        )
+
+    def _has_exact_issue_signature(self, repo_full_name: str, issue_number: int, signature: str) -> bool:
+        return bool(
+            self.github.find_comments_by_signature(
+                repo_full_name, issue_number, kind="issue", signature_fragment=signature
+            )
         )
 
     def _is_approve_comment(self, body: str | None) -> bool:
@@ -875,17 +1038,82 @@ class DaniService:
                 self.storage.update_job(signature["job"], status="completed", pr_number=event.number)
         if issue_number is None:
             issue_number = self._extract_issue_number(event.body)
+        is_agent_managed_pr = bool(signature and signature.get("stage") == "implementation")
+        if is_agent_managed_pr:
+            if event.action != "opened":
+                return {"status": "ignored", "reason": "agent_managed_pr_followup"}
+            job = self._enqueue_job(
+                repo,
+                stage="review_round",
+                issue_number=issue_number,
+                pr_number=event.number,
+                review_round=1,
+                metadata={"title": event.title or "", "body": event.body or ""},
+            )
+            return {"status": "queued", "job_id": job.id, "stage": job.stage}
+
         if issue_number is None:
             return {"status": "ignored", "reason": "untracked_pr"}
+        return self._queue_external_pull_request_review(
+            repo,
+            event,
+            issue_number=issue_number,
+        )
+
+    def _queue_external_pull_request_review(
+        self,
+        repo: RepoConfig,
+        event: NormalizedEvent,
+        *,
+        issue_number: int,
+    ) -> dict[str, Any]:
+        event_key = self._external_pull_request_event_key(event)
+        if not self.storage.record_processed_event(event_key):
+            return {"status": "ignored", "reason": "duplicate_external_pr_event"}
+
+        if self._has_human_escalation(event.repo_full_name, event.number):
+            return {"status": "ignored", "reason": "human_review_required"}
+
+        completed_reviews = self._completed_external_review_count(event.repo_full_name, event.number)
+        consumed_review_rounds = self._consumed_external_review_rounds(event.repo_full_name, event.number)
+        if completed_reviews >= self.config.external_review_limit:
+            escalation_job = self._enqueue_external_human_escalation(
+                repo,
+                issue_number=issue_number,
+                pr_number=event.number,
+                metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
+            )
+            return {"status": "queued", "job_id": escalation_job.id, "stage": escalation_job.stage}
+
+        if len(consumed_review_rounds) >= self.config.external_review_limit:
+            return {"status": "ignored", "reason": "external_review_limit_pending"}
+
+        next_review_round = max(consumed_review_rounds, default=0) + 1
         job = self._enqueue_job(
             repo,
             stage="review_round",
             issue_number=issue_number,
             pr_number=event.number,
-            review_round=1,
-            metadata={"title": event.title or "", "body": event.body or ""},
+            review_round=next_review_round,
+            metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
         )
         return {"status": "queued", "job_id": job.id, "stage": job.stage}
+
+    def _enqueue_external_human_escalation(
+        self,
+        repo: RepoConfig,
+        *,
+        issue_number: int | None,
+        pr_number: int,
+        metadata: dict[str, Any],
+    ) -> JobRecord:
+        return self._enqueue_job(
+            repo,
+            stage="human_escalation",
+            issue_number=issue_number,
+            pr_number=pr_number,
+            metadata=metadata,
+        )
 
     def _latest_resumable_session(
         self,
@@ -913,12 +1141,62 @@ class DaniService:
                 fields.append((key, value))
         return ";".join(f"{key}={value}" for key, value in fields)
 
+    def _external_pull_request_event_key(self, event: NormalizedEvent) -> str:
+        if event.delivery_id:
+            return f"external_pr_event;delivery={event.delivery_id}"
+
+        fields = [
+            ("repo", event.repo_full_name),
+            ("kind", event.kind),
+            ("pr", str(event.number)),
+            ("action", event.action),
+        ]
+        if event.commit_sha:
+            fields.append(("head_sha", event.commit_sha))
+        elif event.head_branch:
+            fields.append(("head_branch", event.head_branch))
+        requested_reviewer = event.payload.get("requested_reviewer") or {}
+        reviewer_login = requested_reviewer.get("login")
+        if reviewer_login:
+            fields.append(("reviewer", str(reviewer_login)))
+        requested_team = event.payload.get("requested_team") or {}
+        team_slug = requested_team.get("slug") or requested_team.get("name")
+        if team_slug:
+            fields.append(("team", str(team_slug)))
+        updated_at = (event.payload.get("pull_request") or {}).get("updated_at")
+        if updated_at:
+            fields.append(("updated_at", str(updated_at)))
+        return ";".join(f"{key}={value}" for key, value in fields)
+
     def _latest_review_round(self, repo_full_name: str, pr_number: int) -> int:
         rounds = [
             int(job.review_round or 0)
             for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
         ]
         return max(rounds, default=0)
+
+    def _completed_external_review_count(self, repo_full_name: str, pr_number: int) -> int:
+        return sum(
+            1
+            for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
+            if job.metadata.get("external_contribution") and job.status == "completed"
+        )
+
+    def _consumed_external_review_rounds(self, repo_full_name: str, pr_number: int) -> set[int]:
+        return {
+            int(job.review_round)
+            for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
+            if (
+                job.metadata.get("external_contribution")
+                and job.review_round is not None
+                and job.status in {"queued", "launched", "completed"}
+            )
+        }
+
+    def _has_human_escalation(self, repo_full_name: str, pr_number: int) -> bool:
+        return bool(
+            self.storage.find_jobs(repo_full_name=repo_full_name, stage="human_escalation", pr_number=pr_number)
+        )
 
     def _issue_number_for_signature_event(
         self,
@@ -973,3 +1251,44 @@ class DaniService:
             author = comment.get("user", {}).get("login") or comment.get("author", {}).get("login") or "unknown"
             rendered.append(f"[{author}]\n{body}")
         return "\n\n".join(rendered)
+
+    def _render_issue_discussion(self, repo_full_name: str, issue_number: int, *, limit: int = 8) -> str:
+        comments = self.github.issue_comments(repo_full_name, issue_number)
+        rendered: list[str] = []
+        for comment in comments[-limit:]:
+            body = str(comment.get("body") or "").strip()
+            if not body:
+                continue
+            author = comment.get("user", {}).get("login") or comment.get("author", {}).get("login") or "unknown"
+            rendered.append(f"[{author}]\n{body}")
+        return "\n\n".join(rendered)
+
+    def _is_rollout_missing_error(self, exc: Exception) -> bool:
+        if isinstance(exc, RolloutMissingError):
+            return True
+        error_text = str(exc)
+        return any(pattern.search(error_text) for pattern in ROLLOUT_MISSING_PATTERNS)
+
+    def _post_session_lost_warning(self, job: JobRecord) -> None:
+        if job.stage != "issue_followup" or job.issue_number is None:
+            return
+        event_key = f"repo={job.repo_full_name};stage=session_lost;issue={job.issue_number}"
+        signature = build_signature(stage="session_lost", issue=job.issue_number)
+        if self.github.find_comments_by_signature(
+            job.repo_full_name,
+            job.issue_number,
+            kind="issue",
+            signature_fragment=signature,
+        ):
+            if not self.storage.has_processed_event(event_key):
+                self.storage.record_processed_event(event_key)
+            return
+        if self.storage.has_processed_event(event_key):
+            return
+        body = (
+            "⚠️ dani 세션 기록이 유실되어 이전 대화를 이어갈 수 없습니다. "
+            f"`dani restart-issue {job.repo_full_name} {job.issue_number}` 로 새 세션을 시작해 주세요.\n\n"
+            f"{signature}"
+        )
+        self.github.create_issue_comment(job.repo_full_name, job.issue_number, body)
+        self.storage.record_processed_event(event_key)

--- a/dani/service.py
+++ b/dani/service.py
@@ -7,11 +7,16 @@ import time
 from pathlib import Path
 from typing import Any
 
-from dani.errors import ROLLOUT_MISSING_PATTERNS, RolloutMissingError, TransientCapacityError
+from dani.agent_runner import AgentRunner, build_agent_runner
+from dani.errors import (
+    OPENCODE_SESSION_MISSING_PATTERNS,
+    ROLLOUT_MISSING_PATTERNS,
+    RolloutMissingError,
+    TransientCapacityError,
+)
 from dani.git_sync import DevSyncConflictError, GitDevSyncer
 from dani.github import GitHubCLI, MergeConflictError
 from dani.models import DaniConfig, JobRecord, NormalizedEvent, RepoConfig, SessionRecord, utc_now
-from dani.omx_runner import OmxRunner
 from dani.prompts import render_prompt
 from dani.queue import RepoQueueManager
 from dani.signatures import build_signature, is_opt_out_comment, parse_signature
@@ -30,13 +35,16 @@ class DaniService:
         config: DaniConfig,
         storage: JsonStorage | None = None,
         github: Any = None,
-        omx_runner: Any = None,
+        omx_runner: AgentRunner | None = None,
         dev_syncer: Any = None,
     ) -> None:
         self.config = config
         self.storage = storage or JsonStorage(config)
         self.github = github or GitHubCLI()
-        self.omx_runner = omx_runner or OmxRunner(config.run_dir)
+        self.omx_runner: AgentRunner = omx_runner or build_agent_runner(
+            config.agent_runtime,
+            config.run_dir,
+        )
         self.dev_syncer = dev_syncer or GitDevSyncer(config.run_dir)
         self.queue_manager = RepoQueueManager(self._run_job)
 
@@ -424,6 +432,10 @@ class DaniService:
         except Exception:
             self._finalize_session(session, status="failed", termination_reason="failed")
             raise
+        if session.omx_session_id is None:
+            post_wait_session_id = self.omx_runner.get_session_id(session.runtime_handle)
+            if post_wait_session_id:
+                self.storage.update_session(session.id, omx_session_id=post_wait_session_id)
         self._finalize_session(session, status="completed", termination_reason="completed")
 
     def _handle_transient_failure(
@@ -527,6 +539,7 @@ class DaniService:
                     "temp_branch": conflict_context.temp_branch,
                     "commit_message": self.dev_syncer.build_commit_message(repo, job),
                 },
+                runtime=self.config.agent_runtime,
             )
             session = self.omx_runner.launch(conflict_context.worktree_path, job, prompt)
             self.storage.create_session(session)
@@ -546,7 +559,7 @@ class DaniService:
             self.storage.update_job(
                 job.id,
                 status="completed",
-                metadata={**job.metadata, "sync_status": "resolved_with_omx"},
+                metadata={**job.metadata, "sync_status": "resolved_with_agent"},
             )
         except Exception as exc:
             if session is not None:
@@ -642,6 +655,7 @@ class DaniService:
                 "discussion": self._render_issue_discussion(repo.full_name, issue_number),
                 "signature": build_signature(stage="issue_request", job=job.id, issue=issue_number),
             },
+            runtime=self.config.agent_runtime,
         )
 
     def _build_implementation_prompt(
@@ -704,6 +718,7 @@ class DaniService:
                 "signature": signature,
                 "signature_instructions": signature_instructions,
             },
+            runtime=self.config.agent_runtime,
         )
 
     def _build_issue_followup_prompt(
@@ -725,6 +740,7 @@ class DaniService:
                 "comment_body": job.metadata.get("comment_body", ""),
                 "signature": build_signature(stage="issue_followup", job=job.id, issue=issue_number),
             },
+            runtime=self.config.agent_runtime,
         )
 
     def _build_review_round_prompt(
@@ -769,6 +785,7 @@ class DaniService:
                 ),
                 "signature": build_signature(**signature_fields),
             },
+            runtime=self.config.agent_runtime,
         )
 
     def _build_merge_conflict_resolution_prompt(
@@ -794,6 +811,7 @@ class DaniService:
                 "conflict_reason": job.metadata.get("conflict_reason", "Merge conflict detected while merging."),
                 "signature": build_signature(stage="merge_conflict_resolution", job=job.id, pr=pr_number),
             },
+            runtime=self.config.agent_runtime,
         )
 
     def _build_final_verdict_prompt(
@@ -828,6 +846,7 @@ class DaniService:
                 ),
                 "reject_signature": build_signature(stage="final_verdict", job=job.id, pr=pr_number, verdict="REJECT"),
             },
+            runtime=self.config.agent_runtime,
         )
 
     def _build_human_escalation_prompt(
@@ -856,6 +875,7 @@ class DaniService:
                 "review_limit": self.config.external_review_limit,
                 "signature": build_signature(stage="human_escalation", job=job.id, pr=pr_number),
             },
+            runtime=self.config.agent_runtime,
         )
 
     def _verify_issue_request_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
@@ -1267,7 +1287,9 @@ class DaniService:
         if isinstance(exc, RolloutMissingError):
             return True
         error_text = str(exc)
-        return any(pattern.search(error_text) for pattern in ROLLOUT_MISSING_PATTERNS)
+        return any(
+            pattern.search(error_text) for pattern in (*ROLLOUT_MISSING_PATTERNS, *OPENCODE_SESSION_MISSING_PATTERNS)
+        )
 
     def _post_session_lost_warning(self, job: JobRecord) -> None:
         if job.stage != "issue_followup" or job.issue_number is None:

--- a/dani/service.py
+++ b/dani/service.py
@@ -4,21 +4,34 @@ import contextlib
 import logging
 import re
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from dani.agent_runner import AgentRunner, build_agent_runner
+from dani.agent_runner import AgentRunner, build_agent_runner, normalize_runtime
 from dani.errors import (
     OPENCODE_SESSION_MISSING_PATTERNS,
     ROLLOUT_MISSING_PATTERNS,
+    ClaudeUsageLimitError,
     RolloutMissingError,
     TransientCapacityError,
 )
 from dani.git_sync import DevSyncConflictError, GitDevSyncer
 from dani.github import GitHubCLI, MergeConflictError
-from dani.models import DaniConfig, JobRecord, NormalizedEvent, RepoConfig, SessionRecord, utc_now
+from dani.models import (
+    RUNTIME_OMO,
+    RUNTIME_OMX,
+    DaniConfig,
+    JobRecord,
+    NormalizedEvent,
+    RepoConfig,
+    SessionRecord,
+    effective_session_runtime,
+    utc_now,
+)
 from dani.prompts import render_prompt
 from dani.queue import RepoQueueManager
+from dani.session_bridge import BridgeContext, OmoSessionBridge
 from dani.signatures import build_signature, is_opt_out_comment, parse_signature
 from dani.storage import JsonStorage
 
@@ -37,15 +50,19 @@ class DaniService:
         github: Any = None,
         omx_runner: AgentRunner | None = None,
         dev_syncer: Any = None,
+        runtime_runners: dict[str, AgentRunner] | None = None,
+        session_bridge: OmoSessionBridge | None = None,
     ) -> None:
         self.config = config
         self.storage = storage or JsonStorage(config)
         self.github = github or GitHubCLI()
-        self.omx_runner: AgentRunner = omx_runner or build_agent_runner(
-            config.agent_runtime,
-            config.run_dir,
-        )
+        preferred_runtime = normalize_runtime(config.agent_runtime)
+        self.omx_runner: AgentRunner = omx_runner or build_agent_runner(preferred_runtime, config.run_dir)
+        self._runtime_runners: dict[str, AgentRunner] = {preferred_runtime: self.omx_runner}
+        if runtime_runners:
+            self._runtime_runners.update({normalize_runtime(name): runner for name, runner in runtime_runners.items()})
         self.dev_syncer = dev_syncer or GitDevSyncer(config.run_dir)
+        self.session_bridge = session_bridge or OmoSessionBridge()
         self.queue_manager = RepoQueueManager(self._run_job)
 
     def register_repo(
@@ -419,24 +436,222 @@ class DaniService:
                 return
 
     def _run_job_attempt(self, repo: RepoConfig, job: JobRecord) -> None:
-        prompt = self._build_prompt(repo, job)
-        if job.stage == "issue_followup":
-            session = self.omx_runner.resume(Path(repo.local_path), job, prompt, self._omx_session_id_for(job))
-        else:
-            session = self.omx_runner.launch(Path(repo.local_path), job, prompt)
-        self.storage.create_session(session)
-        self.storage.update_job(job.id, status="launched", session_id=session.id)
+        preferred_runtime = self._preferred_runtime_for(job)
+        lineage_session = self._lineage_session_for(job)
+        initial_runtime = self._initial_runtime_for(job, preferred_runtime, lineage_session)
         try:
-            self.omx_runner.wait(session.runtime_handle)
+            session = self._execute_job_session(
+                repo,
+                job,
+                runtime=initial_runtime,
+                preferred_runtime=preferred_runtime,
+                resume_session=lineage_session if job.stage == "issue_followup" else None,
+            )
+        except ClaudeUsageLimitError as exc:
+            if initial_runtime != RUNTIME_OMO:
+                raise
+            bridge = self._bridge_context_for(repo, job, lineage_session)
+            session = self._execute_job_session(
+                repo,
+                job,
+                runtime=RUNTIME_OMX,
+                preferred_runtime=preferred_runtime,
+                bridge_context=bridge,
+                fallback_reason=f"claude_{exc.limit_type}_limit",
+                usage_limit_error=exc,
+            )
+        self.storage.update_job(
+            job.id,
+            status="launched",
+            session_id=session.id,
+            metadata={**job.metadata, "effective_runtime": session.effective_runtime or initial_runtime},
+        )
+
+    def _execute_job_session(
+        self,
+        repo: RepoConfig,
+        job: JobRecord,
+        *,
+        runtime: str,
+        preferred_runtime: str,
+        resume_session: SessionRecord | None = None,
+        bridge_context: BridgeContext | None = None,
+        fallback_reason: str | None = None,
+        usage_limit_error: ClaudeUsageLimitError | None = None,
+    ) -> SessionRecord:
+        prompt = self._build_prompt(
+            repo,
+            job,
+            runtime=runtime,
+            bridge_prompt=(bridge_context.prompt_block if bridge_context else ""),
+        )
+        runner = self._runner_for_runtime(runtime)
+        if resume_session is not None and effective_session_runtime(resume_session) == runtime:
+            session = runner.resume(Path(repo.local_path), job, prompt, self._session_id_for_resume(job, resume_session))
+        else:
+            session = runner.launch(Path(repo.local_path), job, prompt)
+
+        self._annotate_session_record(
+            session,
+            preferred_runtime=preferred_runtime,
+            effective_runtime=runtime,
+            fallback_reason=fallback_reason,
+            bridge_context=bridge_context,
+        )
+        self.storage.create_session(session)
+        try:
+            runner.wait(session.runtime_handle)
             self._verify_side_effect(repo, job)
         except Exception:
             self._finalize_session(session, status="failed", termination_reason="failed")
             raise
         if session.omx_session_id is None:
-            post_wait_session_id = self.omx_runner.get_session_id(session.runtime_handle)
+            post_wait_session_id = runner.get_session_id(session.runtime_handle)
             if post_wait_session_id:
-                self.storage.update_session(session.id, omx_session_id=post_wait_session_id)
+                session.omx_session_id = post_wait_session_id
+                self.storage.update_session(
+                    session.id,
+                    omx_session_id=post_wait_session_id,
+                    native_session_runtime=session.native_session_runtime or runtime,
+                    effective_runtime=session.effective_runtime or runtime,
+                )
         self._finalize_session(session, status="completed", termination_reason="completed")
+        self._update_job_runtime_metadata(
+            job,
+            preferred_runtime=preferred_runtime,
+            effective_runtime=runtime,
+            fallback_reason=fallback_reason,
+            bridge_context=bridge_context,
+            usage_limit_error=usage_limit_error,
+            session=session,
+        )
+        return session
+
+    def _annotate_session_record(
+        self,
+        session: SessionRecord,
+        *,
+        preferred_runtime: str,
+        effective_runtime: str,
+        fallback_reason: str | None,
+        bridge_context: BridgeContext | None = None,
+    ) -> None:
+        session.preferred_runtime = preferred_runtime
+        session.effective_runtime = effective_runtime
+        session.native_session_runtime = effective_runtime
+        session.fallback_reason = fallback_reason
+        if bridge_context is not None:
+            session.bridge_source_runtime = bridge_context.source_runtime
+            session.bridge_source_session_id = bridge_context.source_session_id
+
+    def _update_job_runtime_metadata(
+        self,
+        job: JobRecord,
+        *,
+        preferred_runtime: str,
+        effective_runtime: str,
+        fallback_reason: str | None,
+        bridge_context: BridgeContext | None = None,
+        usage_limit_error: ClaudeUsageLimitError | None = None,
+        session: SessionRecord,
+    ) -> None:
+        job.metadata["preferred_runtime"] = preferred_runtime
+        job.metadata["effective_runtime"] = effective_runtime
+        job.metadata["native_session_runtime"] = effective_runtime
+        if fallback_reason:
+            job.metadata["fallback_reason"] = fallback_reason
+        if bridge_context is not None:
+            if bridge_context.source_runtime:
+                job.metadata["bridge_source_runtime"] = bridge_context.source_runtime
+            if bridge_context.source_session_id:
+                job.metadata["bridge_source_session_id"] = bridge_context.source_session_id
+            if bridge_context.note:
+                job.metadata["bridge_note"] = bridge_context.note
+        if usage_limit_error is not None:
+            job.metadata["usage_limit_runtime"] = RUNTIME_OMO
+            job.metadata["usage_limit_kind"] = usage_limit_error.limit_type
+            if usage_limit_error.reset_hint:
+                job.metadata["usage_limit_reset_hint"] = usage_limit_error.reset_hint
+            if usage_limit_error.suggested_retry_at:
+                job.metadata["usage_limit_until"] = usage_limit_error.suggested_retry_at
+        if session.omx_session_id:
+            job.metadata["omx_session_id"] = session.omx_session_id
+
+    def _runner_for_runtime(self, runtime: str) -> AgentRunner:
+        normalized = normalize_runtime(runtime)
+        runner = self._runtime_runners.get(normalized)
+        if runner is None:
+            runner = build_agent_runner(normalized, self.config.run_dir)
+            self._runtime_runners[normalized] = runner
+        return runner
+
+    def _preferred_runtime_for(self, job: JobRecord) -> str:
+        runtime = job.metadata.get("preferred_runtime")
+        if isinstance(runtime, str) and runtime:
+            return normalize_runtime(runtime)
+        return normalize_runtime(self.config.agent_runtime)
+
+    def _lineage_session_for(self, job: JobRecord) -> SessionRecord | None:
+        if job.stage != "issue_followup":
+            return None
+        if job.issue_number is None:
+            return None
+        return self._latest_issue_lineage_session(job.repo_full_name, job.issue_number)
+
+    def _initial_runtime_for(
+        self,
+        job: JobRecord,
+        preferred_runtime: str,
+        lineage_session: SessionRecord | None,
+    ) -> str:
+        if job.stage == "issue_followup" and lineage_session is not None:
+            lineage_runtime = effective_session_runtime(lineage_session)
+            if lineage_runtime:
+                return lineage_runtime
+        if preferred_runtime != RUNTIME_OMO:
+            return preferred_runtime
+        if self._has_active_omo_usage_limit(job.repo_full_name):
+            job.metadata["fallback_reason"] = "cached_claude_usage_limit"
+            return RUNTIME_OMX
+        return preferred_runtime
+
+    def _has_active_omo_usage_limit(self, repo_full_name: str) -> bool:
+        now = datetime.now(tz=timezone.utc)
+        for job in reversed(self.storage.list_jobs()):
+            if job.repo_full_name != repo_full_name:
+                continue
+            if job.metadata.get("usage_limit_runtime") != RUNTIME_OMO:
+                continue
+            retry_at = job.metadata.get("usage_limit_until")
+            if not isinstance(retry_at, str) or not retry_at:
+                continue
+            try:
+                retry_at_dt = datetime.fromisoformat(retry_at)
+            except ValueError:
+                continue
+            if retry_at_dt.tzinfo is None:
+                retry_at_dt = retry_at_dt.replace(tzinfo=timezone.utc)
+            if retry_at_dt > now:
+                return True
+        return False
+
+    def _session_id_for_resume(self, job: JobRecord, session: SessionRecord) -> str:
+        if session.omx_session_id:
+            return session.omx_session_id
+        return self._omx_session_id_for(job)
+
+    def _bridge_context_for(
+        self, repo: RepoConfig, job: JobRecord, lineage_session: SessionRecord | None
+    ) -> BridgeContext | None:
+        source_session_id = None
+        if lineage_session is not None and effective_session_runtime(lineage_session) == RUNTIME_OMO:
+            source_session_id = lineage_session.omx_session_id
+        bridge = self.session_bridge.load(repo_path=Path(repo.local_path), session_id=source_session_id)
+        if bridge is None:
+            return None
+        if not bridge.prompt_block and not bridge.note:
+            return None
+        return bridge
 
     def _handle_transient_failure(
         self,
@@ -511,6 +726,14 @@ class DaniService:
             "retry_attempts": attempt - 1,
             "retry_history": retry_history,
         }
+        if isinstance(exc, ClaudeUsageLimitError):
+            metadata["error"] = "claude_usage_limit"
+            metadata["usage_limit_runtime"] = RUNTIME_OMO
+            metadata["usage_limit_kind"] = exc.limit_type
+            if exc.reset_hint:
+                metadata["usage_limit_reset_hint"] = exc.reset_hint
+            if exc.suggested_retry_at:
+                metadata["usage_limit_until"] = exc.suggested_retry_at
         if self._is_rollout_missing_error(exc):
             metadata["error"] = "rollout_missing"
             metadata["error_detail"] = str(exc)
@@ -528,6 +751,12 @@ class DaniService:
             )
         except DevSyncConflictError as exc:
             conflict_context = exc.context
+            preferred_runtime = self._preferred_runtime_for(job)
+            runtime = preferred_runtime
+            fallback_reason = None
+            if preferred_runtime == RUNTIME_OMO and self._has_active_omo_usage_limit(job.repo_full_name):
+                runtime = RUNTIME_OMX
+                fallback_reason = "cached_claude_usage_limit"
             prompt = render_prompt(
                 "dev_sync_conflict",
                 {
@@ -539,27 +768,109 @@ class DaniService:
                     "temp_branch": conflict_context.temp_branch,
                     "commit_message": self.dev_syncer.build_commit_message(repo, job),
                 },
-                runtime=self.config.agent_runtime,
+                runtime=runtime,
             )
-            session = self.omx_runner.launch(conflict_context.worktree_path, job, prompt)
-            self.storage.create_session(session)
-            self.storage.update_job(
-                job.id,
-                status="launched",
-                session_id=session.id,
-                metadata={
+            runner = self._runner_for_runtime(runtime)
+            try:
+                session = runner.launch(conflict_context.worktree_path, job, prompt)
+                self._annotate_session_record(
+                    session,
+                    preferred_runtime=preferred_runtime,
+                    effective_runtime=runtime,
+                    fallback_reason=fallback_reason,
+                )
+                self.storage.create_session(session)
+                self.storage.update_job(
+                    job.id,
+                    status="launched",
+                    session_id=session.id,
+                    metadata={
+                        **job.metadata,
+                        "preferred_runtime": preferred_runtime,
+                        "effective_runtime": runtime,
+                        "native_session_runtime": runtime,
+                        "fallback_reason": fallback_reason,
+                        "sync_status": "conflict",
+                        "worktree_path": str(conflict_context.worktree_path),
+                    },
+                )
+                job.metadata = {
                     **job.metadata,
+                    "preferred_runtime": preferred_runtime,
+                    "effective_runtime": runtime,
+                    "native_session_runtime": runtime,
+                    "fallback_reason": fallback_reason,
                     "sync_status": "conflict",
                     "worktree_path": str(conflict_context.worktree_path),
-                },
-            )
-            self.omx_runner.wait(session.runtime_handle)
+                }
+                runner.wait(session.runtime_handle)
+            except ClaudeUsageLimitError as limit_exc:
+                if runtime != RUNTIME_OMO:
+                    raise
+                if session is not None:
+                    self._finalize_session(session, status="failed", termination_reason="failed")
+                runtime = RUNTIME_OMX
+                fallback_reason = f"claude_{limit_exc.limit_type}_limit"
+                prompt = render_prompt(
+                    "dev_sync_conflict",
+                    {
+                        "repo": repo.full_name,
+                        "local_path": str(conflict_context.worktree_path),
+                        "main_branch": repo.main_branch,
+                        "dev_branch": repo.dev_branch,
+                        "main_sha": conflict_context.source_sha,
+                        "temp_branch": conflict_context.temp_branch,
+                        "commit_message": self.dev_syncer.build_commit_message(repo, job),
+                    },
+                    runtime=runtime,
+                )
+                runner = self._runner_for_runtime(runtime)
+                session = runner.launch(conflict_context.worktree_path, job, prompt)
+                self._annotate_session_record(
+                    session,
+                    preferred_runtime=preferred_runtime,
+                    effective_runtime=runtime,
+                    fallback_reason=fallback_reason,
+                )
+                self.storage.create_session(session)
+                self.storage.update_job(
+                    job.id,
+                    status="launched",
+                    session_id=session.id,
+                    metadata={
+                        **job.metadata,
+                        "preferred_runtime": preferred_runtime,
+                        "effective_runtime": runtime,
+                        "native_session_runtime": runtime,
+                        "fallback_reason": fallback_reason,
+                        "usage_limit_runtime": RUNTIME_OMO,
+                        "usage_limit_kind": limit_exc.limit_type,
+                        "usage_limit_until": limit_exc.suggested_retry_at,
+                        "usage_limit_reset_hint": limit_exc.reset_hint,
+                        "sync_status": "conflict",
+                        "worktree_path": str(conflict_context.worktree_path),
+                    },
+                )
+                job.metadata = {
+                    **job.metadata,
+                    "preferred_runtime": preferred_runtime,
+                    "effective_runtime": runtime,
+                    "native_session_runtime": runtime,
+                    "fallback_reason": fallback_reason,
+                    "usage_limit_runtime": RUNTIME_OMO,
+                    "usage_limit_kind": limit_exc.limit_type,
+                    "usage_limit_until": limit_exc.suggested_retry_at,
+                    "usage_limit_reset_hint": limit_exc.reset_hint,
+                    "sync_status": "conflict",
+                    "worktree_path": str(conflict_context.worktree_path),
+                }
+                runner.wait(session.runtime_handle)
             self.dev_syncer.verify_remote_sync(conflict_context)
             self._finalize_session(session, status="completed", termination_reason="completed")
             self.storage.update_job(
                 job.id,
                 status="completed",
-                metadata={**job.metadata, "sync_status": "resolved_with_agent"},
+                metadata={**job.metadata, "effective_runtime": runtime, "sync_status": "resolved_with_agent"},
             )
         except Exception as exc:
             if session is not None:
@@ -573,8 +884,12 @@ class DaniService:
                 self.dev_syncer.cleanup(conflict_context)
 
     def _finalize_session(self, session: SessionRecord, *, status: str, termination_reason: str) -> None:
+        runtime = effective_session_runtime(session) or session.native_session_runtime or normalize_runtime(
+            self.config.agent_runtime
+        )
+        runner = self._runner_for_runtime(runtime)
         try:
-            self.omx_runner.close_session(session.runtime_handle)
+            runner.close_session(session.runtime_handle)
         finally:
             self.storage.update_session(
                 session.id,
@@ -583,7 +898,15 @@ class DaniService:
                 termination_reason=termination_reason,
             )
 
-    def _build_prompt(self, repo: RepoConfig, job: JobRecord) -> str:
+    def _build_prompt(
+        self,
+        repo: RepoConfig,
+        job: JobRecord,
+        *,
+        runtime: str | None = None,
+        bridge_prompt: str = "",
+    ) -> str:
+        resolved_runtime = normalize_runtime(runtime or self.config.agent_runtime)
         issue_number = job.issue_number or 0
         pr_number = job.pr_number or 0
         issue_context = self._issue_metadata(repo.full_name, issue_number) if issue_number else {}
@@ -593,26 +916,82 @@ class DaniService:
         pr_title = pr_snapshot.get("title", job.metadata.get("title", f"PR #{pr_number}"))
         pr_body = pr_snapshot.get("body", job.metadata.get("body", ""))
         if job.stage == "issue_request":
-            return self._build_issue_request_prompt(repo, job, issue_number, issue_title, issue_body)
+            prompt = self._build_issue_request_prompt(repo, job, issue_number, issue_title, issue_body, resolved_runtime)
+            return self._apply_bridge_context(prompt, bridge_prompt)
 
         if job.stage == "implementation":
-            return self._build_implementation_prompt(
-                repo, job, issue_number, issue_title, issue_body, pr_number, pr_title, pr_body
+            prompt = self._build_implementation_prompt(
+                repo,
+                job,
+                issue_number,
+                issue_title,
+                issue_body,
+                pr_number,
+                pr_title,
+                pr_body,
+                resolved_runtime,
             )
+            return self._apply_bridge_context(prompt, bridge_prompt)
 
         if job.stage == "issue_followup":
-            return self._build_issue_followup_prompt(repo, job, issue_number, issue_title, issue_body)
+            prompt = self._build_issue_followup_prompt(
+                repo,
+                job,
+                issue_number,
+                issue_title,
+                issue_body,
+                resolved_runtime,
+            )
+            return self._apply_bridge_context(prompt, bridge_prompt)
 
         if job.stage == "review_round":
-            return self._build_review_round_prompt(repo, job, issue_number, pr_number, pr_title, pr_body)
+            prompt = self._build_review_round_prompt(
+                repo,
+                job,
+                issue_number,
+                pr_number,
+                pr_title,
+                pr_body,
+                resolved_runtime,
+            )
+            return self._apply_bridge_context(prompt, bridge_prompt)
 
         if job.stage == "human_escalation":
-            return self._build_human_escalation_prompt(repo, job, issue_number, pr_number, pr_title, pr_body)
+            prompt = self._build_human_escalation_prompt(
+                repo,
+                job,
+                issue_number,
+                pr_number,
+                pr_title,
+                pr_body,
+                resolved_runtime,
+            )
+            return self._apply_bridge_context(prompt, bridge_prompt)
 
         if job.stage == "merge_conflict_resolution":
-            return self._build_merge_conflict_resolution_prompt(repo, job, issue_number, pr_number, pr_title, pr_body)
+            prompt = self._build_merge_conflict_resolution_prompt(
+                repo,
+                job,
+                issue_number,
+                pr_number,
+                pr_title,
+                pr_body,
+                resolved_runtime,
+            )
+            return self._apply_bridge_context(prompt, bridge_prompt)
 
-        return self._build_final_verdict_prompt(job, issue_number, pr_number, pr_title, pr_body)
+        prompt = self._build_final_verdict_prompt(job, issue_number, pr_number, pr_title, pr_body, resolved_runtime)
+        return self._apply_bridge_context(prompt, bridge_prompt)
+
+    def _apply_bridge_context(self, prompt: str, bridge_prompt: str) -> str:
+        if not bridge_prompt.strip():
+            return prompt
+        return (
+            f"{bridge_prompt}\n\n"
+            "Use the imported OMO context above only as bounded background context. "
+            "This is not a native resume; continue from it conservatively.\n\n"
+            f"{prompt}"
+        )
 
     def _verify_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
         if job.stage == "issue_request":
@@ -643,6 +1022,7 @@ class DaniService:
         issue_number: int,
         issue_title: str,
         issue_body: str,
+        runtime: str,
     ) -> str:
         return render_prompt(
             "issue_request",
@@ -655,7 +1035,7 @@ class DaniService:
                 "discussion": self._render_issue_discussion(repo.full_name, issue_number),
                 "signature": build_signature(stage="issue_request", job=job.id, issue=issue_number),
             },
-            runtime=self.config.agent_runtime,
+            runtime=runtime,
         )
 
     def _build_implementation_prompt(
@@ -668,6 +1048,7 @@ class DaniService:
         pr_number: int,
         pr_title: str,
         pr_body: str,
+        runtime: str,
     ) -> str:
         pr_discussion = self._render_pr_discussion(repo.full_name, pr_number) if pr_number else ""
         pr_context = ""
@@ -718,7 +1099,7 @@ class DaniService:
                 "signature": signature,
                 "signature_instructions": signature_instructions,
             },
-            runtime=self.config.agent_runtime,
+            runtime=runtime,
         )
 
     def _build_issue_followup_prompt(
@@ -728,6 +1109,7 @@ class DaniService:
         issue_number: int,
         issue_title: str,
         issue_body: str,
+        runtime: str,
     ) -> str:
         return render_prompt(
             "issue_followup",
@@ -740,7 +1122,7 @@ class DaniService:
                 "comment_body": job.metadata.get("comment_body", ""),
                 "signature": build_signature(stage="issue_followup", job=job.id, issue=issue_number),
             },
-            runtime=self.config.agent_runtime,
+            runtime=runtime,
         )
 
     def _build_review_round_prompt(
@@ -751,6 +1133,7 @@ class DaniService:
         pr_number: int,
         pr_title: str,
         pr_body: str,
+        runtime: str,
     ) -> str:
         signature_fields: dict[str, int | str] = {
             "stage": "review_round",
@@ -785,7 +1168,7 @@ class DaniService:
                 ),
                 "signature": build_signature(**signature_fields),
             },
-            runtime=self.config.agent_runtime,
+            runtime=runtime,
         )
 
     def _build_merge_conflict_resolution_prompt(
@@ -796,6 +1179,7 @@ class DaniService:
         pr_number: int,
         pr_title: str,
         pr_body: str,
+        runtime: str,
     ) -> str:
         return render_prompt(
             "merge_conflict_resolution",
@@ -811,7 +1195,7 @@ class DaniService:
                 "conflict_reason": job.metadata.get("conflict_reason", "Merge conflict detected while merging."),
                 "signature": build_signature(stage="merge_conflict_resolution", job=job.id, pr=pr_number),
             },
-            runtime=self.config.agent_runtime,
+            runtime=runtime,
         )
 
     def _build_final_verdict_prompt(
@@ -821,6 +1205,7 @@ class DaniService:
         pr_number: int,
         pr_title: str,
         pr_body: str,
+        runtime: str,
     ) -> str:
         discussion_parts = []
         if issue_number:
@@ -846,7 +1231,7 @@ class DaniService:
                 ),
                 "reject_signature": build_signature(stage="final_verdict", job=job.id, pr=pr_number, verdict="REJECT"),
             },
-            runtime=self.config.agent_runtime,
+            runtime=runtime,
         )
 
     def _build_human_escalation_prompt(
@@ -857,6 +1242,7 @@ class DaniService:
         pr_number: int,
         pr_title: str,
         pr_body: str,
+        runtime: str,
     ) -> str:
         discussion_parts = []
         if issue_number:
@@ -875,7 +1261,7 @@ class DaniService:
                 "review_limit": self.config.external_review_limit,
                 "signature": build_signature(stage="human_escalation", job=job.id, pr=pr_number),
             },
-            runtime=self.config.agent_runtime,
+            runtime=runtime,
         )
 
     def _verify_issue_request_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
@@ -1019,11 +1405,7 @@ class DaniService:
         return {"status": "queued", "job_id": job.id, "stage": job.stage}
 
     def _queue_issue_followup(self, repo: RepoConfig, event: NormalizedEvent) -> dict[str, Any]:
-        session = self._latest_resumable_session(
-            repo_full_name=event.repo_full_name,
-            stage="issue_request",
-            issue_number=event.number,
-        )
+        session = self._latest_issue_lineage_session(event.repo_full_name, event.number)
         if session is None or session.omx_session_id is None:
             return {"status": "ignored", "reason": "missing_issue_session"}
         job = self._enqueue_job(
@@ -1035,9 +1417,28 @@ class DaniService:
                 "body": event.payload.get("issue", {}).get("body", ""),
                 "comment_body": event.body or "",
                 "omx_session_id": session.omx_session_id,
+                "preferred_runtime": session.preferred_runtime or normalize_runtime(self.config.agent_runtime),
+                "effective_runtime": effective_session_runtime(session),
+                "native_session_runtime": session.native_session_runtime,
+                "fallback_reason": session.fallback_reason,
+                "bridge_source_runtime": session.bridge_source_runtime,
+                "bridge_source_session_id": session.bridge_source_session_id,
             },
         )
         return {"status": "queued", "job_id": job.id, "stage": job.stage}
+
+    def _latest_issue_lineage_session(self, repo_full_name: str, issue_number: int) -> SessionRecord | None:
+        for session in reversed(self.storage.list_sessions()):
+            if session.repo_full_name != repo_full_name:
+                continue
+            if session.issue_number != issue_number:
+                continue
+            if session.stage not in {"issue_request", "issue_followup"}:
+                continue
+            if not session.omx_session_id:
+                continue
+            return session
+        return None
 
     def _omx_session_id_for(self, job: JobRecord) -> str:
         omx_session_id = job.metadata.get("omx_session_id")
@@ -1133,22 +1534,6 @@ class DaniService:
             issue_number=issue_number,
             pr_number=pr_number,
             metadata=metadata,
-        )
-
-    def _latest_resumable_session(
-        self,
-        *,
-        repo_full_name: str,
-        stage: str,
-        issue_number: int | None = None,
-        pr_number: int | None = None,
-    ) -> SessionRecord | None:
-        return self.storage.find_latest_session(
-            repo_full_name=repo_full_name,
-            stage=stage,
-            issue_number=issue_number,
-            pr_number=pr_number,
-            require_omx_session_id=True,
         )
 
     def _agent_event_key(self, signature: dict[str, str], *, default_pr: int | None = None) -> str:

--- a/dani/session_bridge.py
+++ b/dani/session_bridge.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_OPENCODE_DB_PATH = Path.home() / ".local" / "share" / "opencode" / "opencode.db"
+MAX_SECTION_ITEMS = 3
+MAX_SNIPPET_LENGTH = 280
+MAX_PROMPT_CHARS = 1800
+
+
+@dataclass(slots=True)
+class BridgeContext:
+    prompt_block: str
+    source_runtime: str = "omo"
+    source_session_id: str | None = None
+    note: str | None = None
+
+
+class OmoSessionBridge:
+    def __init__(self, db_path: Path | None = None) -> None:
+        self.db_path = db_path or DEFAULT_OPENCODE_DB_PATH
+
+    def load(self, *, repo_path: Path, session_id: str | None = None) -> BridgeContext | None:
+        if not self.db_path.exists():
+            return BridgeContext(prompt_block="", note="opencode_db_missing")
+
+        try:
+            with sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True) as conn:
+                conn.row_factory = sqlite3.Row
+                session_row = self._select_session(conn, repo_path=repo_path, session_id=session_id)
+                if session_row is None:
+                    return BridgeContext(prompt_block="", note="opencode_session_unavailable")
+                source_session_id = str(session_row["id"])
+                session_title = _clean_text(session_row["title"])
+                completed = self._load_todos(conn, source_session_id, status="completed")
+                pending = self._load_todos(conn, source_session_id, status="pending")
+                pending.extend(self._load_todos(conn, source_session_id, status="in_progress"))
+                recent_text = self._load_recent_text(conn, source_session_id)
+        except sqlite3.Error:
+            return BridgeContext(prompt_block="", note="opencode_db_unreadable")
+
+        lines = [
+            "Prior OMO context (imported summary; not a native resume):",
+            f"- Source session id: {source_session_id}",
+        ]
+        if session_title:
+            lines.append(f"- Prior goal: {session_title}")
+        if completed:
+            lines.append("- Latest completed work:")
+            lines.extend(f"  - {item}" for item in completed[:MAX_SECTION_ITEMS])
+        if pending:
+            lines.append("- Open thread:")
+            lines.extend(f"  - {item}" for item in pending[:MAX_SECTION_ITEMS])
+        if recent_text:
+            lines.append("- Recent relevant context:")
+            lines.extend(f"  - {item}" for item in recent_text[:MAX_SECTION_ITEMS])
+
+        prompt_block = _truncate_block("\n".join(lines), MAX_PROMPT_CHARS)
+        if prompt_block.strip() == "Prior OMO context (imported summary; not a native resume):":
+            return BridgeContext(prompt_block="", source_session_id=source_session_id, note="opencode_context_empty")
+        return BridgeContext(prompt_block=prompt_block, source_session_id=source_session_id)
+
+    def _select_session(self, conn: sqlite3.Connection, *, repo_path: Path, session_id: str | None) -> sqlite3.Row | None:
+        if session_id:
+            row = conn.execute(
+                "SELECT id, title, directory FROM session WHERE id = ? LIMIT 1",
+                (session_id,),
+            ).fetchone()
+            if row is not None:
+                return row
+        return conn.execute(
+            "SELECT id, title, directory FROM session WHERE directory = ? ORDER BY time_updated DESC LIMIT 1",
+            (str(repo_path),),
+        ).fetchone()
+
+    def _load_todos(self, conn: sqlite3.Connection, session_id: str, *, status: str) -> list[str]:
+        rows = conn.execute(
+            "SELECT content FROM todo WHERE session_id = ? AND status = ? ORDER BY position ASC, time_updated DESC LIMIT 6",
+            (session_id, status),
+        ).fetchall()
+        return [_clean_text(str(row["content"])) for row in rows if _clean_text(str(row["content"]))]
+
+    def _load_recent_text(self, conn: sqlite3.Connection, session_id: str) -> list[str]:
+        rows = conn.execute(
+            "SELECT data FROM part WHERE session_id = ? ORDER BY time_created DESC LIMIT 40",
+            (session_id,),
+        ).fetchall()
+        snippets: list[str] = []
+        for row in rows:
+            try:
+                payload = json.loads(row["data"])
+            except (TypeError, json.JSONDecodeError):
+                continue
+            if payload.get("type") != "text":
+                continue
+            text = _clean_text(str(payload.get("text") or ""))
+            if not text:
+                continue
+            if text.startswith("<ultrawork-mode>"):
+                continue
+            if "ULTRAWORK MODE ENABLED!" in text:
+                continue
+            snippets.append(text)
+            if len(snippets) >= 6:
+                break
+        return snippets
+
+
+def _clean_text(text: str) -> str:
+    stripped = " ".join(text.split())
+    if len(stripped) > MAX_SNIPPET_LENGTH:
+        return stripped[: MAX_SNIPPET_LENGTH - 1].rstrip() + "…"
+    return stripped
+
+
+def _truncate_block(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"

--- a/dani/signatures.py
+++ b/dani/signatures.py
@@ -3,6 +3,18 @@ from __future__ import annotations
 import re
 
 SIGNATURE_PATTERN = re.compile(r"<!--\s*(?:dani|DANI):\s*(?P<body>[^>]+)\s*-->")
+IGNORE_COMMAND_PATTERN = re.compile(r"(?mi)(?:^|\s)/dani\s+ignore(?:\s|$)")
+
+
+def _parse_signature_body(raw_body: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    parts = raw_body.split(";") if ";" in raw_body else raw_body.split()
+    for item in parts:
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        fields[key.strip()] = value.strip()
+    return fields
 
 
 def build_signature(**fields: object) -> str:
@@ -21,16 +33,30 @@ def parse_signature(text: str | None) -> dict[str, str] | None:
     match = SIGNATURE_PATTERN.search(text)
     if not match:
         return None
-    fields: dict[str, str] = {}
-    raw_body = match.group("body")
-    parts = raw_body.split(";") if ";" in raw_body else raw_body.split()
-    for item in parts:
-        if "=" not in item:
-            continue
-        key, value = item.split("=", 1)
-        fields[key.strip()] = value.strip()
+    fields = _parse_signature_body(match.group("body"))
     return fields or None
 
 
+def parse_agent_signature(text: str | None) -> dict[str, str] | None:
+    fields = parse_signature(text)
+    if fields is None or fields.get("stage", "").lower() == "ignore":
+        return None
+    return fields
+
+
 def has_agent_signature(text: str | None) -> bool:
-    return parse_signature(text) is not None
+    return parse_agent_signature(text) is not None
+
+
+def has_ignore_signature(text: str | None) -> bool:
+    if not text:
+        return False
+    for match in SIGNATURE_PATTERN.finditer(text):
+        fields = _parse_signature_body(match.group("body"))
+        if fields.get("stage", "").lower() == "ignore":
+            return True
+    return False
+
+
+def is_opt_out_comment(text: str | None) -> bool:
+    return has_ignore_signature(text) or bool(text and IGNORE_COMMAND_PATTERN.search(text))

--- a/dani/storage.py
+++ b/dani/storage.py
@@ -5,7 +5,7 @@ import threading
 from pathlib import Path
 from typing import Any
 
-from dani.models import DaniConfig, JobRecord, RepoConfig, SessionRecord, utc_now
+from dani.models import DaniConfig, JobRecord, RepoConfig, SessionRecord, effective_session_runtime, utc_now
 
 
 class JsonStorage:
@@ -146,6 +146,7 @@ class JsonStorage:
         issue_number: int | None = None,
         pr_number: int | None = None,
         require_omx_session_id: bool = False,
+        effective_runtime: str | None = None,
     ) -> SessionRecord | None:
         for session in reversed(self.list_sessions()):
             if session.repo_full_name != repo_full_name:
@@ -157,6 +158,8 @@ class JsonStorage:
             if pr_number is not None and session.pr_number != pr_number:
                 continue
             if require_omx_session_id and not session.omx_session_id:
+                continue
+            if effective_runtime is not None and effective_session_runtime(session) != effective_runtime:
                 continue
             return session
         return None

--- a/dani/webhook.py
+++ b/dani/webhook.py
@@ -15,7 +15,9 @@ def verify_github_signature(secret: str, body: bytes, signature_header: str | No
     return hmac.compare_digest(expected, signature_header)
 
 
-def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent | None:
+def normalize_event(
+    event_name: str, payload: dict[str, Any], *, delivery_id: str | None = None
+) -> NormalizedEvent | None:
     repo = payload.get("repository") or {}
     repo_full_name = repo.get("full_name")
     if not repo_full_name:
@@ -33,6 +35,7 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             payload=payload,
             body=issue.get("body"),
             title=issue.get("title"),
+            delivery_id=delivery_id,
         )
 
     if event_name == "issue_comment" and action == "created":
@@ -47,6 +50,7 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             payload=payload,
             body=payload["comment"].get("body"),
             title=issue.get("title"),
+            delivery_id=delivery_id,
             is_pull_request=is_pr,
         )
 
@@ -62,11 +66,18 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             number=0,
             actor_login=payload["sender"]["login"],
             payload=payload,
+            delivery_id=delivery_id,
             ref=ref,
             commit_sha=commit_sha,
         )
 
-    if event_name == "pull_request" and action == "opened":
+    if event_name == "pull_request" and action in {
+        "opened",
+        "synchronize",
+        "reopened",
+        "ready_for_review",
+        "review_requested",
+    }:
         pull_request = payload["pull_request"]
         return NormalizedEvent(
             kind="pull_request_opened",
@@ -79,6 +90,8 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             title=pull_request.get("title"),
             base_branch=pull_request["base"]["ref"],
             head_branch=pull_request["head"]["ref"],
+            delivery_id=delivery_id,
+            commit_sha=pull_request["head"].get("sha"),
             is_pull_request=True,
         )
 
@@ -95,6 +108,8 @@ def normalize_event(event_name: str, payload: dict[str, Any]) -> NormalizedEvent
             title=pull_request.get("title"),
             base_branch=pull_request["base"]["ref"],
             head_branch=pull_request["head"]["ref"],
+            delivery_id=delivery_id,
+            commit_sha=pull_request["head"].get("sha"),
             is_pull_request=True,
         )
 

--- a/docs/issue-33-verification.md
+++ b/docs/issue-33-verification.md
@@ -1,0 +1,63 @@
+# Issue 33 verification log
+
+This document records the development-time evidence that Issue 33 was resolved
+according to the user's process constraints (no global install, no pm2
+redeploy) and that the new OMO (Oh-My-OpenAgents) backend actually works
+end-to-end against a real `opencode` subprocess.
+
+## Process constraints
+
+| Constraint | Evidence |
+|---|---|
+| No `uv tool install` during development | All commands used `uv run ...` against the local workspace only. No `uv tool install` was invoked. `git grep "uv tool install"` returns no matches in project-owned files; matches only come from vendored `.venv/**/METADATA` files unrelated to this work. |
+| No pm2 redeploy | No changes to any pm2 config (none exists in repo) and no `pm2 start` / `pm2 reload` was invoked during development. `git grep pm2` returns no matches. |
+| Local version only | `dani` is a uv-managed editable install in `.venv`. Verified via `uv run python -c "import dani, sys; print(dani.__file__)"` pointing inside the repo's working tree, not `~/.local/share/uv/tools/...`. |
+
+## Live OMO subprocess runs (requirement 4)
+
+Three reproducible smoke scripts under `scripts/dev/omo_smoke/` spawn real
+`opencode run` subprocesses and inspect the logs. They are checked into the
+repo so future reviewers can re-run them. An equivalent pytest file at
+`tests/test_omo_live.py` is opt-in (`DANI_OMO_LIVE=1 uv run pytest tests/test_omo_live.py`)
+and is skipped by default because it consumes model tokens.
+
+| Script | Proves | Sample captured session id |
+|---|---|---|
+| `smoke_launch.py` | `OmoRunner.launch` spawns opencode, gets back `{"type":"text","text":"dani omo smoke ok"}`, sessionID captured. | `ses_25e9164e7ffeleSyF3UGalrfuo` |
+| `smoke_resume.py` | `OmoRunner.resume` runs `opencode run --session <id>` and opencode **remembers** a keyword planted in phase 1 (`PURPLE_HIPPO_9182`). | `ses_25e99ee42ffeZiayJpmLNjDbBQ` |
+| `smoke_ultrawork.py` | `OmoRunner` unconditionally prefixes `prompt.txt` with `"ultrawork\n\n"` and real opencode accepts it. | `ses_25e919f1cffe7LPKpAR04SCyNQ` |
+
+All three scripts passed their assertions when executed locally with
+`uv run python scripts/dev/omo_smoke/<name>.py` against `opencode` 1.4.11 on
+macOS (Darwin), with opencode data dir at `~/.local/share/opencode/opencode.db`.
+Session IDs above are pulled from actual run logs and are specific to that
+environment — they will differ on every execution.
+
+## Unit / integration test coverage
+
+- 154 tests pass (`uv run pytest -q`), up from 125 before this work.
+- New tests in `tests/test_omo_runner.py` cover:
+  - Factory selection (both `omx` and `omo`; ultrawork flag forwarded only to omo; ultrawork+omx rejected with `ValueError`).
+  - `opencode run` and `opencode run --session <id>` script construction.
+  - JSONL `sessionID` parsing from stdout, including partial-line / malformed-line tolerance.
+  - `get_session_id(runtime_handle)` post-wait recovery.
+  - Prompt-file contents (raw and ultrawork-decorated, idempotency).
+  - Error handling: `Session not found` (→ `RolloutMissingError`) and `model is at capacity` (→ `TransientCapacityError`).
+  - Full `DaniService` integration paths:
+    - `issue_request` launched through OMO → session persisted → job completed.
+    - `issue_opened` → persisted sessionID → `issue_comment` → OmoRunner.resume with exact `--session <id>` flag.
+    - Follow-up resume failing with `Session not found` stderr → job marked failed with `error=rollout_missing` → `stage=session_lost` warning comment posted.
+    - Late sessionID emission (opencode emits id AFTER launch's pre-wait poll times out): service re-queries `get_session_id` post-wait and updates storage.
+- New tests in `tests/test_omo_live.py` cover the same surface with **real**
+  opencode subprocess execution, opt-in via `DANI_OMO_LIVE=1`.
+
+## Backward compatibility
+
+- No field renames in persisted records (`SessionRecord.omx_session_id`,
+  `JobRecord.metadata["omx_session_id"]`, `storage.find_latest_session(require_omx_session_id=...)`)
+  — existing `~/.dani/sessions.json` and `jobs.json` stay readable.
+- Default runtime is unchanged (`agent_runtime="omx"`); OMO is strictly opt-in
+  via `DANI_AGENT_RUNTIME=omo`.
+- All 125 pre-existing tests still pass without modification.
+- `FakeOmxRunner` test double unchanged; satisfies the new `AgentRunner`
+  protocol structurally.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dani"
 version = "0.0.1"
-description = "Simple loop for managing Github Repository; Backend is Oh-My-Codex"
+description = "Simple loop for managing Github Repository; Backend is Oh-My-Codex or Oh-My-OpenAgents"
 authors = [{ name = "NomaDamas", email = "vkehfdl1@gmail.com" }]
 readme = "README.md"
 keywords = ["python"]
@@ -88,6 +88,8 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101", "S105", "S106"]
 "dani/omx_runner.py" = ["S607"]
+"dani/omo_runner.py" = ["S607"]
+"scripts/dev/**" = ["S101", "S108", "S603", "S607", "T201"]
 
 [tool.ruff.format]
 preview = true

--- a/scripts/dev/omo_smoke/README.md
+++ b/scripts/dev/omo_smoke/README.md
@@ -1,0 +1,42 @@
+# OMO (Oh-My-OpenAgents) live smoke scripts
+
+These three scripts exercise the `OmoRunner` against a **real** `opencode`
+binary. They are committed here so anyone verifying Issue 33 (`omo` backend
+support) can reproduce the same end-to-end evidence locally.
+
+Unlike the unit/integration tests under `tests/test_omo_runner.py`, these
+scripts do **not** monkeypatch `subprocess.Popen`. They spawn real `opencode run`
+processes, consume real model tokens, and assert on real CLI output.
+
+## Prerequisites
+
+- `opencode` binary on `PATH` (install via `curl -fsSL https://opencode.ai/install | bash`,
+  `npm install -g oh-my-opencode`, `brew install opencode`, etc.).
+- An opencode model provider configured (`opencode auth login` once).
+- `uv` available for running the scripts inside the project's virtualenv.
+
+## Running
+
+Each script creates its own throwaway workspace under `/tmp/dani-omo-smoke/`
+(or the path the script defines). No global state, no writes to your repos.
+
+```sh
+# from the dani repo root, using the local (uninstalled) version:
+uv run python scripts/dev/omo_smoke/smoke_launch.py
+uv run python scripts/dev/omo_smoke/smoke_resume.py
+uv run python scripts/dev/omo_smoke/smoke_ultrawork.py
+```
+
+## What each script proves
+
+| Script | Proves |
+|--------|--------|
+| `smoke_launch.py` | `OmoRunner.launch` actually spawns `opencode run --format json --dangerously-skip-permissions ...`, the model replies, and `_capture_session_id` extracts a valid `ses_...` id from the JSONL stream. |
+| `smoke_resume.py` | `OmoRunner.resume` runs `opencode run --session <id> ...` and opencode **continues** the prior conversation (recalls a keyword planted in phase 1). |
+| `smoke_ultrawork.py` | `OmoRunner` always prepends `"ultrawork\n\n"` to `prompt.txt` and opencode accepts it. |
+
+## Why these are not part of `pytest` by default
+
+They take 10–60 seconds each and cost model tokens. The equivalent pytest
+integration file is `tests/test_omo_live.py`, which is skipped unless you set
+`DANI_OMO_LIVE=1` and have `opencode` on `PATH`.

--- a/scripts/dev/omo_smoke/smoke_launch.py
+++ b/scripts/dev/omo_smoke/smoke_launch.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+from dani.agent_runner import build_agent_runner
+from dani.models import JobRecord
+
+REPO_PATH = Path("/tmp/dani-omo-smoke/repo")
+RUN_DIR = Path("/tmp/dani-omo-smoke/runs-launch")
+
+
+def ensure_repo() -> None:
+    import subprocess
+
+    REPO_PATH.mkdir(parents=True, exist_ok=True)
+    if not (REPO_PATH / ".git").exists():
+        subprocess.run(["git", "init", "-q"], cwd=REPO_PATH, check=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+            cwd=REPO_PATH,
+            check=True,
+        )
+
+
+def main() -> int:
+    ensure_repo()
+    runner = build_agent_runner("omo", RUN_DIR)
+    print(f"[smoke-launch] runner class: {type(runner).__name__}")
+
+    job = JobRecord(repo_full_name="acme/smoke", stage="issue_request", issue_number=42)
+    prompt = "Reply with exactly the words 'dani omo smoke ok' and stop. Do not use tools. Do not call any agents."
+
+    t0 = time.monotonic()
+    session = runner.launch(REPO_PATH, job, prompt)
+    print(f"[smoke-launch] launch() took {time.monotonic() - t0:.2f}s")
+    print(f"[smoke-launch] captured session id: {session.omx_session_id!r}")
+    script_text = Path(session.script_path).read_text(encoding="utf-8")
+    assert "opencode run --format json --dangerously-skip-permissions" in script_text
+    assert f"cd {REPO_PATH}" in script_text
+
+    runner.wait(session.runtime_handle, timeout_seconds=180)
+    runner.close_session(session.runtime_handle)
+
+    assert session.stdout_path is not None
+    stdout_text = Path(session.stdout_path).read_text(encoding="utf-8", errors="replace")
+    captured = session.omx_session_id or runner.get_session_id(session.runtime_handle)
+    assert captured is not None and captured.startswith("ses_"), f"expected a ses_... session id, got {captured!r}"
+    print(f"[smoke-launch] stdout head: {stdout_text[:300]}")
+    print("[smoke-launch] ==> PASS: opencode ran; session id captured; script matched expectations")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/omo_smoke/smoke_resume.py
+++ b/scripts/dev/omo_smoke/smoke_resume.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+from dani.agent_runner import build_agent_runner
+from dani.models import JobRecord
+
+REPO_PATH = Path("/tmp/dani-omo-smoke/repo")
+RUN_DIR = Path("/tmp/dani-omo-smoke/runs-resume")
+
+
+def ensure_repo() -> None:
+    import subprocess
+
+    REPO_PATH.mkdir(parents=True, exist_ok=True)
+    if not (REPO_PATH / ".git").exists():
+        subprocess.run(["git", "init", "-q"], cwd=REPO_PATH, check=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+            cwd=REPO_PATH,
+            check=True,
+        )
+
+
+def main() -> int:
+    ensure_repo()
+    runner = build_agent_runner("omo", RUN_DIR)
+
+    job1 = JobRecord(repo_full_name="acme/smoke", stage="issue_request", issue_number=77)
+    launch_prompt = "Remember this exact keyword: PURPLE_HIPPO_9182. Reply only with 'ok' and stop."
+
+    print("[smoke-resume] phase 1: launching opencode session...")
+    t0 = time.monotonic()
+    session1 = runner.launch(REPO_PATH, job1, launch_prompt)
+    runner.wait(session1.runtime_handle, timeout_seconds=180)
+    runner.close_session(session1.runtime_handle)
+    first_sid = session1.omx_session_id or runner.get_session_id(session1.runtime_handle)
+    assert first_sid is not None and first_sid.startswith("ses_")
+    print(f"[smoke-resume] phase 1 session id: {first_sid} ({time.monotonic() - t0:.1f}s)")
+
+    job2 = JobRecord(repo_full_name="acme/smoke", stage="issue_followup", issue_number=77)
+    resume_prompt = (
+        "What was the keyword I told you earlier in this conversation? Reply with only the keyword and nothing else."
+    )
+
+    print("[smoke-resume] phase 2: resuming prior session via --session flag...")
+    t1 = time.monotonic()
+    session2 = runner.resume(REPO_PATH, job2, resume_prompt, first_sid)
+    script = Path(session2.script_path).read_text(encoding="utf-8")
+    assert f"opencode run --session {first_sid} --format json --dangerously-skip-permissions" in script
+    runner.wait(session2.runtime_handle, timeout_seconds=180)
+    runner.close_session(session2.runtime_handle)
+    assert session2.stdout_path is not None
+    stdout_text = Path(session2.stdout_path).read_text(encoding="utf-8", errors="replace")
+    print(f"[smoke-resume] phase 2 wall: {time.monotonic() - t1:.1f}s")
+
+    assert "PURPLE_HIPPO_9182" in stdout_text, (
+        f"resume did NOT continue prior session; stdout tail: {stdout_text[-400:]!r}"
+    )
+    print("[smoke-resume] ==> PASS: opencode resumed; keyword recovered from conversation state")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/omo_smoke/smoke_ultrawork.py
+++ b/scripts/dev/omo_smoke/smoke_ultrawork.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+from dani.agent_runner import build_agent_runner
+from dani.models import JobRecord
+
+REPO_PATH = Path("/tmp/dani-omo-smoke/repo")
+RUN_DIR = Path("/tmp/dani-omo-smoke/runs-ultrawork")
+
+
+def ensure_repo() -> None:
+    import subprocess
+
+    REPO_PATH.mkdir(parents=True, exist_ok=True)
+    if not (REPO_PATH / ".git").exists():
+        subprocess.run(["git", "init", "-q"], cwd=REPO_PATH, check=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+            cwd=REPO_PATH,
+            check=True,
+        )
+
+
+def main() -> int:
+    ensure_repo()
+    runner = build_agent_runner("omo", RUN_DIR)
+    print(f"[smoke-ulw] runner={type(runner).__name__}")
+
+    job = JobRecord(repo_full_name="acme/smoke", stage="issue_request", issue_number=777)
+    prompt = (
+        "Reply with exactly the words 'ulw mode ok' and stop immediately. "
+        "Do NOT enter any loop. Do NOT call any agents."
+    )
+
+    session = runner.launch(REPO_PATH, job, prompt)
+    actual_prompt = Path(session.prompt_path).read_text(encoding="utf-8")
+    assert actual_prompt.startswith("ultrawork\n\n"), f"expected ultrawork prefix, got: {actual_prompt[:60]!r}"
+    print(f"[smoke-ulw] prompt-file starts with ultrawork prefix: {actual_prompt[:60]!r}")
+
+    t0 = time.monotonic()
+    runner.wait(session.runtime_handle, timeout_seconds=300)
+    runner.close_session(session.runtime_handle)
+
+    assert session.stdout_path is not None and session.stderr_path is not None
+    stdout_text = Path(session.stdout_path).read_text(encoding="utf-8", errors="replace")
+    stderr_text = Path(session.stderr_path).read_text(encoding="utf-8", errors="replace")
+    assert "ses_" in stdout_text, "expected sessionID events in opencode stdout"
+    assert "error" not in stderr_text.lower(), f"opencode emitted error: {stderr_text[:400]}"
+    print(f"[smoke-ulw] wait: {time.monotonic() - t0:.1f}s; stderr bytes: {len(stderr_text)}")
+    print("[smoke-ulw] ==> PASS: opencode accepted ultrawork-prefixed prompt and ran clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,7 +8,7 @@ from dani.errors import TransientCapacityError
 from dani.git_sync import DevSyncConflictError, DevSyncContext, DevSyncOutcome
 from dani.github import MergeConflictError
 from dani.models import JobRecord, SessionRecord
-from dani.signatures import build_signature, parse_signature
+from dani.signatures import build_signature, is_opt_out_comment, parse_agent_signature, parse_signature
 
 _CAPACITY_MSG = "capacity"
 
@@ -60,7 +60,9 @@ class FakeGitHubCLI:
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
         for comment in reversed(comments):
-            parsed = parse_signature(comment.get("body", ""))
+            if is_opt_out_comment(comment.get("body", "")):
+                continue
+            parsed = parse_agent_signature(comment.get("body", ""))
             if parsed is not None:
                 return comment, parsed
         return None
@@ -71,7 +73,11 @@ class FakeGitHubCLI:
         comments = (
             self.issue_comments(repo_full_name, number) if kind == "issue" else self.pr_comments(repo_full_name, number)
         )
-        return [comment for comment in comments if signature_fragment in (comment.get("body") or "")]
+        return [
+            comment
+            for comment in comments
+            if not is_opt_out_comment(comment.get("body", "")) and signature_fragment in (comment.get("body") or "")
+        ]
 
     def merge_pull_request(self, repo_full_name: str, pr_number: int) -> None:
         if (repo_full_name, pr_number) in self.merge_conflicts:
@@ -83,6 +89,16 @@ class FakeGitHubCLI:
 
     def add_pr_signature(self, repo_full_name: str, pr_number: int, signature: str) -> None:
         self.pr_comment_map.setdefault((repo_full_name, pr_number), []).append({"body": signature})
+
+    def create_issue_comment(self, repo_full_name: str, issue_number: int, body: str) -> dict[str, Any]:
+        comment = {"body": body}
+        self.issue_comment_map.setdefault((repo_full_name, issue_number), []).append(comment)
+        return comment
+
+    def create_pr_comment(self, repo_full_name: str, pr_number: int, body: str) -> dict[str, Any]:
+        comment = {"body": body}
+        self.pr_comment_map.setdefault((repo_full_name, pr_number), []).append(comment)
+        return comment
 
     def add_pull_request(
         self,
@@ -130,10 +146,14 @@ class FakeOmxRunner:
         self.resumes: list[ResumeRecord] = []
         self.closed_sessions: list[str] = []
         self._transient_failures_remaining: int = 0
+        self.resume_error: Exception | None = None
 
     def set_transient_failures(self, count: int) -> None:
         """Configure the runner to raise TransientCapacityError for the next *count* wait() calls."""
         self._transient_failures_remaining = count
+
+    def set_resume_failure(self, exc: Exception) -> None:
+        self.resume_error = exc
 
     def launch(self, repo_path: Path, job: JobRecord, prompt: str) -> SessionRecord:
         repo_full_name = job.repo_full_name
@@ -193,6 +213,13 @@ class FakeOmxRunner:
                 pr_number,
                 build_signature(stage="merge_conflict_resolution", job=job.id, pr=pr_number),
             )
+        elif job.stage == "human_escalation":
+            pr_number = int((signature or {}).get("pr", job.pr_number or 0))
+            self.github.add_pr_signature(
+                repo_full_name,
+                pr_number,
+                build_signature(stage="human_escalation", job=job.id, pr=pr_number),
+            )
         elif job.stage != "dev_sync":
             self.github.add_pr_signature(
                 repo_full_name,
@@ -201,6 +228,8 @@ class FakeOmxRunner:
             )
 
     def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
+        if self.resume_error is not None:
+            raise self.resume_error
         issue_number = job.issue_number or 0
         self.github.add_issue_signature(
             job.repo_full_name,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 from typing import Any, TypedDict
 
-from dani.errors import TransientCapacityError
+from dani.errors import ClaudeUsageLimitError, TransientCapacityError
 from dani.git_sync import DevSyncConflictError, DevSyncContext, DevSyncOutcome
 from dani.github import MergeConflictError
 from dani.models import JobRecord, SessionRecord
@@ -268,6 +268,81 @@ class FakeOmxRunner:
     def get_session_id(self, runtime_handle: str) -> str | None:
         del runtime_handle
         return None
+
+
+class FakeRuntimeRunner(FakeOmxRunner):
+    def __init__(self, github: FakeGitHubCLI, *, runtime_name: str) -> None:
+        super().__init__(github)
+        self.runtime_name = runtime_name
+        self.session_id_prefix = "ses_" if runtime_name == "omo" else "omx-"
+        self.wait_errors: list[Exception] = []
+
+    def queue_wait_error(self, exc: Exception) -> None:
+        self.wait_errors.append(exc)
+
+    def launch(self, repo_path: Path, job: JobRecord, prompt: str) -> SessionRecord:
+        repo_full_name = job.repo_full_name
+        matches = re.findall(r"<!--\s*dani:([^>]+)\s*-->", prompt)
+        signature = parse_signature(f"<!-- dani:{matches[-1]} -->") if matches else None
+        pending_wait_error = self.wait_errors[0] if self.wait_errors else None
+        should_skip_side_effect = isinstance(pending_wait_error, (ClaudeUsageLimitError, TransientCapacityError))
+        if self._transient_failures_remaining == 0 and not should_skip_side_effect:
+            self._post_side_effect(repo_full_name, job, signature)
+        self.launches.append({"repo_path": str(repo_path), "job": job, "prompt": prompt})
+        return SessionRecord(
+            repo_full_name=repo_full_name,
+            stage=job.stage,
+            runtime_handle=f"{self.runtime_name}-runtime-{job.id}",
+            prompt_path=str(repo_path / "prompt.txt"),
+            script_path=str(repo_path / "run.sh"),
+            worktree_path=str(repo_path),
+            job_id=job.id,
+            issue_number=job.issue_number,
+            pr_number=job.pr_number,
+            review_round=job.review_round,
+            omx_session_id=f"{self.session_id_prefix}{job.id}",
+        )
+
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
+        if self.resume_error is not None:
+            raise self.resume_error
+        issue_number = job.issue_number or 0
+        self.github.add_issue_signature(
+            job.repo_full_name,
+            issue_number,
+            build_signature(stage="issue_followup", job=job.id, issue=issue_number),
+        )
+        self.resumes.append({
+            "repo_path": str(repo_path),
+            "job": job,
+            "prompt": prompt,
+            "omx_session_id": omx_session_id,
+        })
+        return SessionRecord(
+            repo_full_name=job.repo_full_name,
+            stage=job.stage,
+            runtime_handle=f"{self.runtime_name}-runtime-{job.id}",
+            prompt_path=str(repo_path / "prompt.txt"),
+            script_path=str(repo_path / "run.sh"),
+            worktree_path=str(repo_path),
+            job_id=job.id,
+            issue_number=job.issue_number,
+            pr_number=job.pr_number,
+            review_round=job.review_round,
+            omx_session_id=omx_session_id,
+        )
+
+    def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
+        del poll_interval, timeout_seconds
+        if self.wait_errors:
+            raise self.wait_errors.pop(0)
+        return super().wait(runtime_handle)
+
+    def get_session_id(self, runtime_handle: str) -> str | None:
+        suffix = runtime_handle.removeprefix(f"{self.runtime_name}-runtime-")
+        if not suffix:
+            return None
+        return f"{self.session_id_prefix}{suffix}"
 
 
 class FakeGitDevSyncer:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -265,6 +265,10 @@ class FakeOmxRunner:
     def close_session(self, runtime_handle: str) -> None:
         self.closed_sessions.append(runtime_handle)
 
+    def get_session_id(self, runtime_handle: str) -> str | None:
+        del runtime_handle
+        return None
+
 
 class FakeGitDevSyncer:
     def __init__(self, *, conflict: bool = False, fail: bool = False) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from typer.testing import CliRunner
 
 import dani.cli as cli_module
 from dani.cli import app
+from dani.models import JobRecord
 
 
 class FakeBootstrapService:
@@ -15,6 +16,18 @@ class FakeBootstrapService:
     def bootstrap_repo(self, repo_full_name: str) -> int:
         self.calls.append(("bootstrap_repo", repo_full_name))
         return self.count
+
+    def wait_for_idle(self) -> None:
+        self.calls.append(("wait_for_idle", None))
+
+
+class FakeRestartService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, int] | tuple[str, None]] = []
+
+    def restart_issue(self, repo_full_name: str, issue_number: int) -> JobRecord:
+        self.calls.append(("restart_issue", repo_full_name, issue_number))
+        return JobRecord(repo_full_name=repo_full_name, stage="issue_request", issue_number=issue_number, id="job-123")
 
     def wait_for_idle(self) -> None:
         self.calls.append(("wait_for_idle", None))
@@ -44,3 +57,19 @@ def test_bootstrap_waits_for_idle_before_exiting(tmp_path: Path, monkeypatch) ->
     assert result.exit_code == 0
     assert fake_service.calls == [("bootstrap_repo", "acme/demo"), ("wait_for_idle", None)]
     assert result.stdout.strip() == "processed 2 issues"
+
+
+def test_restart_issue_invokes_service_waits_for_idle_and_prints_job(tmp_path: Path, monkeypatch) -> None:
+    runner = CliRunner()
+    data_dir = tmp_path / ".dani"
+    fake_service = FakeRestartService()
+    monkeypatch.setattr(cli_module, "build_service", lambda data_dir: fake_service)
+
+    result = runner.invoke(app, ["restart-issue", "acme/demo", "41", "--data-dir", str(data_dir)])
+
+    assert result.exit_code == 0
+    assert fake_service.calls == [("restart_issue", "acme/demo", 41), ("wait_for_idle", None)]
+    payload = json.loads(result.stdout)
+    assert payload["id"] == "job-123"
+    assert payload["stage"] == "issue_request"
+    assert payload["issue_number"] == 41

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -175,6 +175,42 @@ def test_create_issue_and_pr_comments_use_repository_objects(fake_repo: FakeRepo
     assert fake_repo.pulls[7].created_issue_comments == ["hello pr"]
 
 
+def test_latest_signature_comment_ignores_opt_out_marker(fake_repo: FakeRepo) -> None:
+    fake_repo.issues[5] = FakeIssue([
+        "<!-- dani:stage=issue_request;job=job-1;issue=5 -->",
+        "<!-- dani:stage=ignore -->",
+    ])
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    latest = github.latest_signature_comment("acme/demo", 5, kind="issue")
+
+    assert latest is not None
+    assert latest[1]["stage"] == "issue_request"
+
+
+def test_latest_signature_comment_skips_dani_ignore_command_even_with_embedded_signature(fake_repo: FakeRepo) -> None:
+    fake_repo.issues[5] = FakeIssue([
+        "<!-- dani:stage=issue_request;job=job-1;issue=5 -->",
+        "/dani ignore\nQuoted marker <!-- dani:stage=review_round;job=job-2;pr=7;round=1 -->",
+    ])
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    latest = github.latest_signature_comment("acme/demo", 5, kind="issue")
+
+    assert latest is not None
+    assert latest[1]["stage"] == "issue_request"
+
+
+def test_find_comments_by_signature_skips_opt_out_comment_that_quotes_exact_signature(fake_repo: FakeRepo) -> None:
+    signature = "<!-- dani:stage=review_round;job=job-2;pr=7;round=1 -->"
+    fake_repo.pulls[7] = FakePullRequest(number=7, body="body", comments=[f"/dani ignore\nQuoted marker {signature}"])
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    matching_comments = github.find_comments_by_signature("acme/demo", 7, kind="pr", signature_fragment=signature)
+
+    assert matching_comments == []
+
+
 def test_ensure_pull_request_updates_existing_open_pull_request(fake_repo: FakeRepo) -> None:
     github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
 
@@ -216,6 +252,16 @@ def test_merge_pull_request_raises_merge_conflict_error_for_merge_api_failures(
         github.merge_pull_request("acme/demo", 7)
 
     assert exc_info.value.status == status
+
+
+def test_merge_pull_request_reraises_non_conflict_github_failures(fake_repo: FakeRepo) -> None:
+    fake_repo.pulls[7].merge_exception = GithubException(500, {"message": "GitHub outage"}, {})
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    with pytest.raises(GithubException) as exc_info:
+        github.merge_pull_request("acme/demo", 7)
+
+    assert exc_info.value.status == 500
 
 
 def test_merge_pull_request_raises_merge_conflict_error_when_merge_status_is_false(fake_repo: FakeRepo) -> None:

--- a/tests/test_omo_live.py
+++ b/tests/test_omo_live.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from dani.omo_runner import OmoRunner
+
+LIVE_FLAG = "DANI_OMO_LIVE"
+LIVE_FLAG_VALUES = {"1", "true", "yes", "on"}
+pytestmark = pytest.mark.skipif(
+    os.environ.get(LIVE_FLAG, "").strip().lower() not in LIVE_FLAG_VALUES or shutil.which("opencode") is None,
+    reason=(
+        f"Live opencode tests are opt-in: set {LIVE_FLAG}=1 and install the `opencode` binary. "
+        "These tests spawn real opencode subprocesses and consume model tokens."
+    ),
+)
+
+
+@pytest.fixture
+def live_repo(tmp_path: Path) -> Path:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo_path, check=True)  # noqa: S607
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-q", "-m", "init"],  # noqa: S607
+        cwd=repo_path,
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "dani-live",
+            "GIT_AUTHOR_EMAIL": "dani-live@example.com",
+            "GIT_COMMITTER_NAME": "dani-live",
+            "GIT_COMMITTER_EMAIL": "dani-live@example.com",
+        },
+    )
+    return repo_path
+
+
+def _import_job_record():
+    from dani.models import JobRecord
+
+    return JobRecord
+
+
+def test_live_opencode_launch_emits_session_id_and_completes(tmp_path: Path, live_repo: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    job_cls = _import_job_record()
+    job = job_cls(repo_full_name="live/demo", stage="issue_request", issue_number=1)
+
+    prompt = "Reply with exactly the words 'dani live ok' and stop immediately. Do not use tools."
+    session = runner.launch(live_repo, job, prompt)
+
+    try:
+        runner.wait(session.runtime_handle, timeout_seconds=240)
+    finally:
+        runner.close_session(session.runtime_handle)
+
+    assert session.stdout_path is not None and session.stderr_path is not None
+    stdout_text = Path(session.stdout_path).read_text(encoding="utf-8", errors="replace")
+    stderr_text = Path(session.stderr_path).read_text(encoding="utf-8", errors="replace")
+
+    session_ids = [
+        json.loads(line).get("sessionID")
+        for line in stdout_text.splitlines()
+        if line.strip().startswith("{") and '"sessionID"' in line
+    ]
+    session_ids = [sid for sid in session_ids if isinstance(sid, str) and sid.startswith("ses_")]
+    assert session_ids, f"opencode stdout never contained a sessionID event; stderr preview: {stderr_text[:400]!r}"
+
+    assert session.omx_session_id is not None, (
+        "launch() should have captured the session id during its pre-wait poll; "
+        f"stdout bytes={len(stdout_text)}, stderr bytes={len(stderr_text)}"
+    )
+    assert session.omx_session_id == session_ids[0]
+
+
+def test_live_opencode_resume_continues_prior_session(tmp_path: Path, live_repo: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    job_cls = _import_job_record()
+    launch_job = job_cls(repo_full_name="live/demo", stage="issue_request", issue_number=2)
+
+    launch_prompt = (
+        "Remember this exact keyword for later: CRIMSON_MOOSE_7361. Reply only with the word 'ok' and stop immediately."
+    )
+    launch_session = runner.launch(live_repo, launch_job, launch_prompt)
+    try:
+        runner.wait(launch_session.runtime_handle, timeout_seconds=240)
+    finally:
+        runner.close_session(launch_session.runtime_handle)
+
+    first_id = launch_session.omx_session_id
+    if first_id is None:
+        first_id = runner.get_session_id(launch_session.runtime_handle)
+    assert first_id is not None and first_id.startswith("ses_"), (
+        f"expected captured session id after launch, got {first_id!r}"
+    )
+
+    resume_job = job_cls(repo_full_name="live/demo", stage="issue_followup", issue_number=2)
+    resume_prompt = (
+        "What was the keyword I told you earlier in this conversation? Reply with only the keyword and nothing else."
+    )
+    resume_session = runner.resume(live_repo, resume_job, resume_prompt, first_id)
+
+    try:
+        runner.wait(resume_session.runtime_handle, timeout_seconds=240)
+    finally:
+        runner.close_session(resume_session.runtime_handle)
+
+    resume_script_text = Path(resume_session.script_path).read_text(encoding="utf-8")
+    assert f"opencode run --session {first_id} --format json --dangerously-skip-permissions" in resume_script_text
+
+    assert resume_session.stdout_path is not None
+    resume_stdout = Path(resume_session.stdout_path).read_text(encoding="utf-8", errors="replace")
+    assert "CRIMSON_MOOSE_7361" in resume_stdout, (
+        "resume did not continue prior session — keyword missing from opencode reply; "
+        f"stdout tail: {resume_stdout[-400:]!r}"
+    )
+
+
+def test_live_opencode_ultrawork_prefix_accepted(tmp_path: Path, live_repo: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    job_cls = _import_job_record()
+    job = job_cls(repo_full_name="live/demo", stage="issue_request", issue_number=3)
+
+    prompt = "Reply with exactly the words 'ulw live ok' and stop immediately. Do not use tools. Do not enter any loop."
+    session = runner.launch(live_repo, job, prompt)
+
+    prompt_text = Path(session.prompt_path).read_text(encoding="utf-8")
+    assert prompt_text.startswith("ultrawork\n\n"), f"expected ultrawork-prefixed prompt, got {prompt_text[:60]!r}"
+
+    try:
+        runner.wait(session.runtime_handle, timeout_seconds=240)
+    finally:
+        runner.close_session(session.runtime_handle)
+
+    assert session.stdout_path is not None and session.stderr_path is not None
+    stdout_text = Path(session.stdout_path).read_text(encoding="utf-8", errors="replace")
+    stderr_text = Path(session.stderr_path).read_text(encoding="utf-8", errors="replace")
+    assert "ses_" in stdout_text, f"opencode stdout missing sessionID events; stderr preview: {stderr_text[:400]!r}"

--- a/tests/test_omo_runner.py
+++ b/tests/test_omo_runner.py
@@ -1,0 +1,899 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dani.errors import RolloutMissingError, TransientCapacityError
+from dani.omo_runner import OmoRunner
+
+
+def test_build_script_uses_opencode_run(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    script = runner._build_script(repo_path=tmp_path / "repo", prompt_path=tmp_path / "prompt.txt")
+
+    assert "opencode run --format json --dangerously-skip-permissions" in script
+    assert "cd " in script
+
+
+def test_build_resume_script_uses_opencode_session_flag(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    script = runner._build_resume_script(
+        repo_path=tmp_path / "repo",
+        prompt_path=tmp_path / "prompt.txt",
+        opencode_session_id="ses_abc123",
+    )
+
+    assert "opencode run --session ses_abc123 --format json --dangerously-skip-permissions" in script
+
+
+def test_build_script_honours_custom_binary(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs", opencode_bin="/usr/local/bin/opencode")
+    script = runner._build_script(repo_path=tmp_path / "repo", prompt_path=tmp_path / "prompt.txt")
+
+    assert "/usr/local/bin/opencode run --format json" in script
+
+
+def test_session_id_from_stdout_parses_sessionid_field(tmp_path: Path) -> None:
+    stdout_path = tmp_path / "stdout.log"
+    stdout_path.write_text(
+        json.dumps({
+            "type": "step_start",
+            "timestamp": 1776528793789,
+            "sessionID": "ses_25ea1f4beffeDiVTHAxqiPJa4G",
+            "part": {"type": "step-start"},
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+
+    assert runner._session_id_from_stdout(stdout_path) == "ses_25ea1f4beffeDiVTHAxqiPJa4G"
+
+
+def test_session_id_from_stdout_ignores_malformed_lines(tmp_path: Path) -> None:
+    stdout_path = tmp_path / "stdout.log"
+    stdout_path.write_text(
+        "\n".join([
+            "not-json",
+            json.dumps({"type": "noise", "other": "value"}),
+            json.dumps({"type": "text", "sessionID": "ses_realone123"}),
+        ])
+        + "\n",
+        encoding="utf-8",
+    )
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+
+    assert runner._session_id_from_stdout(stdout_path) == "ses_realone123"
+
+
+def test_session_id_from_stdout_returns_none_when_no_event(tmp_path: Path) -> None:
+    stdout_path = tmp_path / "stdout.log"
+    stdout_path.write_text("", encoding="utf-8")
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+
+    assert runner._session_id_from_stdout(stdout_path) is None
+
+
+def test_capture_session_id_polls_until_visible(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    stdout_path = runs_dir / "stdout.log"
+    stdout_path.write_text(
+        json.dumps({"type": "step_start", "sessionID": "ses_polled"}) + "\n",
+        encoding="utf-8",
+    )
+    runner = OmoRunner(run_dir=runs_dir)
+
+    result = runner._capture_session_id(stdout_path=stdout_path, poll_interval=0.01, timeout_seconds=0.05)
+
+    assert result == "ses_polled"
+
+
+def test_capture_session_id_returns_none_on_timeout(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    stdout_path = runs_dir / "stdout.log"
+    stdout_path.write_text("", encoding="utf-8")
+    runner = OmoRunner(run_dir=runs_dir)
+
+    result = runner._capture_session_id(stdout_path=stdout_path, poll_interval=0.01, timeout_seconds=0.03)
+
+    assert result is None
+
+
+def test_close_session_terminates_active_process(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    stdout_path = tmp_path / "stdout.log"
+    stderr_path = tmp_path / "stderr.log"
+    stdout_path.write_text("", encoding="utf-8")
+    stderr_path.write_text("", encoding="utf-8")
+    stdout_file = stdout_path.open("w", encoding="utf-8")
+    stderr_file = stderr_path.open("w", encoding="utf-8")
+
+    process = type(
+        "Process",
+        (),
+        {
+            "poll": lambda self: None,
+            "terminate": lambda self: None,
+            "wait": lambda self, timeout=None: 0,
+            "kill": lambda self: None,
+        },
+    )()
+    runner._processes["runtime-123"] = (process, stdout_file, stderr_file)
+
+    runner.close_session("runtime-123")
+
+    assert stdout_file.closed
+    assert stderr_file.closed
+    assert runner._processes == {}
+
+
+def test_close_session_skips_missing_process(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    runner.close_session("runtime-123")
+
+
+def test_wait_raises_rollout_missing_error_when_stderr_mentions_session_not_found(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    runtime_handle = "runtime-missing"
+    runtime_dir = runner.run_dir / runtime_handle
+    runtime_dir.mkdir(parents=True)
+    stdout_path = runtime_dir / "stdout.log"
+    stderr_path = runtime_dir / "stderr.log"
+    stdout_path.write_text("", encoding="utf-8")
+    stderr_path.write_text("Error: Session not found: ses_missing123", encoding="utf-8")
+    stdout_file = stdout_path.open("w", encoding="utf-8")
+    stderr_file = stderr_path.open("a", encoding="utf-8")
+    process = type(
+        "Process",
+        (),
+        {
+            "poll": lambda self: 1,
+            "terminate": lambda self: None,
+            "wait": lambda self, timeout=None: 1,
+            "kill": lambda self: None,
+        },
+    )()
+    runner._processes[runtime_handle] = (process, stdout_file, stderr_file)
+
+    try:
+        with pytest.raises(RolloutMissingError, match="Session not found"):
+            runner.wait(runtime_handle)
+    finally:
+        stdout_file.close()
+        stderr_file.close()
+
+
+def test_wait_raises_transient_capacity_when_stderr_matches_pattern(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    runtime_handle = "runtime-capacity"
+    runtime_dir = runner.run_dir / runtime_handle
+    runtime_dir.mkdir(parents=True)
+    stdout_path = runtime_dir / "stdout.log"
+    stderr_path = runtime_dir / "stderr.log"
+    stdout_path.write_text("", encoding="utf-8")
+    stderr_path.write_text("Selected model is at capacity, retrying...", encoding="utf-8")
+    stdout_file = stdout_path.open("w", encoding="utf-8")
+    stderr_file = stderr_path.open("a", encoding="utf-8")
+    process = type(
+        "Process",
+        (),
+        {
+            "poll": lambda self: 1,
+            "terminate": lambda self: None,
+            "wait": lambda self, timeout=None: 1,
+            "kill": lambda self: None,
+        },
+    )()
+    runner._processes[runtime_handle] = (process, stdout_file, stderr_file)
+
+    try:
+        with pytest.raises(TransientCapacityError):
+            runner.wait(runtime_handle)
+    finally:
+        stdout_file.close()
+        stderr_file.close()
+
+
+def test_launch_writes_prompt_file_with_exact_prompt_content(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from dani.models import JobRecord
+
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    captured_prompts: list[str] = []
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        captured_prompts.append(prompt_file.read_text(encoding="utf-8"))
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(runner, "_capture_session_id", lambda **kwargs: None)
+
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
+    runner.launch(tmp_path / "repo", job, "HELLO EXACT PROMPT BODY 12345")
+
+    assert captured_prompts == ["ultrawork\n\nHELLO EXACT PROMPT BODY 12345"]
+
+
+def test_resume_writes_prompt_file_with_exact_prompt_content(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from dani.models import JobRecord
+
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    captured_prompts: list[str] = []
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        captured_prompts.append(prompt_file.read_text(encoding="utf-8"))
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=1)
+    runner.resume(tmp_path / "repo", job, "RESUME EXACT PROMPT 67890", "ses_persisted")
+
+    assert captured_prompts == ["ultrawork\n\nRESUME EXACT PROMPT 67890"]
+
+
+def test_get_session_id_returns_parsed_id_from_stdout_log(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    runtime_handle = "dani-issue_request-xyz"
+    runtime_dir = runner.run_dir / runtime_handle
+    runtime_dir.mkdir(parents=True)
+    stdout_path = runtime_dir / "stdout.log"
+    stdout_path.write_text(
+        json.dumps({"type": "step_start", "sessionID": "ses_postwaitrecovered01"}) + "\n",
+        encoding="utf-8",
+    )
+
+    assert runner.get_session_id(runtime_handle) == "ses_postwaitrecovered01"
+
+
+def test_get_session_id_returns_none_when_stdout_missing(tmp_path: Path) -> None:
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    assert runner.get_session_id("dani-issue_request-missing") is None
+
+
+def test_omx_runner_get_session_id_returns_none(tmp_path: Path) -> None:
+    from dani.omx_runner import OmxRunner
+
+    omx = OmxRunner(run_dir=tmp_path / "omx-runs")
+    assert omx.get_session_id("any-handle") is None
+
+
+def test_dani_service_recovers_late_session_id_from_omo_runner_after_wait(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """issue_request runs; _capture_session_id times out; wait() completes; service re-queries runner and updates storage."""
+    from typing import cast
+
+    from dani.github import GitHubCLI
+    from dani.models import DaniConfig, NormalizedEvent
+    from dani.service import DaniService
+    from dani.storage import JsonStorage
+    from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    github_stub = FakeGitHubCLI()
+    late_session_id = "ses_latecapture000000000abcdef"
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        prompt_body = prompt_file.read_text(encoding="utf-8")
+
+        stdout_path = Path(kwargs["stdout"].name)
+        stderr_path = Path(kwargs["stderr"].name)
+        stdout_path.write_text(
+            json.dumps({"type": "step_start", "sessionID": late_session_id}) + "\n",
+            encoding="utf-8",
+        )
+        stderr_path.write_text("", encoding="utf-8")
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+
+        signature = next(
+            (fragment for fragment in prompt_body.splitlines() if fragment.startswith("<!-- dani:")),
+            None,
+        )
+        if signature is not None:
+            github_stub.issue_comment_map.setdefault(("acme/demo", 77), []).append({"body": signature})
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(
+        "dani.omo_runner.OmoRunner._capture_session_id",
+        lambda self, **kwargs: None,
+    )
+
+    config = DaniConfig(
+        data_dir=tmp_path / ".dani",
+        webhook_secret="unit-test-secret",
+        agent_runtime="omo",
+    )
+    storage = JsonStorage(config)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github_stub),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=77,
+            actor_login="human",
+            payload={},
+            body="Simulate slow session-id emission",
+            title="Late-capture smoke",
+        )
+    )
+    service.wait_for_idle()
+
+    sessions = storage.list_sessions()
+    assert sessions
+    assert sessions[0].omx_session_id == late_session_id, (
+        "service must re-query runner post-wait and update session with late-arriving id"
+    )
+
+
+def test_build_agent_runner_factory_returns_omo_runner(tmp_path: Path) -> None:
+    from dani.agent_runner import build_agent_runner
+
+    runner = build_agent_runner("omo", tmp_path / "runs")
+
+    assert isinstance(runner, OmoRunner)
+
+
+def test_build_agent_runner_factory_returns_omx_runner_by_default(tmp_path: Path) -> None:
+    from dani.agent_runner import build_agent_runner
+    from dani.omx_runner import OmxRunner
+
+    runner = build_agent_runner("omx", tmp_path / "runs")
+
+    assert isinstance(runner, OmxRunner)
+
+
+def test_build_agent_runner_rejects_unknown_runtime(tmp_path: Path) -> None:
+    from dani.agent_runner import build_agent_runner
+
+    with pytest.raises(ValueError, match="unknown agent runtime"):
+        build_agent_runner("nonsense", tmp_path / "runs")
+
+
+def test_omo_runner_always_prepends_ultrawork_prefix(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from dani.models import JobRecord
+
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    captured_prompts: list[str] = []
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        captured_prompts.append(prompt_file.read_text(encoding="utf-8"))
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(runner, "_capture_session_id", lambda **kwargs: None)
+
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
+    runner.launch(tmp_path / "repo", job, "Investigate Issue #33.")
+
+    assert captured_prompts == ["ultrawork\n\nInvestigate Issue #33."]
+
+
+def test_omo_runner_does_not_double_prefix_when_prompt_already_starts_with_ultrawork(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from dani.models import JobRecord
+
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    captured_prompts: list[str] = []
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        captured_prompts.append(prompt_file.read_text(encoding="utf-8"))
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+    monkeypatch.setattr(runner, "_capture_session_id", lambda **kwargs: None)
+
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=1)
+    runner.launch(tmp_path / "repo", job, "ultrawork already leading")
+
+    assert captured_prompts == ["ultrawork already leading"]
+
+
+def test_omo_runner_resume_also_applies_ultrawork_prefix(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from dani.models import JobRecord
+
+    runner = OmoRunner(run_dir=tmp_path / "runs")
+    captured_prompts: list[str] = []
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        captured_prompts.append(prompt_file.read_text(encoding="utf-8"))
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+
+    job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=1)
+    runner.resume(tmp_path / "repo", job, "Continue fixing", "ses_persisted_omo")
+
+    assert captured_prompts == ["ultrawork\n\nContinue fixing"]
+
+
+def test_dani_service_instantiates_omo_runner_when_config_agent_runtime_is_omo(tmp_path: Path) -> None:
+    from dani.models import DaniConfig
+    from dani.service import DaniService
+
+    config = DaniConfig(
+        data_dir=tmp_path / ".dani",
+        webhook_secret="unit-test-secret",
+        agent_runtime="omo",
+    )
+    service = DaniService(config)
+
+    assert isinstance(service.omx_runner, OmoRunner)
+
+
+def test_dani_service_defaults_to_omx_runner_for_backward_compat(tmp_path: Path) -> None:
+    from dani.models import DaniConfig
+    from dani.omx_runner import OmxRunner
+    from dani.service import DaniService
+
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret="unit-test-secret")
+    service = DaniService(config)
+
+    assert isinstance(service.omx_runner, OmxRunner)
+
+
+def test_dani_service_runs_issue_request_through_omo_runner_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from typing import cast
+
+    from dani.github import GitHubCLI
+    from dani.models import DaniConfig, NormalizedEvent
+    from dani.service import DaniService
+    from dani.storage import JsonStorage
+    from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    github_stub = FakeGitHubCLI()
+    captured_scripts: list[str] = []
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        captured_scripts.append(script_text)
+        stdout_path = Path(kwargs["stdout"].name)
+        stderr_path = Path(kwargs["stderr"].name)
+        import json as _json
+
+        session_id = "ses_stubbedomo1234567890abcdef"
+        event = {"type": "step_start", "timestamp": 0, "sessionID": session_id, "part": {"type": "step-start"}}
+        stdout_path.write_text(_json.dumps(event) + "\n", encoding="utf-8")
+        stderr_path.write_text("", encoding="utf-8")
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        prompt_body = prompt_file.read_text(encoding="utf-8")
+        signature = next(
+            (fragment for fragment in prompt_body.splitlines() if fragment.startswith("<!-- dani:")),
+            None,
+        )
+        if signature is not None:
+            github_stub.issue_comment_map.setdefault(("acme/demo", 99), []).append({"body": signature})
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+
+    config = DaniConfig(
+        data_dir=tmp_path / ".dani",
+        webhook_secret="unit-test-secret",
+        agent_runtime="omo",
+    )
+    storage = JsonStorage(config)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github_stub),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    assert isinstance(service.omx_runner, OmoRunner)
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=99,
+            actor_login="human",
+            payload={},
+            body="Investigate runtime selection",
+            title="Runtime selection smoke",
+        )
+    )
+    service.wait_for_idle()
+
+    job = storage.list_jobs()[0]
+    assert job.status == "completed", f"expected completed, got {job.status} / {job.metadata!r}"
+    assert captured_scripts, "expected at least one opencode run invocation"
+    assert "opencode run --format json --dangerously-skip-permissions" in captured_scripts[0]
+
+    sessions = storage.list_sessions()
+    assert len(sessions) == 1
+    assert sessions[0].omx_session_id == "ses_stubbedomo1234567890abcdef"
+
+
+def test_dani_service_resumes_opencode_session_on_issue_followup_end_to_end(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """issue_opened -> persisted sessionID -> issue_comment -> OmoRunner.resume with --session flag."""
+    from typing import cast
+
+    from dani.github import GitHubCLI
+    from dani.models import DaniConfig, NormalizedEvent
+    from dani.service import DaniService
+    from dani.storage import JsonStorage
+    from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI
+
+    class FakeProcess:
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    github_stub = FakeGitHubCLI()
+    scripts_executed: list[str] = []
+    prompts_executed: list[str] = []
+    captured_session_id = "ses_resumechain0000000000abcd"
+
+    def fake_popen(cmd, **kwargs):
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        scripts_executed.append(script_text)
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        prompt_body = prompt_file.read_text(encoding="utf-8")
+        prompts_executed.append(prompt_body)
+
+        stdout_path = Path(kwargs["stdout"].name)
+        stderr_path = Path(kwargs["stderr"].name)
+        import json as _json
+
+        event = {"type": "step_start", "timestamp": 0, "sessionID": captured_session_id, "part": {}}
+        stdout_path.write_text(_json.dumps(event) + "\n", encoding="utf-8")
+        stderr_path.write_text("", encoding="utf-8")
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+
+        signature = next(
+            (fragment for fragment in prompt_body.splitlines() if fragment.startswith("<!-- dani:")),
+            None,
+        )
+        if signature is not None:
+            github_stub.issue_comment_map.setdefault(("acme/demo", 42), []).append({"body": signature})
+        return FakeProcess()
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+
+    config = DaniConfig(
+        data_dir=tmp_path / ".dani",
+        webhook_secret="unit-test-secret",
+        agent_runtime="omo",
+    )
+    storage = JsonStorage(config)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github_stub),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    assert isinstance(service.omx_runner, OmoRunner)
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=42,
+            actor_login="human",
+            payload={},
+            body="Initial issue body for OMO resume chain",
+            title="OMO resume chain smoke",
+        )
+    )
+    service.wait_for_idle()
+
+    first_job = storage.list_jobs()[0]
+    assert first_job.status == "completed"
+    persisted_session = storage.list_sessions()[0]
+    assert persisted_session.omx_session_id == captured_session_id
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=42,
+            actor_login="human",
+            payload={"issue": {"body": "Initial issue body for OMO resume chain"}},
+            body="Actually also look at subsystem Y.",
+            title="OMO resume chain smoke",
+        )
+    )
+    service.wait_for_idle()
+
+    followup_jobs = [job for job in storage.list_jobs() if job.stage == "issue_followup"]
+    assert followup_jobs, "issue_followup job should have been enqueued"
+    followup_job = followup_jobs[-1]
+    assert followup_job.status == "completed", (
+        f"expected completed, got {followup_job.status} with metadata {followup_job.metadata!r}"
+    )
+    assert followup_job.metadata.get("omx_session_id") == captured_session_id
+
+    followup_scripts = [script for script in scripts_executed if "--session" in script]
+    assert followup_scripts, "resume path should have generated an opencode run --session script"
+    assert (
+        f"opencode run --session {captured_session_id} --format json --dangerously-skip-permissions"
+        in (followup_scripts[-1])
+    )
+
+    followup_sessions = [session for session in storage.list_sessions() if session.stage == "issue_followup"]
+    assert followup_sessions and followup_sessions[-1].omx_session_id == captured_session_id
+
+
+def test_dani_service_handles_opencode_session_missing_on_followup_resume(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from typing import cast
+
+    from dani.github import GitHubCLI
+    from dani.models import DaniConfig, NormalizedEvent
+    from dani.service import DaniService
+    from dani.storage import JsonStorage
+    from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI
+
+    class FakeProcess:
+        def __init__(self, exit_code: int = 0) -> None:
+            self._exit_code = exit_code
+
+        def poll(self) -> int:
+            return self._exit_code
+
+        def wait(self, timeout: float | None = None) -> int:
+            return self._exit_code
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    github_stub = FakeGitHubCLI()
+    invocation_count = {"count": 0}
+    captured_session_id = "ses_missingchain000000000ffff"
+
+    def fake_popen(cmd, **kwargs):
+        invocation_count["count"] += 1
+        script_path = Path(cmd[0])
+        script_text = script_path.read_text(encoding="utf-8")
+        prompt_line = next((line for line in script_text.splitlines() if "cat " in line), "")
+        prompt_file = Path(prompt_line.rsplit("cat ", 1)[1].rstrip(')"'))
+        prompt_body = prompt_file.read_text(encoding="utf-8")
+
+        stdout_path = Path(kwargs["stdout"].name)
+        stderr_path = Path(kwargs["stderr"].name)
+        import json as _json
+
+        if "--session" in script_text:
+            stdout_path.write_text("", encoding="utf-8")
+            stderr_path.write_text(f"Error: Session not found: {captured_session_id}\n", encoding="utf-8")
+            kwargs["stdout"].close()
+            kwargs["stderr"].close()
+            return FakeProcess(exit_code=1)
+
+        event = {"type": "step_start", "timestamp": 0, "sessionID": captured_session_id, "part": {}}
+        stdout_path.write_text(_json.dumps(event) + "\n", encoding="utf-8")
+        stderr_path.write_text("", encoding="utf-8")
+        kwargs["stdout"].close()
+        kwargs["stderr"].close()
+
+        signature = next(
+            (fragment for fragment in prompt_body.splitlines() if fragment.startswith("<!-- dani:")),
+            None,
+        )
+        if signature is not None:
+            github_stub.issue_comment_map.setdefault(("acme/demo", 88), []).append({"body": signature})
+        return FakeProcess(exit_code=0)
+
+    monkeypatch.setattr("dani.omo_runner.subprocess.Popen", fake_popen)
+
+    config = DaniConfig(
+        data_dir=tmp_path / ".dani",
+        webhook_secret="unit-test-secret",
+        agent_runtime="omo",
+    )
+    storage = JsonStorage(config)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github_stub),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=88,
+            actor_login="human",
+            payload={},
+            body="Initial",
+            title="Session-missing smoke",
+        )
+    )
+    service.wait_for_idle()
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=88,
+            actor_login="human",
+            payload={"issue": {"body": "Initial"}},
+            body="Ping",
+            title="Session-missing smoke",
+        )
+    )
+    service.wait_for_idle()
+
+    followup_jobs = [job for job in storage.list_jobs() if job.stage == "issue_followup"]
+    assert followup_jobs, "followup job should have been enqueued"
+    followup_job = followup_jobs[-1]
+    assert followup_job.status == "failed"
+    assert followup_job.metadata.get("error") == "rollout_missing"
+    warning_comments = [
+        comment
+        for comment in github_stub.issue_comment_map.get(("acme/demo", 88), [])
+        if "stage=session_lost" in comment.get("body", "")
+    ]
+    assert warning_comments, "service should have posted the session_lost warning comment"

--- a/tests/test_omx_runner.py
+++ b/tests/test_omx_runner.py
@@ -4,6 +4,9 @@ import json
 import time
 from pathlib import Path
 
+import pytest
+
+from dani.errors import RolloutMissingError
 from dani.omx_runner import OmxRunner
 from dani.signatures import build_signature
 
@@ -102,3 +105,37 @@ def test_build_resume_script_uses_omx_exec_resume(tmp_path: Path) -> None:
     )
 
     assert "omx exec resume session-123 --dangerously-bypass-approvals-and-sandbox" in script
+
+
+def test_wait_raises_rollout_missing_error_when_resume_stderr_mentions_no_rollout_found(tmp_path: Path) -> None:
+    runner = OmxRunner(run_dir=tmp_path / "runs")
+    runtime_handle = "runtime-123"
+    runtime_dir = runner.run_dir / runtime_handle
+    runtime_dir.mkdir(parents=True)
+    stdout_path = tmp_path / "stdout.log"
+    stderr_path = runtime_dir / "stderr.log"
+    stdout_path.write_text("", encoding="utf-8")
+    stderr_path.write_text(
+        "Error: thread/resume failed: no rollout found for thread id 019d6829",
+        encoding="utf-8",
+    )
+    stdout_file = stdout_path.open("w", encoding="utf-8")
+    stderr_file = stderr_path.open("a", encoding="utf-8")
+    process = type(
+        "Process",
+        (),
+        {
+            "poll": lambda self: 1,
+            "terminate": lambda self: None,
+            "wait": lambda self, timeout=None: 1,
+            "kill": lambda self: None,
+        },
+    )()
+    runner._processes[runtime_handle] = (process, stdout_file, stderr_file)
+
+    try:
+        with pytest.raises(RolloutMissingError, match="no rollout found"):
+            runner.wait(runtime_handle)
+    finally:
+        stdout_file.close()
+        stderr_file.close()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -77,6 +77,7 @@ def test_issue_request_prompt_uses_gh_instructions() -> None:
             "issue_number": 7,
             "issue_title": "Need a bot",
             "issue_body": "Implement it",
+            "discussion": "",
             "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
         },
     )
@@ -94,12 +95,31 @@ def test_issue_request_prompt_requires_ai_summary_and_expected_outcome() -> None
             "issue_number": 7,
             "issue_title": "Need a bot",
             "issue_body": "Implement it",
+            "discussion": "",
             "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
         },
     )
 
     assert "AI-understood issue summary" in prompt
     assert "Expected Outcome" in prompt
+
+
+def test_issue_request_prompt_includes_existing_discussion_history() -> None:
+    prompt = render_prompt(
+        "issue_request",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "[human]\nEarlier context",
+            "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
+        },
+    )
+
+    assert "Existing issue discussion history" in prompt
+    assert "Earlier context" in prompt
 
 
 def test_review_round_prompt_requires_code_review_and_verification() -> None:
@@ -120,6 +140,30 @@ def test_review_round_prompt_requires_code_review_and_verification() -> None:
     assert "actual verification" in prompt.lower()
     assert "concrete evidence appropriate for what you verified" in prompt
     assert "gh pr comment 5 --repo acme/demo --body-file <review-comment.md>" in prompt
+
+
+def test_review_round_prompt_for_external_contribution_mentions_contributor_ownership() -> None:
+    prompt = render_prompt(
+        "review_round",
+        {
+            "repo": "acme/demo",
+            "pr_number": 5,
+            "pr_title": "Feature",
+            "pr_body": "Body",
+            "discussion": "history",
+            "round_number": 2,
+            "round_total": 10,
+            "review_mode_note": (
+                "This is an external contribution PR. The contributor owns any follow-up implementation. "
+                "If the PR is ready to merge, include /approve in your review comment so dani can run the final verdict pass."
+            ),
+            "signature": "<!-- dani:stage=review_round;job=abc;pr=5;round=2 -->",
+        },
+    )
+
+    assert "2 / 10" in prompt
+    assert "external contribution pr" in prompt.lower()
+    assert "/approve" in prompt
 
 
 def test_final_verdict_prompt_contains_both_signatures() -> None:
@@ -183,3 +227,23 @@ def test_merge_conflict_resolution_prompt_requires_recheck_without_direct_merge(
     assert "Do not merge the PR yourself" in prompt
     assert "stage=merge_conflict_resolution" in prompt
     assert "gh pr comment 5 --repo acme/demo --body-file <merge-conflict-comment.md>" in prompt
+
+
+def test_human_escalation_prompt_mentions_review_limit_and_signature() -> None:
+    prompt = render_prompt(
+        "human_escalation",
+        {
+            "repo": "acme/demo",
+            "pr_number": 5,
+            "pr_title": "Feature",
+            "pr_body": "Body",
+            "discussion": "history",
+            "review_limit": 10,
+            "signature": "<!-- dani:stage=human_escalation;job=abc;pr=5 -->",
+        },
+    )
+
+    assert "10" in prompt
+    assert "human maintainer" in prompt.lower()
+    assert "gh pr comment 5 --repo acme/demo --body-file <human-escalation.md>" in prompt
+    assert "stage=human_escalation" in prompt

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -23,6 +23,51 @@ def test_implementation_prompt_keeps_ralph_literal() -> None:
     assert "<!-- dani:stage=implementation;job=abc;issue=7 -->" in prompt
 
 
+def test_implementation_prompt_for_omo_replaces_ralph_with_ultrawork() -> None:
+    prompt = render_prompt(
+        "implementation",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "approved",
+            "pr_context": "",
+            "pr_number": "",
+            "dev_branch": "dev",
+            "signature": "<!-- dani:stage=implementation;job=abc;issue=7 -->",
+            "signature_instructions": "Use this signature in the PR body:\n<!-- dani:stage=implementation;job=abc;issue=7 -->",
+        },
+        runtime="omo",
+    )
+
+    assert "$ralph" not in prompt
+    assert "ultrawork" in prompt
+
+
+def test_implementation_prompt_for_omx_explicit_runtime_still_keeps_ralph() -> None:
+    prompt = render_prompt(
+        "implementation",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "approved",
+            "pr_context": "",
+            "pr_number": "",
+            "dev_branch": "dev",
+            "signature": "<!-- dani:stage=implementation;job=abc;issue=7 -->",
+            "signature_instructions": "Use this signature in the PR body:\n<!-- dani:stage=implementation;job=abc;issue=7 -->",
+        },
+        runtime="omx",
+    )
+
+    assert "$ralph" in prompt
+
+
 def test_implementation_prompt_prefers_push_over_pr_edit_for_existing_pr() -> None:
     prompt = render_prompt(
         "implementation",
@@ -104,6 +149,81 @@ def test_issue_request_prompt_requires_ai_summary_and_expected_outcome() -> None
     assert "Expected Outcome" in prompt
 
 
+def test_issue_request_prompt_demands_evidence_based_plan() -> None:
+    prompt = render_prompt(
+        "issue_request",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "",
+            "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
+        },
+    )
+
+    assert "Evidence-based implementation plan" in prompt
+    assert "Concise implementation plan" not in prompt
+
+
+def test_issue_request_prompt_instructs_research_before_planning() -> None:
+    prompt = render_prompt(
+        "issue_request",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "",
+            "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
+        },
+    )
+
+    lowered = prompt.lower()
+    assert "search the codebase" in lowered or "explore the codebase" in lowered
+    assert "external" in lowered
+    assert "official docs" in lowered or "documentation" in lowered
+
+
+def test_issue_request_prompt_allows_explicit_not_found_statement() -> None:
+    prompt = render_prompt(
+        "issue_request",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "",
+            "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
+        },
+    )
+
+    lowered = prompt.lower()
+    assert "no existing reusable code found" in lowered
+    assert "no suitable external library found" in lowered
+
+
+def test_issue_request_prompt_specifies_citation_format() -> None:
+    prompt = render_prompt(
+        "issue_request",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "",
+            "signature": "<!-- dani:stage=issue_request;job=abc;issue=7 -->",
+        },
+    )
+
+    assert "path/to/file.py:line" in prompt
+    assert "URL" in prompt
+
+
 def test_issue_request_prompt_includes_existing_discussion_history() -> None:
     prompt = render_prompt(
         "issue_request",
@@ -140,6 +260,44 @@ def test_review_round_prompt_requires_code_review_and_verification() -> None:
     assert "actual verification" in prompt.lower()
     assert "concrete evidence appropriate for what you verified" in prompt
     assert "gh pr comment 5 --repo acme/demo --body-file <review-comment.md>" in prompt
+
+
+def test_review_round_prompt_for_omo_delegates_to_momus_plan_critic() -> None:
+    prompt = render_prompt(
+        "review_round",
+        {
+            "repo": "acme/demo",
+            "pr_number": 5,
+            "pr_title": "Feature",
+            "pr_body": "Body",
+            "discussion": "history",
+            "round_number": 2,
+            "signature": "<!-- dani:stage=review_round;job=abc;pr=5;round=2 -->",
+        },
+        runtime="omo",
+    )
+
+    assert "$code-review" not in prompt
+    assert "Momus-Plan-Critic" in prompt
+    assert "subagent" in prompt.lower()
+
+
+def test_review_round_prompt_for_omo_does_not_mention_ralph_command() -> None:
+    prompt = render_prompt(
+        "review_round",
+        {
+            "repo": "acme/demo",
+            "pr_number": 5,
+            "pr_title": "Feature",
+            "pr_body": "Body",
+            "discussion": "history",
+            "round_number": 2,
+            "signature": "<!-- dani:stage=review_round;job=abc;pr=5;round=2 -->",
+        },
+        runtime="omo",
+    )
+
+    assert "$ralph" not in prompt
 
 
 def test_review_round_prompt_for_external_contribution_mentions_contributor_ownership() -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -154,6 +154,28 @@ def test_failed_job_releases_lock() -> None:
     ]
 
 
+def test_superseded_job_releases_lock() -> None:
+    """A superseded locked job releases the issue lock so other issues can proceed."""
+    execution_order: list[tuple[int, str, str]] = []
+    lock = threading.Lock()
+
+    def handler(job: JobRecord) -> None:
+        with lock:
+            execution_order.append((job.issue_number, job.stage, job.status))  # type: ignore[arg-type]
+        if job.issue_number == 1:
+            job.status = "superseded"
+
+    manager = RepoQueueManager(handler)
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=1))
+    manager.submit(JobRecord(repo_full_name="acme/repo", stage="implementation", issue_number=2))
+    manager.join_all()
+
+    assert execution_order == [
+        (1, "implementation", "queued"),
+        (2, "implementation", "queued"),
+    ]
+
+
 def test_handler_exception_releases_lock() -> None:
     """If the handler raises an unhandled exception, the issue lock is still released."""
     execution_order: list[tuple[int, str]] = []

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -187,3 +187,33 @@ def test_transient_error_with_side_effect_already_posted_completes(mock_sleep: o
     assert job.metadata.get("note") == "side_effect_already_posted"
     # Should NOT have retried — only 1 launch
     assert len(omx_runner.launches) == 1
+
+
+@patch("dani.service.time.sleep")
+def test_restart_issue_request_with_stale_signed_comments_does_not_false_complete_on_transient(
+    mock_sleep: object, tmp_path: Path
+) -> None:
+    service, github, _ = make_service(tmp_path)
+    stale_signature = "<!-- dani:stage=issue_request;job=stale-job;issue=11 -->"
+    github.add_issue_signature("acme/demo", 11, stale_signature)
+
+    original_launch = service.omx_runner.launch
+
+    def launch_without_new_side_effect(repo_path: Path, job, prompt: str):
+        session = original_launch(repo_path, job, prompt)
+        github.issue_comment_map[("acme/demo", 11)] = [{"body": stale_signature}]
+        return session
+
+    service.omx_runner.launch = launch_without_new_side_effect  # type: ignore[assignment]
+
+    def wait_that_always_fails(runtime_handle: str, **kwargs: object) -> None:
+        raise TransientCapacityError(_CAPACITY_MSG, _CAPACITY_MSG)
+
+    service.omx_runner.wait = wait_that_always_fails  # type: ignore[assignment]
+
+    service.handle_event(_issue_event())
+    service.wait_for_idle()
+
+    job = service.storage.list_jobs()[0]
+    assert job.status == "failed"
+    assert job.metadata.get("note") != "side_effect_already_posted"

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -6,7 +6,12 @@ from unittest.mock import patch
 
 import pytest
 
-from dani.errors import TransientCapacityError, check_transient_capacity_error
+from dani.errors import (
+    ClaudeUsageLimitError,
+    TransientCapacityError,
+    check_claude_usage_limit_error,
+    check_transient_capacity_error,
+)
 from dani.github import GitHubCLI
 from dani.models import DaniConfig, NormalizedEvent
 from dani.omx_runner import OmxRunner
@@ -71,6 +76,27 @@ class TestCheckTransientCapacityError:
 
     def test_ignores_empty_string(self) -> None:
         check_transient_capacity_error("")
+
+
+class TestCheckClaudeUsageLimitError:
+    def test_detects_session_window_limit(self) -> None:
+        with pytest.raises(ClaudeUsageLimitError) as exc_info:
+            check_claude_usage_limit_error("Claude usage limit reached. Your limit will reset at 3 PM.")
+
+        assert exc_info.value.limit_type == "session_window"
+        assert exc_info.value.reset_hint == "3 PM"
+        assert exc_info.value.suggested_retry_at is not None
+
+    def test_detects_weekly_limit(self) -> None:
+        with pytest.raises(ClaudeUsageLimitError) as exc_info:
+            check_claude_usage_limit_error("Opus weekly limit reached. It resets on Monday morning.")
+
+        assert exc_info.value.limit_type == "weekly"
+        assert exc_info.value.reset_hint == "Monday morning"
+        assert exc_info.value.suggested_retry_at is not None
+
+    def test_ignores_generic_rate_limit_language(self) -> None:
+        check_claude_usage_limit_error("rate limit exceeded")
 
 
 # --- service.py retry integration tests ---

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -92,3 +92,43 @@ def test_github_webhook_endpoint_queues_dev_sync_on_main_push(tmp_path: Path) ->
 
     assert response.status_code == 200
     assert response.json()["stage"] == "dev_sync"
+
+
+def test_github_webhook_endpoint_dedupes_duplicate_external_pr_delivery(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    github = FakeGitHubCLI()
+    omx_runner = FakeOmxRunner(github)
+    service = DaniService(
+        config, storage=JsonStorage(config), github=cast(GitHubCLI, github), omx_runner=cast(OmxRunner, omx_runner)
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+    client = TestClient(create_app(service))
+    payload = {
+        "action": "synchronize",
+        "repository": {"full_name": "acme/demo"},
+        "sender": {"login": "contributor"},
+        "pull_request": {
+            "number": 21,
+            "title": "Feature/#21",
+            "body": "Implements #21",
+            "base": {"ref": "dev"},
+            "head": {"ref": "feature/#21", "sha": "sha-21-2"},
+        },
+    }
+    body = json.dumps(payload).encode("utf-8")
+    headers = {
+        "x-github-event": "pull_request",
+        "x-github-delivery": "delivery-21",
+        "x-hub-signature-256": _signature(TEST_SECRET, body),
+    }
+
+    first = client.post("/webhook", content=body, headers=headers)
+    second = client.post("/webhook", content=body, headers=headers)
+    service.wait_for_idle()
+
+    assert first.status_code == 200
+    assert first.json()["stage"] == "review_round"
+    assert second.status_code == 200
+    assert second.json() == {"status": "ignored", "reason": "duplicate_external_pr_event"}
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=21)
+    assert [job.review_round for job in review_jobs] == [1]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,8 +1,10 @@
+import threading
 from pathlib import Path
 from typing import cast
 
 import pytest
 
+from dani.errors import RolloutMissingError
 from dani.github import GitHubCLI
 from dani.models import DaniConfig, JobRecord, NormalizedEvent
 from dani.omx_runner import OmxRunner
@@ -14,13 +16,36 @@ from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI, FakeOmxRunner
 TEST_SECRET = "unit-test-secret"
 
 
+def add_exact_review_signature(github: FakeGitHubCLI, job: JobRecord) -> None:
+    signature_fields: dict[str, str | int] = {
+        "stage": "review_round",
+        "job": job.id,
+        "pr": int(job.pr_number or 0),
+        "round": job.review_round or 1,
+    }
+    if job.issue_number is not None:
+        signature_fields["issue"] = int(job.issue_number)
+    github.add_pr_signature(
+        job.repo_full_name,
+        int(job.pr_number or 0),
+        build_signature(**signature_fields),
+    )
+
+
 def make_service(
     tmp_path: Path, *, dev_syncer: FakeGitDevSyncer | None = None
 ) -> tuple[DaniService, FakeGitHubCLI, FakeOmxRunner]:
+    class ExactReviewSignatureOmxRunner(FakeOmxRunner):
+        def launch(self, repo_path: Path, job: JobRecord, prompt: str):
+            session = super().launch(repo_path, job, prompt)
+            if job.stage == "review_round" and job.issue_number is not None:
+                add_exact_review_signature(self.github, job)
+            return session
+
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
-    omx_runner = FakeOmxRunner(github)
+    omx_runner = ExactReviewSignatureOmxRunner(github)
     service = DaniService(
         config,
         storage=storage,
@@ -30,6 +55,47 @@ def make_service(
     )
     service.register_repo("acme/demo", str(tmp_path))
     return service, github, omx_runner
+
+
+def make_pr_event(
+    *,
+    pr_number: int,
+    action: str,
+    body: str,
+    actor_login: str = "contributor",
+    commit_sha: str | None = None,
+    delivery_id: str | None = None,
+) -> NormalizedEvent:
+    head_sha = commit_sha or f"sha-{pr_number}-{action}"
+    return NormalizedEvent(
+        kind="pull_request_opened",
+        repo_full_name="acme/demo",
+        action=action,
+        number=pr_number,
+        actor_login=actor_login,
+        payload={"pull_request": {"head": {"sha": head_sha}}},
+        body=body,
+        title=f"Feature/#{pr_number}",
+        base_branch="dev",
+        head_branch=f"feature/#{pr_number}",
+        commit_sha=head_sha,
+        is_pull_request=True,
+        delivery_id=delivery_id,
+    )
+
+
+def make_pr_comment_event(*, pr_number: int, body: str, actor_login: str = "agent") -> NormalizedEvent:
+    return NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=pr_number,
+        actor_login=actor_login,
+        payload={},
+        body=body,
+        title=f"Feature/#{pr_number}",
+        is_pull_request=True,
+    )
 
 
 def test_issue_request_persists_omx_session_id(tmp_path: Path) -> None:
@@ -51,6 +117,29 @@ def test_issue_request_persists_omx_session_id(tmp_path: Path) -> None:
 
     session = service.storage.list_sessions()[0]
     assert session.omx_session_id == "omx-" + session.job_id
+
+
+def test_issue_request_verification_requires_exact_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_request", issue_number=21)
+    expected_signature = build_signature(stage="issue_request", job=job.id, issue=21)
+    github.add_issue_signature("acme/demo", 21, build_signature(stage="issue_request", job="stale-job", issue=21))
+    github.add_issue_signature("acme/demo", 21, expected_signature)
+
+    service._verify_side_effect(repo, job)
+
+
+def test_issue_request_verification_rejects_stale_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_request", issue_number=21)
+    github.add_issue_signature("acme/demo", 21, build_signature(stage="issue_request", job="stale-job", issue=21))
+
+    with pytest.raises(RuntimeError, match="issue-request-comment-missing"):
+        service._verify_side_effect(repo, job)
 
 
 def test_issue_opened_queues_issue_request(tmp_path: Path) -> None:
@@ -136,6 +225,307 @@ def test_general_issue_comment_without_existing_issue_session_is_ignored(tmp_pat
     assert omx_runner.resumes == []
 
 
+def test_issue_followup_verification_requires_exact_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_followup", issue_number=31)
+    expected_signature = build_signature(stage="issue_followup", job=job.id, issue=31)
+    github.add_issue_signature("acme/demo", 31, build_signature(stage="issue_followup", job="stale-job", issue=31))
+    github.add_issue_signature("acme/demo", 31, expected_signature)
+
+    service._verify_side_effect(repo, job)
+
+
+def test_issue_followup_verification_rejects_stale_signature(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_followup", issue_number=31)
+    github.add_issue_signature("acme/demo", 31, build_signature(stage="issue_followup", job="stale-job", issue=31))
+
+    with pytest.raises(RuntimeError, match="issue-followup-comment-missing"):
+        service._verify_side_effect(repo, job)
+
+
+def test_issue_followup_rollout_missing_marks_job_failed_and_posts_restart_warning(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=33,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    omx_runner.set_resume_failure(
+        RolloutMissingError(
+            "thread/resume failed: no rollout found for thread id 019d6829",
+            "no rollout found",
+        )
+    )
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=33,
+            actor_login="human",
+            payload={"issue": {"body": "Need automation"}},
+            body="Please continue.",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    job = service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=33)[0]
+    assert job.status == "failed"
+    assert job.metadata["error"] == "rollout_missing"
+    assert "thread/resume failed" in job.metadata["error_detail"]
+
+    warning_signature = build_signature(stage="session_lost", issue=33)
+    warning_comments = github.find_comments_by_signature(
+        "acme/demo", 33, kind="issue", signature_fragment=warning_signature
+    )
+    assert len(warning_comments) == 1
+    assert "dani restart-issue acme/demo 33" in warning_comments[0]["body"]
+    latest_comment = github.latest_signature_comment("acme/demo", 33, kind="issue")
+    assert latest_comment is not None
+    assert latest_comment[1]["stage"] == "session_lost"
+    assert latest_comment[1]["issue"] == "33"
+
+
+def test_issue_followup_rollout_missing_warning_comment_is_posted_only_once(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=34,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+    omx_runner.set_resume_failure(
+        RolloutMissingError(
+            "thread/resume failed: no rollout found for thread id 019d6829",
+            "no rollout found",
+        )
+    )
+
+    event = NormalizedEvent(
+        kind="issue_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=34,
+        actor_login="human",
+        payload={"issue": {"body": "Need automation"}},
+        body="Please continue.",
+        title="Need automation",
+    )
+
+    service.handle_event(event)
+    service.wait_for_idle()
+    service.handle_event(event)
+    service.wait_for_idle()
+
+    warning_comments = github.find_comments_by_signature(
+        "acme/demo",
+        34,
+        kind="issue",
+        signature_fragment=build_signature(stage="session_lost", issue=34),
+    )
+    assert len(warning_comments) == 1
+    matching_keys = [
+        key
+        for key in service.storage.snapshot()["processed_events"]["keys"]
+        if "stage=session_lost" in key and "issue=34" in key
+    ]
+    assert len(matching_keys) == 1
+    failed_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=34)
+    assert len(failed_jobs) == 2
+    assert all(job.status == "failed" for job in failed_jobs)
+
+
+def test_issue_followup_rollout_missing_retries_warning_after_comment_post_failure(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=35,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+    omx_runner.set_resume_failure(
+        RolloutMissingError(
+            "thread/resume failed: no rollout found for thread id 019d6829",
+            "no rollout found",
+        )
+    )
+
+    original_create_issue_comment = github.create_issue_comment
+    attempts = 0
+
+    def flaky_create_issue_comment(repo_full_name: str, issue_number: int, body: str) -> dict[str, object]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            msg = "temporary GitHub failure"
+            raise RuntimeError(msg)
+        return original_create_issue_comment(repo_full_name, issue_number, body)
+
+    github.create_issue_comment = flaky_create_issue_comment  # type: ignore[assignment]
+
+    event = NormalizedEvent(
+        kind="issue_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=35,
+        actor_login="human",
+        payload={"issue": {"body": "Need automation"}},
+        body="Please continue.",
+        title="Need automation",
+    )
+
+    service.handle_event(event)
+    service.wait_for_idle()
+    service.handle_event(event)
+    service.wait_for_idle()
+
+    warning_comments = github.find_comments_by_signature(
+        "acme/demo",
+        35,
+        kind="issue",
+        signature_fragment=build_signature(stage="session_lost", issue=35),
+    )
+    assert attempts == 2
+    assert len(warning_comments) == 1
+    matching_keys = [
+        key
+        for key in service.storage.snapshot()["processed_events"]["keys"]
+        if "stage=session_lost" in key and "issue=35" in key
+    ]
+    assert len(matching_keys) == 1
+
+
+def test_restart_issue_supersedes_existing_jobs_and_enqueues_new_issue_request(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    service.queue_manager.submit = lambda job: None  # type: ignore[assignment]
+    stale_request = JobRecord(
+        repo_full_name="acme/demo",
+        stage="issue_request",
+        issue_number=41,
+        status="completed",
+        metadata={"title": "Restart me", "body": "Original body"},
+    )
+    stale_followup = JobRecord(
+        repo_full_name="acme/demo",
+        stage="issue_followup",
+        issue_number=41,
+        status="failed",
+        metadata={"omx_session_id": "omx-stale", "title": "Restart me", "body": "Original body"},
+    )
+    untouched = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=99, status="completed")
+    service.storage.create_job(stale_request)
+    service.storage.create_job(stale_followup)
+    service.storage.create_job(untouched)
+    github.issue_comment_map[("acme/demo", 41)] = [
+        {"body": "Earlier user context", "user": {"login": "human"}},
+        {"body": "Earlier dani reply", "user": {"login": "dani"}},
+    ]
+
+    new_job = service.restart_issue("acme/demo", 41)
+
+    refreshed_request = service.storage.get_job(stale_request.id)
+    refreshed_followup = service.storage.get_job(stale_followup.id)
+    untouched_job = service.storage.get_job(untouched.id)
+    assert refreshed_request is not None and refreshed_request.status == "superseded"
+    assert refreshed_followup is not None and refreshed_followup.status == "superseded"
+    assert untouched_job is not None and untouched_job.status == "completed"
+    assert new_job.stage == "issue_request"
+    assert new_job.status == "queued"
+    assert new_job.issue_number == 41
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    prompt = service._build_prompt(repo, new_job)
+    assert "Earlier user context" in prompt
+    assert "Earlier dani reply" in prompt
+
+
+def test_issue_comment_with_ignore_signature_is_ignored_before_followup(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=36,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=36,
+            actor_login="human",
+            payload={"issue": {"body": "Need automation"}},
+            body="Please ignore this.\n<!-- dani:stage=ignore -->",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "comment_opt_out"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=36) == []
+    assert omx_runner.resumes == []
+
+
+def test_issue_comment_with_ignore_command_overrides_approve(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=37,
+            actor_login="human",
+            payload={"issue": {"body": "context"}},
+            body="/approve\n/dani ignore",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "comment_opt_out"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", issue_number=37) == []
+    assert omx_runner.launches == []
+
+
 def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
     service, _, omx_runner = make_service(tmp_path)
     event = NormalizedEvent(
@@ -210,6 +600,344 @@ def test_pr_opened_from_implementation_signature_queues_review_round(tmp_path: P
     assert result["stage"] == "review_round"
     assert review_jobs[0].review_round == 1
     assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_external_pr_opened_queues_review_round(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == [1]
+    assert review_jobs[0].metadata["external_contribution"] is True
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_external_pr_new_commit_queues_another_review_round(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+
+    result = service.handle_event(make_pr_event(pr_number=88, action="synchronize", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == [1, 2]
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_duplicate_external_pr_activity_event_is_ignored(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21", commit_sha="sha-1"))
+    service.wait_for_idle()
+
+    first = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-2")
+    )
+    service.wait_for_idle()
+    duplicate = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-2")
+    )
+    service.wait_for_idle()
+
+    assert first["stage"] == "review_round"
+    assert duplicate == {"status": "ignored", "reason": "duplicate_external_pr_event"}
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == [1, 2]
+    assert len(omx_runner.launches) == 2
+
+
+def test_duplicate_external_pr_activity_does_not_consume_review_limit(tmp_path: Path) -> None:
+    service, _, _ = make_service(tmp_path)
+    for round_number in range(1, 10):
+        service.storage.create_job(
+            JobRecord(
+                repo_full_name="acme/demo",
+                stage="review_round",
+                pr_number=88,
+                review_round=round_number,
+                metadata={"external_contribution": True},
+                status="completed",
+            )
+        )
+
+    first = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-10")
+    )
+    service.wait_for_idle()
+    duplicate = service.handle_event(
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-10")
+    )
+    service.wait_for_idle()
+
+    assert first["stage"] == "review_round"
+    assert duplicate == {"status": "ignored", "reason": "duplicate_external_pr_event"}
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs if job.metadata.get("external_contribution")] == list(range(1, 11))
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
+
+
+def test_external_pr_fallback_dedupe_key_is_repo_scoped(tmp_path: Path) -> None:
+    service, _, _ = make_service(tmp_path)
+    service.register_repo("acme/other", str(tmp_path))
+
+    first = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="synchronize",
+            number=88,
+            actor_login="contributor",
+            payload={"pull_request": {"head": {"sha": "shared-sha"}}},
+            body="Implements #21",
+            title="Feature/#21",
+            base_branch="dev",
+            head_branch="feature/#21",
+            commit_sha="shared-sha",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    second = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/other",
+            action="synchronize",
+            number=88,
+            actor_login="contributor",
+            payload={"pull_request": {"head": {"sha": "shared-sha"}}},
+            body="Implements #21",
+            title="Feature/#21",
+            base_branch="dev",
+            head_branch="feature/#21",
+            commit_sha="shared-sha",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    assert first["stage"] == "review_round"
+    assert second["stage"] == "review_round"
+    assert [
+        job.review_round for job in service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round")
+    ] == [1]
+    assert [
+        job.review_round for job in service.storage.find_jobs(repo_full_name="acme/other", stage="review_round")
+    ] == [1]
+
+
+def test_external_pr_review_requested_queues_review_round(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(make_pr_event(pr_number=91, action="review_requested", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_external_review_comment_does_not_queue_implementation(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+    review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
+
+    result = service.handle_event(
+        make_pr_comment_event(
+            pr_number=88,
+            body=build_signature(stage="review_round", job=review_job.id, pr=88, round=1),
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "updated", "stage": "review_round"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
+    assert len(omx_runner.launches) == 1
+    assert github.merged == []
+
+
+def test_external_review_approve_comment_queues_final_verdict(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
+    service.wait_for_idle()
+    review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
+
+    result = service.handle_event(
+        make_pr_comment_event(
+            pr_number=88,
+            body=f"/approve\n{build_signature(stage='review_round', job=review_job.id, pr=88, round=1)}",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result["stage"] == "final_verdict"
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
+    assert len(service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=88)) == 1
+    assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+    assert github.merged == []
+
+
+def test_external_final_verdict_approve_merges_without_implementation_job(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        make_pr_comment_event(
+            pr_number=88,
+            body=build_signature(stage="final_verdict", job="verdict-1", pr=88, verdict="APPROVE"),
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "merged", "pr_number": 88}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
+    assert omx_runner.launches == []
+    assert github.merged == [("acme/demo", 88)]
+
+
+def test_external_pr_escalates_after_ten_review_passes(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    for _ in range(10):
+        service.storage.create_job(
+            JobRecord(
+                repo_full_name="acme/demo",
+                stage="review_round",
+                pr_number=88,
+                metadata={"external_contribution": True},
+                status="completed",
+            )
+        )
+
+    result = service.handle_event(make_pr_event(pr_number=88, action="synchronize", body="Implements #21"))
+    service.wait_for_idle()
+
+    assert result["stage"] == "human_escalation"
+    escalation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)
+    assert len(escalation_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "human_escalation"
+
+
+def test_external_review_comment_queues_human_escalation_on_tenth_completed_pass(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    for round_number in range(1, 11):
+        action = "opened" if round_number == 1 else "synchronize"
+        result = service.handle_event(
+            make_pr_event(pr_number=88, action=action, body="Implements #21", commit_sha=f"sha-{round_number}")
+        )
+        service.wait_for_idle()
+
+        assert result["stage"] == "review_round"
+        review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
+        comment_result = service.handle_event(
+            make_pr_comment_event(
+                pr_number=88,
+                body=build_signature(stage="review_round", job=review_job.id, pr=88, round=round_number),
+            )
+        )
+        service.wait_for_idle()
+
+        if round_number < 10:
+            assert comment_result == {"status": "updated", "stage": "review_round"}
+            assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
+            continue
+
+        assert comment_result["stage"] == "human_escalation"
+
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == list(range(1, 11))
+    assert all(job.status == "completed" for job in review_jobs)
+
+    escalation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)
+    assert len(escalation_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "human_escalation"
+
+    post_limit = service.handle_event(
+        make_pr_event(
+            pr_number=88,
+            action="synchronize",
+            body="Implements #21",
+            commit_sha="sha-11",
+        )
+    )
+    service.wait_for_idle()
+
+    assert post_limit == {"status": "ignored", "reason": "human_review_required"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88) == review_jobs
+    assert len(service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)) == 1
+
+
+def test_external_pr_unique_activity_never_queues_an_eleventh_automated_review(tmp_path: Path) -> None:
+    class BlockingOmxRunner(FakeOmxRunner):
+        def __init__(self, github: FakeGitHubCLI) -> None:
+            super().__init__(github)
+            self.review_started = threading.Event()
+            self.release_review = threading.Event()
+
+        def launch(self, repo_path: Path, job: JobRecord, prompt: str):
+            session = super().launch(repo_path, job, prompt)
+            if job.stage == "review_round":
+                add_exact_review_signature(self.github, job)
+            return session
+
+        def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
+            if (
+                runtime_handle.startswith("runtime-")
+                and self.launches
+                and self.launches[-1]["job"].stage == "review_round"
+            ):
+                self.review_started.set()
+                self.release_review.wait(timeout=timeout_seconds)
+
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    github = FakeGitHubCLI()
+    omx_runner = BlockingOmxRunner(github)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github),
+        omx_runner=cast(OmxRunner, omx_runner),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    opened = service.handle_event(
+        make_pr_event(pr_number=88, action="opened", body="Implements #21", commit_sha="sha-1")
+    )
+    assert opened["stage"] == "review_round"
+    assert omx_runner.review_started.wait(timeout=1)
+
+    results = []
+    for round_number in range(2, 12):
+        results.append(
+            service.handle_event(
+                make_pr_event(
+                    pr_number=88,
+                    action="synchronize",
+                    body="Implements #21",
+                    commit_sha=f"sha-{round_number}",
+                )
+            )
+        )
+
+    assert all(result["stage"] == "review_round" for result in results[:9])
+    assert results[9] == {"status": "ignored", "reason": "external_review_limit_pending"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
+
+    omx_runner.release_review.set()
+    service.wait_for_idle()
+
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
+    assert [job.review_round for job in review_jobs] == list(range(1, 11))
+    assert all(job.status == "completed" for job in review_jobs)
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88) == review_jobs
+    assert [job.review_round for job in review_jobs] == list(range(1, 11))
 
 
 def test_review_chain_reaches_verdict_and_merges_on_approve(tmp_path: Path) -> None:
@@ -343,6 +1071,53 @@ def test_approve_verdict_with_merge_conflict_queues_resolution_job(tmp_path: Pat
     assert github.merged == []
 
 
+def test_approve_verdict_with_merge_conflict_reuses_tracked_issue_number_without_pr_body_reference(
+    tmp_path: Path,
+) -> None:
+    service, github, _ = make_service(tmp_path)
+    github.merge_conflicts.add(("acme/demo", 77))
+    service.storage.create_job(
+        JobRecord(
+            repo_full_name="acme/demo",
+            stage="review_round",
+            issue_number=5,
+            pr_number=77,
+            review_round=1,
+            status="completed",
+        )
+    )
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "No issue reference in body",
+        title="Feature without issue in body",
+        head_branch="feature/no-issue",
+        base_branch="dev",
+    )
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=77,
+            actor_login="agent",
+            payload={},
+            body=build_signature(stage="final_verdict", job="verdict-1", pr=77, verdict="APPROVE"),
+            title="Feature without issue in body",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    resolution_jobs = service.storage.find_jobs(
+        repo_full_name="acme/demo", stage="merge_conflict_resolution", pr_number=77
+    )
+    assert result["stage"] == "merge_conflict_resolution"
+    assert resolution_jobs[0].issue_number == 5
+    assert resolution_jobs[0].metadata["head_branch"] == "feature/no-issue"
+
+
 def test_merge_conflict_resolution_comment_queues_final_verdict_retry(tmp_path: Path) -> None:
     service, github, omx_runner = make_service(tmp_path)
     pr_body = "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->"
@@ -377,6 +1152,41 @@ def test_merge_conflict_resolution_comment_queues_final_verdict_retry(tmp_path: 
     assert verdict_jobs[0].metadata["title"] == "Feature/#5"
     assert verdict_jobs[0].metadata["body"] == pr_body
     assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+
+
+def test_duplicate_merge_conflict_resolution_event_is_ignored(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->",
+        title="Feature/#5",
+        head_branch="Feature/#5",
+        base_branch="dev",
+    )
+    event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="merge_conflict_resolution", job="resolve-1", pr=77),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+
+    first = service.handle_event(event)
+    service.wait_for_idle()
+    second = service.handle_event(event)
+    service.wait_for_idle()
+
+    verdict_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=77)
+    assert first["status"] == "queued"
+    assert second == {"status": "ignored", "reason": "duplicate_agent_event"}
+    assert len(verdict_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+    assert omx_runner.launches[-1]["job"].pr_number == 77
 
 
 def test_merge_conflict_resolution_requires_its_own_signed_comment(tmp_path: Path) -> None:
@@ -488,6 +1298,95 @@ def test_final_verdict_verification_rejects_unrelated_signed_comment(tmp_path: P
 
     with pytest.raises(RuntimeError, match="final-verdict-comment-missing"):
         service._verify_side_effect(repo, job)
+
+
+def test_duplicate_final_verdict_event_is_ignored(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.merge_conflicts.add(("acme/demo", 77))
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->",
+        title="Feature/#5",
+        head_branch="Feature/#5",
+        base_branch="dev",
+    )
+    event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="final_verdict", job="verdict-1", pr=77, verdict="APPROVE"),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+
+    first = service.handle_event(event)
+    service.wait_for_idle()
+    second = service.handle_event(event)
+    service.wait_for_idle()
+
+    resolution_jobs = service.storage.find_jobs(
+        repo_full_name="acme/demo", stage="merge_conflict_resolution", pr_number=77
+    )
+    assert first["status"] == "queued"
+    assert second == {"status": "ignored", "reason": "duplicate_agent_event"}
+    assert len(resolution_jobs) == 1
+    assert omx_runner.launches[-1]["job"].stage == "merge_conflict_resolution"
+    assert omx_runner.launches[-1]["job"].pr_number == 77
+
+
+def test_final_verdict_transient_failure_allows_redelivery(tmp_path: Path) -> None:
+    """A transient merge failure must not poison redelivery — the retry must succeed."""
+    from github.GithubException import GithubException
+
+    service, github, _omx_runner = make_service(tmp_path)
+    service.storage.create_job(
+        JobRecord(
+            repo_full_name="acme/demo",
+            stage="review_round",
+            issue_number=5,
+            pr_number=77,
+            review_round=1,
+            status="completed",
+        )
+    )
+    github.add_pull_request(
+        "acme/demo",
+        77,
+        "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->",
+        title="Feature/#5",
+        head_branch="feature/5",
+        base_branch="dev",
+    )
+    original_merge = github.merge_pull_request
+
+    def boom(repo_full_name: str, pr_number: int) -> None:
+        raise GithubException(500, {"message": "GitHub outage"}, {})
+
+    github.merge_pull_request = boom  # type: ignore[assignment]
+    event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=77,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="final_verdict", job="verdict-1", pr=77, verdict="APPROVE"),
+        title="Feature/#5",
+        is_pull_request=True,
+    )
+
+    with pytest.raises(GithubException):
+        service.handle_event(event)
+
+    # Restore normal merge and redeliver the same event
+    github.merge_pull_request = original_merge  # type: ignore[assignment]
+    result = service.handle_event(event)
+    assert result["status"] == "merged"
+    assert ("acme/demo", 77) in github.merged
 
 
 def test_bootstrap_repo_queues_existing_open_issues(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4,14 +4,15 @@ from typing import cast
 
 import pytest
 
-from dani.errors import RolloutMissingError
+from dani.errors import ClaudeUsageLimitError, RolloutMissingError
 from dani.github import GitHubCLI
-from dani.models import DaniConfig, JobRecord, NormalizedEvent
+from dani.models import RUNTIME_OMO, RUNTIME_OMX, DaniConfig, JobRecord, NormalizedEvent
 from dani.omx_runner import OmxRunner
 from dani.service import DaniService
+from dani.session_bridge import BridgeContext, OmoSessionBridge
 from dani.signatures import build_signature
 from dani.storage import JsonStorage
-from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI, FakeOmxRunner
+from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI, FakeOmxRunner, FakeRuntimeRunner
 
 TEST_SECRET = "unit-test-secret"
 
@@ -55,6 +56,40 @@ def make_service(
     )
     service.register_repo("acme/demo", str(tmp_path))
     return service, github, omx_runner
+
+
+def make_omo_preferred_service(
+    tmp_path: Path,
+    *,
+    dev_syncer: FakeGitDevSyncer | None = None,
+    bridge_context: BridgeContext | None = None,
+) -> tuple[DaniService, FakeGitHubCLI, FakeRuntimeRunner, FakeRuntimeRunner]:
+    class StubBridge:
+        def __init__(self, context: BridgeContext | None) -> None:
+            self.context = context
+            self.calls: list[tuple[str, str | None]] = []
+
+        def load(self, *, repo_path: Path, session_id: str | None = None) -> BridgeContext | None:
+            self.calls.append((str(repo_path), session_id))
+            return self.context
+
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET, agent_runtime=RUNTIME_OMO)
+    storage = JsonStorage(config)
+    github = FakeGitHubCLI()
+    omo_runner = FakeRuntimeRunner(github, runtime_name=RUNTIME_OMO)
+    omx_runner = FakeRuntimeRunner(github, runtime_name=RUNTIME_OMX)
+    bridge = StubBridge(bridge_context)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github),
+        omx_runner=cast(OmxRunner, omo_runner),
+        dev_syncer=dev_syncer or FakeGitDevSyncer(),
+        runtime_runners={RUNTIME_OMX: cast(OmxRunner, omx_runner)},
+        session_bridge=cast(OmoSessionBridge, bridge),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+    return service, github, omo_runner, omx_runner
 
 
 def make_pr_event(
@@ -223,6 +258,155 @@ def test_general_issue_comment_without_existing_issue_session_is_ignored(tmp_pat
 
     assert result == {"status": "ignored", "reason": "missing_issue_session"}
     assert omx_runner.resumes == []
+
+
+def test_issue_request_falls_back_from_omo_to_omx_on_claude_session_limit(tmp_path: Path) -> None:
+    bridge_context = BridgeContext(
+        prompt_block="Prior OMO context (imported summary; not a native resume):\n- Open thread: finish edge cases",
+        source_session_id="ses_prior_123",
+        note="from_test",
+    )
+    service, _, omo_runner, omx_runner = make_omo_preferred_service(tmp_path, bridge_context=bridge_context)
+    omo_runner.queue_wait_error(
+        ClaudeUsageLimitError(
+            "Claude usage limit reached",
+            "Claude usage limit reached",
+            "session_window",
+            reset_hint="in 5 hours",
+            suggested_retry_at="2026-04-22T08:00:00+00:00",
+        )
+    )
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=51,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    job = service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_request", issue_number=51)[0]
+    sessions = service.storage.list_sessions()
+    assert job.status == "completed"
+    assert job.metadata["preferred_runtime"] == RUNTIME_OMO
+    assert job.metadata["effective_runtime"] == RUNTIME_OMX
+    assert job.metadata["fallback_reason"] == "claude_session_window_limit"
+    assert job.metadata["usage_limit_kind"] == "session_window"
+    assert job.metadata["bridge_source_session_id"] == "ses_prior_123"
+    assert len(omo_runner.launches) == 1
+    assert len(omx_runner.launches) == 1
+    assert "Prior OMO context" in omx_runner.launches[0]["prompt"]
+    assert "not a native resume" in omx_runner.launches[0]["prompt"]
+    assert [session.effective_runtime for session in sessions] == [RUNTIME_OMO, RUNTIME_OMX]
+    assert sessions[0].status == "failed"
+    assert sessions[1].status == "completed"
+
+
+def test_issue_request_uses_cached_claude_weekly_limit_to_start_directly_on_omx(tmp_path: Path) -> None:
+    service, _, omo_runner, omx_runner = make_omo_preferred_service(tmp_path)
+    service.storage.create_job(
+        JobRecord(
+            repo_full_name="acme/demo",
+            stage="issue_request",
+            issue_number=1,
+            status="failed",
+            metadata={
+                "usage_limit_runtime": RUNTIME_OMO,
+                "usage_limit_kind": "weekly",
+                "usage_limit_until": "2099-01-01T00:00:00+00:00",
+            },
+        )
+    )
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=52,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    job = service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_request", issue_number=52)[0]
+    assert job.status == "completed"
+    assert job.metadata["effective_runtime"] == RUNTIME_OMX
+    assert job.metadata["fallback_reason"] == "cached_claude_usage_limit"
+    assert omo_runner.launches == []
+    assert len(omx_runner.launches) == 1
+
+
+def test_issue_followup_after_omo_fallback_continues_on_omx_session(tmp_path: Path) -> None:
+    service, _, omo_runner, omx_runner = make_omo_preferred_service(tmp_path)
+    omo_runner.queue_wait_error(
+        ClaudeUsageLimitError(
+            "Opus weekly limit reached",
+            "weekly limit reached",
+            "weekly",
+            reset_hint="next week",
+            suggested_retry_at="2026-04-29T00:00:00+00:00",
+        )
+    )
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=53,
+            actor_login="human",
+            payload={},
+            body="Need automation",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=53,
+            actor_login="human",
+            payload={"issue": {"body": "Need automation"}},
+            body="Please continue on the latest plan.",
+            title="Need automation",
+        )
+    )
+    service.wait_for_idle()
+
+    followup_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=53)[0]
+    assert result["stage"] == "issue_followup"
+    assert followup_job.status == "completed"
+    assert followup_job.metadata["effective_runtime"] == RUNTIME_OMX
+    assert len(omo_runner.resumes) == 0
+    assert len(omx_runner.resumes) == 1
+    assert omx_runner.resumes[0]["job"].stage == "issue_followup"
+
+
+def test_service_build_prompt_uses_effective_runtime_not_configured_runtime(tmp_path: Path) -> None:
+    service, _, _, _ = make_omo_preferred_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=54)
+
+    omx_prompt = service._build_prompt(repo, job, runtime=RUNTIME_OMX)
+    omo_prompt = service._build_prompt(repo, job, runtime=RUNTIME_OMO)
+
+    assert "$ralph" in omx_prompt
+    assert "$ralph" not in omo_prompt
+    assert "ultrawork" in omo_prompt
 
 
 def test_issue_followup_verification_requires_exact_signature(tmp_path: Path) -> None:
@@ -1544,6 +1728,44 @@ def test_dev_sync_conflict_launches_omx_and_cleans_up(tmp_path: Path) -> None:
     assert len(dev_syncer.verify_calls) == 1
     assert len(dev_syncer.cleanup_calls) == 1
     assert jobs[0].status == "completed"
+
+
+def test_dev_sync_conflict_falls_back_from_omo_to_omx_on_weekly_limit(tmp_path: Path) -> None:
+    dev_syncer = FakeGitDevSyncer(conflict=True)
+    service, _, omo_runner, omx_runner = make_omo_preferred_service(tmp_path, dev_syncer=dev_syncer)
+    omo_runner.queue_wait_error(
+        ClaudeUsageLimitError(
+            "Opus weekly limit reached",
+            "weekly limit reached",
+            "weekly",
+            reset_hint="next week",
+            suggested_retry_at="2026-04-29T00:00:00+00:00",
+        )
+    )
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="branch_push",
+            repo_full_name="acme/demo",
+            action="push",
+            number=0,
+            actor_login="human",
+            payload={},
+            ref="refs/heads/main",
+            commit_sha="abc123",
+        )
+    )
+    service.wait_for_idle()
+
+    job = service.storage.find_jobs(repo_full_name="acme/demo", stage="dev_sync")[0]
+    assert result["stage"] == "dev_sync"
+    assert job.status == "completed"
+    assert job.metadata["effective_runtime"] == RUNTIME_OMX
+    assert job.metadata["usage_limit_kind"] == "weekly"
+    assert len(omo_runner.launches) == 1
+    assert len(omx_runner.launches) == 1
+    assert len(dev_syncer.verify_calls) == 1
+    assert len(dev_syncer.cleanup_calls) == 1
 
 
 def test_review_round_stops_when_pr_is_closed(tmp_path: Path) -> None:

--- a/tests/test_session_bridge.py
+++ b/tests/test_session_bridge.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from dani.session_bridge import MAX_PROMPT_CHARS, OmoSessionBridge
+
+
+def create_opencode_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE session (id TEXT PRIMARY KEY, title TEXT, directory TEXT, time_updated INTEGER)")
+        conn.execute(
+            "CREATE TABLE todo (session_id TEXT, content TEXT, status TEXT, position INTEGER, time_updated INTEGER)"
+        )
+        conn.execute("CREATE TABLE part (session_id TEXT, data TEXT, time_created INTEGER)")
+
+
+def test_session_bridge_loads_summary_from_opencode_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "opencode.db"
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    create_opencode_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO session (id, title, directory, time_updated) VALUES (?, ?, ?, ?)",
+            ("ses_demo", "Ship the fallback flow", str(repo_path), 2),
+        )
+        conn.executemany(
+            "INSERT INTO todo (session_id, content, status, position, time_updated) VALUES (?, ?, ?, ?, ?)",
+            [
+                ("ses_demo", "Add Claude limit detector", "completed", 1, 1),
+                ("ses_demo", "Bridge prior OMO context", "pending", 2, 2),
+                ("ses_demo", "Write fallback tests", "in_progress", 3, 3),
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO part (session_id, data, time_created) VALUES (?, ?, ?)",
+            [
+                ("ses_demo", json.dumps({"type": "text", "text": "Recent decision about Gastown-style priming"}), 3),
+                ("ses_demo", json.dumps({"type": "tool", "text": "ignored"}), 2),
+                ("ses_demo", "<bad-json>", 1),
+            ],
+        )
+
+    bridge = OmoSessionBridge(db_path=db_path)
+    context = bridge.load(repo_path=repo_path)
+
+    assert context is not None
+    assert context.source_session_id == "ses_demo"
+    assert context.note is None
+    assert "Prior OMO context" in context.prompt_block
+    assert "Ship the fallback flow" in context.prompt_block
+    assert "Add Claude limit detector" in context.prompt_block
+    assert "Bridge prior OMO context" in context.prompt_block
+    assert "Recent decision about Gastown-style priming" in context.prompt_block
+
+
+def test_session_bridge_reports_missing_db(tmp_path: Path) -> None:
+    bridge = OmoSessionBridge(db_path=tmp_path / "missing.db")
+    context = bridge.load(repo_path=tmp_path / "repo")
+
+    assert context is not None
+    assert context.prompt_block == ""
+    assert context.note == "opencode_db_missing"
+
+
+def test_session_bridge_reports_unreadable_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "broken.db"
+    db_path.write_text("not-a-sqlite-db", encoding="utf-8")
+
+    bridge = OmoSessionBridge(db_path=db_path)
+    context = bridge.load(repo_path=tmp_path / "repo")
+
+    assert context is not None
+    assert context.prompt_block == ""
+    assert context.note == "opencode_db_unreadable"
+
+
+def test_session_bridge_reports_unavailable_session(tmp_path: Path) -> None:
+    db_path = tmp_path / "opencode.db"
+    create_opencode_db(db_path)
+
+    bridge = OmoSessionBridge(db_path=db_path)
+    context = bridge.load(repo_path=tmp_path / "repo")
+
+    assert context is not None
+    assert context.prompt_block == ""
+    assert context.note == "opencode_session_unavailable"
+
+
+def test_session_bridge_truncates_prompt_deterministically(tmp_path: Path) -> None:
+    db_path = tmp_path / "opencode.db"
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    create_opencode_db(db_path)
+
+    long_text = "context " * 600
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO session (id, title, directory, time_updated) VALUES (?, ?, ?, ?)",
+            ("ses_long", "Long context", str(repo_path), 1),
+        )
+        for index in range(8):
+            conn.execute(
+                "INSERT INTO part (session_id, data, time_created) VALUES (?, ?, ?)",
+                ("ses_long", json.dumps({"type": "text", "text": f"{index} {long_text}"}), 100 - index),
+            )
+
+    bridge = OmoSessionBridge(db_path=db_path)
+    context = bridge.load(repo_path=repo_path)
+
+    assert context is not None
+    assert len(context.prompt_block) <= MAX_PROMPT_CHARS
+    assert context.prompt_block.endswith("…")

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -1,4 +1,10 @@
-from dani.signatures import build_signature, parse_signature
+from dani.signatures import (
+    build_signature,
+    has_ignore_signature,
+    is_opt_out_comment,
+    parse_agent_signature,
+    parse_signature,
+)
 
 
 def test_signature_round_trip() -> None:
@@ -9,3 +15,17 @@ def test_signature_round_trip() -> None:
         "pr": "7",
         "round": "2",
     }
+
+
+def test_has_ignore_signature_detects_ignore_stage_across_multiple_markers() -> None:
+    text = f"{build_signature(stage='review_round', job='job123', pr=7, round=2)}\n<!-- dani:stage=ignore -->"
+
+    assert has_ignore_signature(text) is True
+
+
+def test_is_opt_out_comment_accepts_dani_ignore_command() -> None:
+    assert is_opt_out_comment("Heads up\n/dani ignore") is True
+
+
+def test_parse_agent_signature_excludes_ignore_stage() -> None:
+    assert parse_agent_signature("<!-- dani:stage=ignore -->") is None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -32,3 +32,58 @@ def test_storage_persists_registry_jobs_sessions_and_events(tmp_path: Path) -> N
     assert snapshot["jobs"]["jobs"][0]["stage"] == "issue_request"
     assert snapshot["sessions"]["sessions"][0]["runtime_handle"] == "runtime-1"
     assert config.events_path.read_text(encoding="utf-8").strip()
+
+
+def test_storage_round_trips_runtime_metadata_and_filters_by_effective_runtime(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    repo = RepoConfig(full_name="acme/demo", local_path=str(tmp_path))
+    storage.register_repo(repo)
+    job = storage.create_job(JobRecord(repo_full_name=repo.full_name, stage="issue_request", issue_number=1))
+    storage.create_session(
+        SessionRecord(
+            repo_full_name=repo.full_name,
+            stage="issue_request",
+            runtime_handle="runtime-omo",
+            prompt_path=str(tmp_path / "prompt-omo.txt"),
+            script_path=str(tmp_path / "run-omo.sh"),
+            worktree_path=str(tmp_path),
+            job_id=job.id,
+            issue_number=1,
+            omx_session_id="ses_omo123",
+            preferred_runtime="omo",
+            effective_runtime="omo",
+            native_session_runtime="omo",
+        )
+    )
+    storage.create_session(
+        SessionRecord(
+            repo_full_name=repo.full_name,
+            stage="issue_request",
+            runtime_handle="runtime-omx",
+            prompt_path=str(tmp_path / "prompt-omx.txt"),
+            script_path=str(tmp_path / "run-omx.sh"),
+            worktree_path=str(tmp_path),
+            job_id=job.id,
+            issue_number=1,
+            omx_session_id="omx-123",
+            preferred_runtime="omo",
+            effective_runtime="omx",
+            native_session_runtime="omx",
+            fallback_reason="claude_weekly_limit",
+            bridge_source_runtime="omo",
+            bridge_source_session_id="ses_omo123",
+        )
+    )
+
+    latest_omx = storage.find_latest_session(
+        repo_full_name=repo.full_name,
+        issue_number=1,
+        require_omx_session_id=True,
+        effective_runtime="omx",
+    )
+
+    assert latest_omx is not None
+    assert latest_omx.fallback_reason == "claude_weekly_limit"
+    assert latest_omx.bridge_source_runtime == "omo"
+    assert latest_omx.bridge_source_session_id == "ses_omo123"

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,56 @@
+from dani.webhook import normalize_event
+
+
+def test_normalize_pull_request_synchronize_event() -> None:
+    event = normalize_event(
+        "pull_request",
+        {
+            "action": "synchronize",
+            "repository": {"full_name": "acme/demo"},
+            "sender": {"login": "contributor"},
+            "pull_request": {
+                "number": 21,
+                "title": "Feature/#21",
+                "body": "Implements #21",
+                "base": {"ref": "dev"},
+                "head": {"ref": "feature/#21", "sha": "abc123"},
+            },
+        },
+        delivery_id="delivery-1",
+    )
+
+    assert event is not None
+    assert event.kind == "pull_request_opened"
+    assert event.number == 21
+    assert event.base_branch == "dev"
+    assert event.head_branch == "feature/#21"
+    assert event.commit_sha == "abc123"
+    assert event.delivery_id == "delivery-1"
+    assert event.is_pull_request is True
+
+
+def test_normalize_pull_request_review_requested_event() -> None:
+    event = normalize_event(
+        "pull_request",
+        {
+            "action": "review_requested",
+            "repository": {"full_name": "acme/demo"},
+            "sender": {"login": "contributor"},
+            "pull_request": {
+                "number": 21,
+                "title": "Feature/#21",
+                "body": "Implements #21",
+                "base": {"ref": "dev"},
+                "head": {"ref": "feature/#21", "sha": "def456"},
+            },
+            "requested_reviewer": {"login": "maintainer"},
+        },
+    )
+
+    assert event is not None
+    assert event.kind == "pull_request_opened"
+    assert event.number == 21
+    assert event.base_branch == "dev"
+    assert event.head_branch == "feature/#21"
+    assert event.commit_sha == "def456"
+    assert event.is_pull_request is True


### PR DESCRIPTION
## 요약
- Claude usage-limit(5시간 윈도우 / weekly)를 OMO 실행 로그에서 분류하도록 추가했습니다.
- OMO가 리밋에 걸리면 새 OMX 세션으로 자동 fallback하고, 이전 OMO 세션의 핵심 컨텍스트를 sqlite bridge로 요약 주입하도록 만들었습니다.
- follow-up / dev-sync conflict도 effective runtime 기준으로 이어지도록 정리했습니다.

## 왜 필요한가
기존에는 dani가 OMO를 사용 중일 때 Claude 사용량 제한에 걸리면 새 세션 시작이나 후속 진행이 실패했습니다. 이 변경으로 제한 상태에서도 dani가 작업을 계속 이어갈 수 있습니다.

## 사용자/개발자 영향
- 사용자는 Claude limit가 걸린 상태에서도 dani가 OMX로 자동 우회해 계속 작업할 수 있습니다.
- 이전 OMO 문맥은 네이티브 resume이 아니라 bounded summary import 방식으로만 전달됩니다.
- 세션/잡 메타데이터에 preferred/effective runtime, fallback reason, bridge source가 남아 디버깅과 후속 lineage 추적이 쉬워집니다.

## 루트 원인
런타임 선택이 사실상 고정 설정값처럼 취급되어, OMO 실행 중 Claude 사용량 제한이 발생해도 세션 단위/라인리지 단위의 runtime fallback 전략이 없었습니다.

## 주요 변경
- runtime alias normalization 및 runtime-aware runner 선택
- Claude usage-limit classifier와 retry-until metadata 저장
- OMO sqlite session bridge (`~/.local/share/opencode/opencode.db`) 추가
- OMO→OMX fallback 시 fresh OMX + imported context 경로 구현
- storage/session metadata 확장 및 테스트 보강

## 검증
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest`

## 비검증 항목
- 실제 Claude quota exhaustion이 걸린 실계정 opencode 환경에서의 end-to-end 확인은 이번 PR에 포함하지 않았습니다.
