### PR TITLE
Make agent wait timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ Optional environment variables:
 - `DANI_AGENT_RUNTIME` — selects the agent backend. Accepted values:
   - `omx` / `oh-my-codex` / `codex` (default)
   - `omo` / `oh-my-openagents` / `oh-my-openagent` / `opencode`
+- `DANI_AGENT_TIMEOUT_SECONDS` — overrides the per-job agent wait timeout in seconds.
+
+Optional config file (`~/.dani/config.json` by default, or `<data-dir>/config.json`):
+
+```json
+{
+  "agent_runtime": "omo",
+  "agent_timeout_seconds": 3600
+}
+```
+
+`agent_timeout_seconds` defaults to `3600`. The environment variable
+`DANI_AGENT_TIMEOUT_SECONDS` takes precedence over the config file when set.
 
 When `DANI_AGENT_RUNTIME=omo` is selected, dani automatically prefixes every
 opencode prompt with the `ultrawork` keyword so oh-my-openagents' ultrawork

--- a/dani/agent_runner.py
+++ b/dani/agent_runner.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Protocol, TextIO, cast, runtime_checkable
 
-from dani.models import JobRecord, SessionRecord
+from dani.models import DEFAULT_AGENT_TIMEOUT_SECONDS, JobRecord, SessionRecord
 
 RUNTIME_ALIASES: dict[str, str] = {
     "omx": "omx",
@@ -53,7 +53,7 @@ class AgentRunner(Protocol):
         runtime_handle: str,
         *,
         poll_interval: float = 0.5,
-        timeout_seconds: float = 1800,
+        timeout_seconds: float = DEFAULT_AGENT_TIMEOUT_SECONDS,
     ) -> None: ...
 
     def close_session(self, runtime_handle: str) -> None: ...

--- a/dani/cli.py
+++ b/dani/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import typer
 import uvicorn
 
-from dani.models import DaniConfig
+from dani.models import DEFAULT_AGENT_TIMEOUT_SECONDS, DaniConfig
 from dani.server import create_app
 from dani.service import DaniService
 
@@ -22,15 +22,53 @@ MAIN_BRANCH_OPTION = typer.Option("main", help="Main branch name.")
 DEV_BRANCH_OPTION = typer.Option("dev", help="Development branch name.")
 
 
+def _load_config_file(data_dir: Path) -> dict[str, object]:
+    config_path = data_dir / "config.json"
+    if not config_path.exists():
+        return {}
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        msg = f"Invalid dani config file {config_path}: {exc}"
+        raise typer.BadParameter(msg) from exc
+    if not isinstance(payload, dict):
+        msg = f"Invalid dani config file {config_path}: top-level JSON value must be an object"
+        raise typer.BadParameter(msg)
+    return payload
+
+
+def _parse_positive_float(value: object, *, name: str) -> float:
+    try:
+        parsed = float(str(value))
+    except (TypeError, ValueError) as exc:
+        msg = f"{name} must be a number of seconds"
+        raise typer.BadParameter(msg) from exc
+    if parsed <= 0:
+        msg = f"{name} must be greater than 0"
+        raise typer.BadParameter(msg)
+    return parsed
+
+
+def _resolve_agent_timeout_seconds(config_payload: dict[str, object]) -> float:
+    value = config_payload.get("agent_timeout_seconds", DEFAULT_AGENT_TIMEOUT_SECONDS)
+    env_value = os.environ.get("DANI_AGENT_TIMEOUT_SECONDS")
+    if env_value:
+        value = env_value
+    return _parse_positive_float(value, name="agent_timeout_seconds")
+
+
 def build_config(data_dir: Path, host: str = "127.0.0.1", port: int = 8787) -> DaniConfig:
+    config_payload = _load_config_file(data_dir)
     secret = os.environ.get("DANI_WEBHOOK_SECRET", "")
-    agent_runtime = os.environ.get("DANI_AGENT_RUNTIME", "omx")
+    agent_runtime = os.environ.get("DANI_AGENT_RUNTIME") or str(config_payload.get("agent_runtime", "omx"))
+    agent_timeout_seconds = _resolve_agent_timeout_seconds(config_payload)
     return DaniConfig(
         data_dir=data_dir,
         webhook_secret=secret,
         host=host,
         port=port,
         agent_runtime=agent_runtime,
+        agent_timeout_seconds=agent_timeout_seconds,
     )
 
 

--- a/dani/models.py
+++ b/dani/models.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 RUNTIME_OMX = "omx"
 RUNTIME_OMO = "omo"
+DEFAULT_AGENT_TIMEOUT_SECONDS = 3600.0
 
 
 def utc_now() -> str:
@@ -120,6 +121,11 @@ class DaniConfig:
     review_rounds: int = 3
     external_review_limit: int = 10
     agent_runtime: str = "omx"
+    agent_timeout_seconds: float = DEFAULT_AGENT_TIMEOUT_SECONDS
+
+    @property
+    def config_path(self) -> Path:
+        return self.data_dir / "config.json"
 
     @property
     def registry_path(self) -> Path:

--- a/dani/omo_http_runner.py
+++ b/dani/omo_http_runner.py
@@ -14,7 +14,7 @@ from dani.errors import (
     check_opencode_session_missing_error,
     check_transient_capacity_error,
 )
-from dani.models import JobRecord, SessionRecord
+from dani.models import DEFAULT_AGENT_TIMEOUT_SECONDS, JobRecord, SessionRecord
 from dani.opencode_http import (
     OPENCODE_BIN_DEFAULT,
     PERMISSION_RESPONSE_DEFAULT,
@@ -149,7 +149,9 @@ class OmoHttpRunner:
             stderr_path=str(event_log_path),
         )
 
-    def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
+    def wait(
+        self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = DEFAULT_AGENT_TIMEOUT_SECONDS
+    ) -> None:
         del poll_interval
         with self._lock:
             task = self._tasks.get(runtime_handle)

--- a/dani/omx_runner.py
+++ b/dani/omx_runner.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 
 from dani.agent_runner import ManagedProcess
 from dani.errors import check_rollout_missing_error, check_transient_capacity_error
-from dani.models import JobRecord, SessionRecord
+from dani.models import DEFAULT_AGENT_TIMEOUT_SECONDS, JobRecord, SessionRecord
 
 __all__ = ["ManagedProcess", "OmxRunner"]
 
@@ -131,7 +131,9 @@ class OmxRunner:
             f'exec omx exec resume {quoted_session_id} --dangerously-bypass-approvals-and-sandbox "$(cat {quoted_prompt})"\n'
         )
 
-    def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
+    def wait(
+        self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = DEFAULT_AGENT_TIMEOUT_SECONDS
+    ) -> None:
         del poll_interval
         with self._lock:
             entry = self._processes.get(runtime_handle)

--- a/dani/service.py
+++ b/dani/service.py
@@ -513,7 +513,7 @@ class DaniService:
         )
         self.storage.create_session(session)
         try:
-            runner.wait(session.runtime_handle)
+            runner.wait(session.runtime_handle, timeout_seconds=self.config.agent_timeout_seconds)
             self._verify_side_effect(repo, job)
         except Exception:
             self._finalize_session(session, status="failed", termination_reason="failed")
@@ -825,7 +825,7 @@ class DaniService:
                     "sync_status": "conflict",
                     "worktree_path": str(conflict_context.worktree_path),
                 }
-                runner.wait(session.runtime_handle)
+                runner.wait(session.runtime_handle, timeout_seconds=self.config.agent_timeout_seconds)
             except ClaudeUsageLimitError as limit_exc:
                 if runtime != RUNTIME_OMO:
                     raise
@@ -886,7 +886,7 @@ class DaniService:
                     "sync_status": "conflict",
                     "worktree_path": str(conflict_context.worktree_path),
                 }
-                runner.wait(session.runtime_handle)
+                runner.wait(session.runtime_handle, timeout_seconds=self.config.agent_timeout_seconds)
             self.dev_syncer.verify_remote_sync(conflict_context)
             self._finalize_session(session, status="completed", termination_reason="completed")
             self.storage.update_job(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -157,6 +157,7 @@ class FakeOmxRunner:
         self.launches: list[LaunchRecord] = []
         self.resumes: list[ResumeRecord] = []
         self.closed_sessions: list[str] = []
+        self.wait_calls: list[dict[str, object]] = []
         self._transient_failures_remaining: int = 0
         self.resume_error: Exception | None = None
 
@@ -269,6 +270,11 @@ class FakeOmxRunner:
         )
 
     def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
+        self.wait_calls.append({
+            "runtime_handle": runtime_handle,
+            "poll_interval": poll_interval,
+            "timeout_seconds": timeout_seconds,
+        })
         if self._transient_failures_remaining > 0:
             self._transient_failures_remaining -= 1
             raise TransientCapacityError(_CAPACITY_MSG, _CAPACITY_MSG)
@@ -348,10 +354,14 @@ class FakeRuntimeRunner(FakeOmxRunner):
         )
 
     def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
-        del poll_interval, timeout_seconds
         if self.wait_errors:
+            self.wait_calls.append({
+                "runtime_handle": runtime_handle,
+                "poll_interval": poll_interval,
+                "timeout_seconds": timeout_seconds,
+            })
             raise self.wait_errors.pop(0)
-        return super().wait(runtime_handle)
+        return super().wait(runtime_handle, poll_interval=poll_interval, timeout_seconds=timeout_seconds)
 
     def get_session_id(self, runtime_handle: str) -> str | None:
         suffix = runtime_handle.removeprefix(f"{self.runtime_name}-runtime-")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,3 +73,25 @@ def test_restart_issue_invokes_service_waits_for_idle_and_prints_job(tmp_path: P
     assert payload["id"] == "job-123"
     assert payload["stage"] == "issue_request"
     assert payload["issue_number"] == 41
+
+
+def test_build_config_reads_agent_timeout_from_config_file(tmp_path: Path, monkeypatch) -> None:
+    data_dir = tmp_path / ".dani"
+    data_dir.mkdir()
+    (data_dir / "config.json").write_text(json.dumps({"agent_timeout_seconds": 7200}), encoding="utf-8")
+    monkeypatch.delenv("DANI_AGENT_TIMEOUT_SECONDS", raising=False)
+
+    config = cli_module.build_config(data_dir)
+
+    assert config.agent_timeout_seconds == 7200
+
+
+def test_build_config_agent_timeout_env_overrides_config_file(tmp_path: Path, monkeypatch) -> None:
+    data_dir = tmp_path / ".dani"
+    data_dir.mkdir()
+    (data_dir / "config.json").write_text(json.dumps({"agent_timeout_seconds": 7200}), encoding="utf-8")
+    monkeypatch.setenv("DANI_AGENT_TIMEOUT_SECONDS", "5400")
+
+    config = cli_module.build_config(data_dir)
+
+    assert config.agent_timeout_seconds == 5400

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2252,3 +2252,34 @@ def test_implementation_without_issue_drops_untracked_pr(tmp_path: Path) -> None
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=42) == []
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=42) == []
     assert omx_runner.launches == []
+
+
+def test_agent_timeout_config_is_passed_to_runner(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET, agent_timeout_seconds=5400)
+    storage = JsonStorage(config)
+    github = FakeGitHubCLI()
+    omx_runner = FakeOmxRunner(github)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github),
+        omx_runner=cast(AgentRunner, omx_runner),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=5,
+            actor_login="alice",
+            payload={},
+            title="Configurable timeout",
+            body="Please handle this.",
+        )
+    )
+    service.wait_for_idle()
+
+    assert omx_runner.wait_calls[-1]["timeout_seconds"] == 5400


### PR DESCRIPTION
## Summary
- add `agent_timeout_seconds` to `DaniConfig` with a 3600s default
- load `<data-dir>/config.json` so operators can set timeout without editing source
- allow `DANI_AGENT_TIMEOUT_SECONDS` to override the config file for emergency runtime tuning
- pass the configured timeout through every agent wait path, including dev-sync conflict resolution

## Configuration
Example `~/.dani/config.json`:

```json
{
  "agent_runtime": "omo",
  "agent_timeout_seconds": 3600
}
```

## Verification
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest` — 209 passed, 2 skipped

## Notes
Untracked local scratch files were intentionally not included in this PR.
