### PR TITLE
Feature/#40

### DIFF
--- a/dani/omo_http_runner.py
+++ b/dani/omo_http_runner.py
@@ -28,7 +28,12 @@ from dani.opencode_http import (
 logger = logging.getLogger(__name__)
 
 ULTRAWORK_PROMPT_PREFIX = "ultrawork\n\n"
-PLANNING_STAGES = frozenset({"issue_request", "issue_followup"})
+COMMENT_ONLY_STAGES = frozenset({
+    "issue_request",
+    "issue_followup",
+    "issue_request_recovery",
+    "issue_followup_recovery",
+})
 DANI_OPENCODE_SERVER_URL_ENV = "DANI_OPENCODE_SERVER_URL"
 DANI_OPENCODE_PERMISSION_RESPONSE_ENV = "DANI_OPENCODE_PERMISSION_RESPONSE"
 SESSION_ID_PATTERN = re.compile(r"^ses_[A-Za-z0-9]+$")
@@ -207,7 +212,7 @@ class OmoHttpRunner:
     def _decorated_prompt(self, prompt: str, *, stage: str | None = None) -> str:
         if prompt.lstrip().lower().startswith("ultrawork"):
             return prompt
-        if stage in PLANNING_STAGES:
+        if stage in COMMENT_ONLY_STAGES:
             return prompt
         return f"{ULTRAWORK_PROMPT_PREFIX}{prompt}"
 

--- a/dani/service.py
+++ b/dani/service.py
@@ -929,6 +929,7 @@ class DaniService:
         source_session = self.storage.find_latest_session(
             repo_full_name=job.repo_full_name,
             stage=job.stage,
+            job_id=job.id,
             issue_number=job.issue_number,
         )
         recovery_attempt = attempts + 1

--- a/dani/service.py
+++ b/dani/service.py
@@ -44,6 +44,17 @@ INELIGIBLE_EXTERNAL_PR_COMMENT = (
 )
 
 RETARGET_REQUEST_STAGE = "retarget_request"
+ISSUE_REQUEST_RECOVERY_STAGE = "issue_request_recovery"
+ISSUE_FOLLOWUP_RECOVERY_STAGE = "issue_followup_recovery"
+ISSUE_COMMENT_RECOVERY_STAGES = {
+    ISSUE_REQUEST_RECOVERY_STAGE: "issue_request",
+    ISSUE_FOLLOWUP_RECOVERY_STAGE: "issue_followup",
+}
+ISSUE_COMMENT_MISSING_ERRORS = {
+    "issue-request-comment-missing",
+    "issue-followup-comment-missing",
+}
+MAX_COMMENT_RECOVERY_ATTEMPTS = 1
 
 RETRY_BACKOFF_SECONDS: list[int] = [60, 180, 600]
 
@@ -434,19 +445,29 @@ class DaniService:
                 if self._handle_transient_failure(repo, job, exc, attempt, max_attempts, retry_history):
                     return
             except Exception as exc:
-                self._handle_job_failure(job, exc, attempt, retry_history)
+                if self._handle_job_failure(job, exc, attempt, retry_history):
+                    return
                 job.status = "failed"
                 return
             else:
-                self.storage.update_job(
-                    job.id,
-                    status="completed",
-                    metadata={**job.metadata, "retry_attempts": attempt - 1, "retry_history": retry_history},
-                )
-                job.status = "completed"
+                self._handle_job_success(job, attempt, retry_history)
                 return
 
+    def _handle_job_success(self, job: JobRecord, attempt: int, retry_history: list[dict[str, str]]) -> None:
+        if job.stage in ISSUE_COMMENT_RECOVERY_STAGES:
+            self._complete_comment_recovery(job)
+        self.storage.update_job(
+            job.id,
+            status="completed",
+            metadata={**job.metadata, "retry_attempts": attempt - 1, "retry_history": retry_history},
+        )
+        job.status = "completed"
+
     def _run_job_attempt(self, repo: RepoConfig, job: JobRecord) -> None:
+        if job.stage in ISSUE_COMMENT_RECOVERY_STAGES:
+            self._run_comment_recovery_attempt(repo, job)
+            return
+
         preferred_runtime = self._preferred_runtime_for(job)
         lineage_session = self._lineage_session_for(job)
         initial_runtime = self._initial_runtime_for(job, preferred_runtime, lineage_session)
@@ -477,6 +498,95 @@ class DaniService:
             session_id=session.id,
             metadata={**job.metadata, "effective_runtime": session.effective_runtime or initial_runtime},
         )
+
+    def _run_comment_recovery_attempt(self, repo: RepoConfig, job: JobRecord) -> None:
+        preferred_runtime = self._preferred_runtime_for(job)
+        runtime = preferred_runtime
+        prompt = self._build_prompt(repo, job, runtime=runtime)
+        runner = self._runner_for_runtime(runtime)
+        resume_session_id = self._recovery_resume_session_id(job, runtime=runtime)
+        if resume_session_id:
+            try:
+                session = runner.resume(Path(repo.local_path), job, prompt, resume_session_id)
+            except Exception as exc:
+                job.metadata["comment_recovery_resume_error"] = str(exc)
+                session = runner.launch(Path(repo.local_path), job, prompt)
+            else:
+                try:
+                    self._wait_for_comment_recovery_session(
+                        runner, repo, job, session, preferred_runtime=preferred_runtime, runtime=runtime
+                    )
+                except Exception as exc:
+                    job.metadata["comment_recovery_resume_error"] = str(exc)
+                    if self._comment_recovery_side_effect_exists(repo, job):
+                        self._mark_comment_recovery_side_effect_already_posted(job)
+                        return
+                    session = runner.launch(Path(repo.local_path), job, prompt)
+                else:
+                    return
+        else:
+            session = runner.launch(Path(repo.local_path), job, prompt)
+        self._wait_for_comment_recovery_session(
+            runner, repo, job, session, preferred_runtime=preferred_runtime, runtime=runtime
+        )
+
+    def _wait_for_comment_recovery_session(
+        self,
+        runner: AgentRunner,
+        repo: RepoConfig,
+        job: JobRecord,
+        session: SessionRecord,
+        *,
+        preferred_runtime: str,
+        runtime: str,
+    ) -> None:
+        self._annotate_session_record(
+            session,
+            preferred_runtime=preferred_runtime,
+            effective_runtime=runtime,
+            fallback_reason=None,
+        )
+        self.storage.create_session(session)
+        self.storage.update_job(
+            job.id,
+            status="launched",
+            session_id=session.id,
+            metadata={
+                **job.metadata,
+                "effective_runtime": session.effective_runtime or runtime,
+                "recovery_runtime_handle": session.runtime_handle,
+            },
+        )
+        job.session_id = session.id
+        job.metadata["effective_runtime"] = session.effective_runtime or runtime
+        job.metadata["recovery_runtime_handle"] = session.runtime_handle
+        try:
+            runner.wait(session.runtime_handle)
+            self._verify_side_effect(repo, job)
+        except Exception:
+            self._finalize_session(session, status="failed", termination_reason="failed")
+            raise
+        self._finalize_session(session, status="completed", termination_reason="completed")
+
+    def _recovery_resume_session_id(self, job: JobRecord, *, runtime: str) -> str | None:
+        source_session_id = job.metadata.get("source_omx_session_id")
+        if not isinstance(source_session_id, str) or not source_session_id:
+            return None
+        runner = self._runner_for_runtime(runtime)
+        if not runner.can_resume(source_session_id):
+            return None
+        return source_session_id
+
+    def _comment_recovery_side_effect_exists(self, repo: RepoConfig, job: JobRecord) -> bool:
+        with contextlib.suppress(Exception):
+            self._verify_side_effect(repo, job)
+            return True
+        return False
+
+    def _mark_comment_recovery_side_effect_already_posted(self, job: JobRecord) -> None:
+        metadata = {**job.metadata, "note": "side_effect_already_posted"}
+        self.storage.update_job(job.id, metadata=metadata)
+        job.metadata = metadata
 
     def _execute_job_session(
         self,
@@ -692,6 +802,8 @@ class DaniService:
             self._verify_side_effect(repo, job)
             side_effect_exists = True
         if side_effect_exists:
+            if job.stage in ISSUE_COMMENT_RECOVERY_STAGES:
+                self._complete_comment_recovery(job)
             self.storage.update_job(
                 job.id,
                 status="completed",
@@ -723,6 +835,8 @@ class DaniService:
                     "retry_history": retry_history,
                 },
             )
+            if job.stage in ISSUE_COMMENT_RECOVERY_STAGES:
+                self._fail_comment_recovery(job, RuntimeError(f"retry_exhausted: {exc}"), attempt, retry_history)
             job.status = "failed"
             return True
         backoff = RETRY_BACKOFF_SECONDS[attempt - 1]
@@ -741,7 +855,12 @@ class DaniService:
         exc: Exception,
         attempt: int,
         retry_history: list[dict[str, str]],
-    ) -> None:
+    ) -> bool:
+        if job.stage in ISSUE_COMMENT_RECOVERY_STAGES:
+            self._fail_comment_recovery(job, exc, attempt, retry_history)
+            return False
+        if self._should_recover_missing_issue_comment(job, exc) and self._enqueue_comment_recovery(job, exc):
+            return True
         metadata = {
             **job.metadata,
             "error": str(exc),
@@ -762,6 +881,149 @@ class DaniService:
             with contextlib.suppress(Exception):
                 self._post_session_lost_warning(job)
         self.storage.update_job(job.id, status="failed", metadata=metadata)
+        return False
+
+    def _should_recover_missing_issue_comment(self, job: JobRecord, exc: Exception) -> bool:
+        return job.stage in {"issue_request", "issue_followup"} and str(exc) in ISSUE_COMMENT_MISSING_ERRORS
+
+    def _enqueue_comment_recovery(self, job: JobRecord, exc: Exception) -> bool:
+        original_error = str(exc)
+        attempts = int(job.metadata.get("comment_recovery_attempts") or 0)
+        existing = self._existing_comment_recovery_job(job)
+        if existing is not None and existing.status in {"queued", "launched", "retrying"}:
+            self.storage.update_job(
+                job.id,
+                status="recovering",
+                metadata={
+                    **job.metadata,
+                    "error": original_error,
+                    "original_error": original_error,
+                    "comment_recovery_attempts": attempts,
+                    "comment_recovery_job_id": existing.id,
+                },
+            )
+            job.status = "recovering"
+            return True
+        if attempts >= MAX_COMMENT_RECOVERY_ATTEMPTS:
+            return False
+
+        repo = self.storage.get_repo(job.repo_full_name)
+        if repo is None or job.issue_number is None:
+            return False
+        recovery_stage = ISSUE_REQUEST_RECOVERY_STAGE if job.stage == "issue_request" else ISSUE_FOLLOWUP_RECOVERY_STAGE
+        expected_signature = build_signature(stage=job.stage, job=job.id, issue=int(job.issue_number))
+        source_session = self.storage.find_latest_session(
+            repo_full_name=job.repo_full_name,
+            stage=job.stage,
+            issue_number=job.issue_number,
+        )
+        recovery_attempt = attempts + 1
+        recovery_job = self._enqueue_job(
+            repo,
+            stage=recovery_stage,
+            issue_number=job.issue_number,
+            metadata={
+                "title": job.metadata.get("title", ""),
+                "body": job.metadata.get("body", ""),
+                "comment_body": job.metadata.get("comment_body", ""),
+                "source_job_id": job.id,
+                "source_stage": job.stage,
+                "original_error": original_error,
+                "expected_signature": expected_signature,
+                "comment_recovery_attempt": recovery_attempt,
+                "preferred_runtime": job.metadata.get(
+                    "preferred_runtime", normalize_runtime(self.config.agent_runtime)
+                ),
+                "source_omx_session_id": (
+                    source_session.omx_session_id
+                    if source_session is not None and source_session.omx_session_id
+                    else job.metadata.get("omx_session_id")
+                ),
+            },
+        )
+        self.storage.update_job(
+            job.id,
+            status="recovering",
+            metadata={
+                **job.metadata,
+                "error": original_error,
+                "original_error": original_error,
+                "comment_recovery_attempts": recovery_attempt,
+                "comment_recovery_job_id": recovery_job.id,
+            },
+        )
+        job.status = "recovering"
+        job.metadata = {
+            **job.metadata,
+            "error": original_error,
+            "original_error": original_error,
+            "comment_recovery_attempts": recovery_attempt,
+            "comment_recovery_job_id": recovery_job.id,
+        }
+        return True
+
+    def _existing_comment_recovery_job(self, job: JobRecord) -> JobRecord | None:
+        recovery_stages = set(ISSUE_COMMENT_RECOVERY_STAGES)
+        for candidate in reversed(
+            self.storage.find_jobs(repo_full_name=job.repo_full_name, issue_number=job.issue_number)
+        ):
+            if candidate.stage not in recovery_stages:
+                continue
+            if candidate.metadata.get("source_job_id") == job.id:
+                return candidate
+        return None
+
+    def _complete_comment_recovery(self, job: JobRecord) -> None:
+        source_job_id = str(job.metadata.get("source_job_id") or "")
+        if not source_job_id:
+            return
+        source = self.storage.get_job(source_job_id)
+        if source is None:
+            return
+        metadata = {
+            **source.metadata,
+            "error": None,
+            "original_error": job.metadata.get("original_error"),
+            "comment_recovery_attempts": job.metadata.get("comment_recovery_attempt", 1),
+            "comment_recovery_job_id": job.id,
+            "comment_recovery_session_id": job.session_id,
+            "comment_recovery_runtime_handle": job.metadata.get("recovery_runtime_handle"),
+        }
+        self.storage.update_job(source.id, status="completed", metadata=metadata)
+
+    def _fail_comment_recovery(
+        self,
+        job: JobRecord,
+        exc: Exception,
+        attempt: int,
+        retry_history: list[dict[str, str]],
+    ) -> None:
+        source_job_id = str(job.metadata.get("source_job_id") or "")
+        original_error = str(job.metadata.get("original_error") or str(exc))
+        metadata = {
+            **job.metadata,
+            "error": str(exc),
+            "retry_attempts": attempt - 1,
+            "retry_history": retry_history,
+        }
+        self.storage.update_job(job.id, status="failed", metadata=metadata)
+        source = self.storage.get_job(source_job_id) if source_job_id else None
+        if source is None:
+            return
+        self.storage.update_job(
+            source.id,
+            status="failed",
+            metadata={
+                **source.metadata,
+                "error": original_error,
+                "original_error": original_error,
+                "comment_recovery_attempts": job.metadata.get("comment_recovery_attempt", 1),
+                "comment_recovery_job_id": job.id,
+                "comment_recovery_session_id": job.session_id,
+                "comment_recovery_runtime_handle": job.metadata.get("recovery_runtime_handle"),
+                "comment_recovery_last_error": str(exc),
+            },
+        )
 
     def _run_dev_sync_job(self, repo: RepoConfig, job: JobRecord) -> None:
         session = None
@@ -970,6 +1232,9 @@ class DaniService:
             )
             return self._apply_bridge_context(prompt, bridge_prompt)
 
+        if job.stage in ISSUE_COMMENT_RECOVERY_STAGES:
+            return self._build_issue_comment_recovery_prompt(repo, job, issue_number, issue_title, issue_body)
+
         if job.stage == "review_round":
             prompt = self._build_review_round_prompt(
                 repo,
@@ -1025,6 +1290,9 @@ class DaniService:
             return
         if job.stage == "issue_followup":
             self._verify_issue_followup_side_effect(repo, job)
+            return
+        if job.stage in ISSUE_COMMENT_RECOVERY_STAGES:
+            self._verify_issue_comment_recovery_side_effect(repo, job)
             return
         if job.stage == "implementation":
             self._verify_implementation_side_effect(repo, job)
@@ -1149,6 +1417,44 @@ class DaniService:
                 "signature": build_signature(stage="issue_followup", job=job.id, issue=issue_number),
             },
             runtime=runtime,
+        )
+
+    def _build_issue_comment_recovery_prompt(
+        self,
+        repo: RepoConfig,
+        job: JobRecord,
+        issue_number: int,
+        issue_title: str,
+        issue_body: str,
+    ) -> str:
+        original_stage = ISSUE_COMMENT_RECOVERY_STAGES[job.stage]
+        source_job_id = str(job.metadata.get("source_job_id", ""))
+        expected_signature = str(job.metadata.get("expected_signature", ""))
+        original_error = str(job.metadata.get("original_error", ""))
+        comment_body = str(job.metadata.get("comment_body", ""))
+        return (
+            f"You are operating inside repository: {repo.full_name}\n"
+            f"Local path: {repo.local_path}\n"
+            f"Recovery task for GitHub issue #{issue_number}: {issue_title}\n\n"
+            "A previous Dani OMX session ended without leaving the required GitHub issue comment, "
+            f"so side-effect verification failed with `{original_error}`.\n\n"
+            "Strict recovery instructions:\n"
+            "- Do not write code, edit files, create branches, open PRs, or run implementation work.\n"
+            "- Leave one GitHub issue comment exactly once, then exit.\n"
+            "- The comment must include the exact Dani signature below unchanged; do not replace it with this "
+            "recovery job's id.\n"
+            "- Keep the comment concise and self-contained for the visible issue discussion.\n\n"
+            f"Repository: {repo.full_name}\n"
+            f"Issue number: {issue_number}\n"
+            f"Issue title: {issue_title}\n\n"
+            f"Original issue body:\n{issue_body}\n\n"
+            f"Latest follow-up comment, if any:\n{comment_body}\n\n"
+            f"Original job id: {source_job_id}\n"
+            f"Original stage: {original_stage}\n"
+            f"Required exact Dani signature:\n{expected_signature}\n\n"
+            "Post it with gh (write the comment to a file first, then send it):\n"
+            f"gh issue comment {issue_number} --repo {repo.full_name} --body-file <recovery-comment.md>\n\n"
+            "After posting the comment, exit."
         )
 
     def _build_review_round_prompt(
@@ -1299,6 +1605,14 @@ class DaniService:
         signature = build_signature(stage="issue_followup", job=job.id, issue=int(job.issue_number or 0))
         if not self._has_exact_issue_signature(repo.full_name, int(job.issue_number or 0), signature):
             raise RuntimeError("issue-followup-comment-missing")
+
+    def _verify_issue_comment_recovery_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
+        signature = str(job.metadata.get("expected_signature") or "")
+        if not signature:
+            raise RuntimeError("issue-comment-recovery-missing-signature")
+        if not self._has_exact_issue_signature(repo.full_name, int(job.issue_number or 0), signature):
+            original_error = str(job.metadata.get("original_error") or "issue-comment-missing")
+            raise RuntimeError(original_error)
 
     def _verify_implementation_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
         signature_fields: dict[str, int | str] = {

--- a/dani/service.py
+++ b/dani/service.py
@@ -510,6 +510,9 @@ class DaniService:
                 session = runner.resume(Path(repo.local_path), job, prompt, resume_session_id)
             except Exception as exc:
                 job.metadata["comment_recovery_resume_error"] = str(exc)
+                if self._comment_recovery_side_effect_exists(repo, job):
+                    self._mark_comment_recovery_side_effect_already_posted(job)
+                    return
                 session = runner.launch(Path(repo.local_path), job, prompt)
             else:
                 try:

--- a/dani/service.py
+++ b/dani/service.py
@@ -501,7 +501,7 @@ class DaniService:
 
     def _run_comment_recovery_attempt(self, repo: RepoConfig, job: JobRecord) -> None:
         preferred_runtime = self._preferred_runtime_for(job)
-        runtime = preferred_runtime
+        runtime = self._runtime_for_comment_recovery_resume(job, preferred_runtime=preferred_runtime)
         prompt = self._build_prompt(repo, job, runtime=runtime)
         runner = self._runner_for_runtime(runtime)
         resume_session_id = self._recovery_resume_session_id(job, runtime=runtime)
@@ -576,6 +576,20 @@ class DaniService:
         if not runner.can_resume(source_session_id):
             return None
         return source_session_id
+
+    def _runtime_for_comment_recovery_resume(self, job: JobRecord, *, preferred_runtime: str) -> str:
+        source_runtime = job.metadata.get("source_effective_runtime") or job.metadata.get(
+            "source_native_session_runtime"
+        )
+        source_session_id = job.metadata.get("source_omx_session_id")
+        if not isinstance(source_runtime, str) or not source_runtime:
+            return preferred_runtime
+        if not isinstance(source_session_id, str) or not source_session_id:
+            return preferred_runtime
+        runtime = normalize_runtime(source_runtime)
+        if self._runner_for_runtime(runtime).can_resume(source_session_id):
+            return runtime
+        return preferred_runtime
 
     def _comment_recovery_side_effect_exists(self, repo: RepoConfig, job: JobRecord) -> bool:
         with contextlib.suppress(Exception):
@@ -939,6 +953,13 @@ class DaniService:
                     if source_session is not None and source_session.omx_session_id
                     else job.metadata.get("omx_session_id")
                 ),
+                "source_preferred_runtime": (source_session.preferred_runtime if source_session is not None else None),
+                "source_effective_runtime": (
+                    effective_session_runtime(source_session) if source_session is not None else None
+                ),
+                "source_native_session_runtime": (
+                    source_session.native_session_runtime if source_session is not None else None
+                ),
             },
         )
         self.storage.update_job(
@@ -987,7 +1008,9 @@ class DaniService:
             "comment_recovery_attempts": job.metadata.get("comment_recovery_attempt", 1),
             "comment_recovery_job_id": job.id,
             "comment_recovery_session_id": job.session_id,
+            "comment_recovery_effective_runtime": job.metadata.get("effective_runtime"),
             "comment_recovery_runtime_handle": job.metadata.get("recovery_runtime_handle"),
+            "comment_recovery_resume_error": job.metadata.get("comment_recovery_resume_error"),
         }
         self.storage.update_job(source.id, status="completed", metadata=metadata)
 
@@ -1020,7 +1043,9 @@ class DaniService:
                 "comment_recovery_attempts": job.metadata.get("comment_recovery_attempt", 1),
                 "comment_recovery_job_id": job.id,
                 "comment_recovery_session_id": job.session_id,
+                "comment_recovery_effective_runtime": job.metadata.get("effective_runtime"),
                 "comment_recovery_runtime_handle": job.metadata.get("recovery_runtime_handle"),
+                "comment_recovery_resume_error": job.metadata.get("comment_recovery_resume_error"),
                 "comment_recovery_last_error": str(exc),
             },
         )

--- a/dani/storage.py
+++ b/dani/storage.py
@@ -143,6 +143,7 @@ class JsonStorage:
         *,
         repo_full_name: str,
         stage: str | None = None,
+        job_id: str | None = None,
         issue_number: int | None = None,
         pr_number: int | None = None,
         require_omx_session_id: bool = False,
@@ -152,6 +153,8 @@ class JsonStorage:
             if session.repo_full_name != repo_full_name:
                 continue
             if stage is not None and session.stage != stage:
+                continue
+            if job_id is not None and session.job_id != job_id:
                 continue
             if issue_number is not None and session.issue_number != issue_number:
                 continue

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -190,7 +190,9 @@ class FakeOmxRunner:
             omx_session_id=f"omx-{job.id}",
         )
 
-    def _post_side_effect(self, repo_full_name: str, job: JobRecord, signature: dict[str, str] | None) -> None:
+    def _post_side_effect(  # noqa: C901
+        self, repo_full_name: str, job: JobRecord, signature: dict[str, str] | None
+    ) -> None:
         if job.stage == "issue_request":
             issue_number = int((signature or {}).get("issue", job.issue_number or 0))
             self.github.add_issue_signature(
@@ -198,6 +200,8 @@ class FakeOmxRunner:
                 issue_number,
                 build_signature(stage="issue_request", job=job.id, issue=issue_number),
             )
+        elif job.stage in {"issue_request_recovery", "issue_followup_recovery"}:
+            self._post_recovery_side_effect(repo_full_name, job)
         elif job.stage == "implementation":
             issue_number = int((signature or {}).get("issue", job.issue_number or 0))
             pr_number = int((signature or {}).get("pr", job.pr_number or 0))
@@ -238,6 +242,11 @@ class FakeOmxRunner:
                 job.pr_number or 0,
                 build_signature(stage="final_verdict", job=job.id, pr=job.pr_number or 0, verdict="APPROVE"),
             )
+
+    def _post_recovery_side_effect(self, repo_full_name: str, job: JobRecord) -> None:
+        expected_signature = job.metadata.get("expected_signature")
+        if isinstance(expected_signature, str) and expected_signature:
+            self.github.add_issue_signature(repo_full_name, job.issue_number or 0, expected_signature)
 
     def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
         if self.resume_error is not None:

--- a/tests/test_omo_http_runner.py
+++ b/tests/test_omo_http_runner.py
@@ -234,6 +234,16 @@ def test_launch_issue_followup_stage_skips_ultrawork_prefix(runner_factory, tmp_
     assert client.prompt_calls[0]["prompt_text"] == "Refine plan based on follow-up."
 
 
+@pytest.mark.parametrize("stage", ["issue_request_recovery", "issue_followup_recovery"])
+def test_launch_issue_comment_recovery_stages_skip_ultrawork_prefix(runner_factory, tmp_path: Path, stage: str) -> None:
+    runner, client, _ = runner_factory()
+    job = JobRecord(repo_full_name="acme/demo", stage=stage, issue_number=2)
+
+    runner.launch(tmp_path, job, "Post the missing Dani signature comment exactly once.")
+
+    assert client.prompt_calls[0]["prompt_text"] == "Post the missing Dani signature comment exactly once."
+
+
 def test_launch_does_not_double_prefix_when_prompt_already_starts_with_ultrawork(
     runner_factory, tmp_path: Path
 ) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2604,6 +2604,83 @@ def test_issue_request_recovery_resumes_source_effective_omx_session_when_prefer
     assert recovery_job.metadata["effective_runtime"] == RUNTIME_OMX
 
 
+def test_issue_request_recovery_prefers_source_job_session_when_newer_same_issue_session_exists(
+    tmp_path: Path,
+) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    github = FakeGitHubCLI()
+    omx_runner = CommentRecoveryRuntimeRunner(github, runtime_name=RUNTIME_OMX)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github),
+        omx_runner=cast(AgentRunner, omx_runner),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    source_job = JobRecord(
+        repo_full_name="acme/demo",
+        stage="issue_request",
+        issue_number=49,
+        status="failed",
+        metadata={"title": "Original", "body": "Original"},
+    )
+    newer_job = JobRecord(
+        repo_full_name="acme/demo",
+        stage="issue_request",
+        issue_number=49,
+        status="completed",
+        metadata={"title": "Newer", "body": "Newer"},
+    )
+    service.storage.create_job(source_job)
+    service.storage.create_job(newer_job)
+    service.storage.create_session(
+        SessionRecord(
+            repo_full_name="acme/demo",
+            stage="issue_request",
+            runtime_handle=f"runtime-{source_job.id}",
+            prompt_path=str(tmp_path / "prompt-source.txt"),
+            script_path=str(tmp_path / "run-source.sh"),
+            worktree_path=str(tmp_path),
+            job_id=source_job.id,
+            issue_number=49,
+            omx_session_id="omx-source",
+            preferred_runtime=RUNTIME_OMX,
+            effective_runtime=RUNTIME_OMX,
+            native_session_runtime=RUNTIME_OMX,
+        )
+    )
+    service.storage.create_session(
+        SessionRecord(
+            repo_full_name="acme/demo",
+            stage="issue_request",
+            runtime_handle=f"runtime-{newer_job.id}",
+            prompt_path=str(tmp_path / "prompt-newer.txt"),
+            script_path=str(tmp_path / "run-newer.sh"),
+            worktree_path=str(tmp_path),
+            job_id=newer_job.id,
+            issue_number=49,
+            omx_session_id="omx-newer",
+            preferred_runtime=RUNTIME_OMX,
+            effective_runtime=RUNTIME_OMX,
+            native_session_runtime=RUNTIME_OMX,
+        )
+    )
+    service.queue_manager.submit = lambda queued_job: None  # type: ignore[method-assign]
+
+    assert service._handle_job_failure(source_job, RuntimeError("issue-request-comment-missing"), 1, [])
+    recovery_job = next(job for job in service.storage.list_jobs() if job.stage == "issue_request_recovery")
+
+    service._run_comment_recovery_attempt(repo, recovery_job)
+
+    assert [record["omx_session_id"] for record in omx_runner.resumes] == ["omx-source"]
+    assert recovery_job.metadata["source_job_id"] == source_job.id
+    assert recovery_job.metadata["source_omx_session_id"] == "omx-source"
+
+
 def test_issue_request_recovery_falls_back_to_fresh_launch_when_resumed_process_fails(tmp_path: Path) -> None:
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -7,7 +7,7 @@ import pytest
 from dani.agent_runner import AgentRunner
 from dani.errors import ClaudeUsageLimitError, RolloutMissingError
 from dani.github import GitHubCLI
-from dani.models import RUNTIME_OMO, RUNTIME_OMX, DaniConfig, JobRecord, NormalizedEvent
+from dani.models import RUNTIME_OMO, RUNTIME_OMX, DaniConfig, JobRecord, NormalizedEvent, SessionRecord
 from dani.omx_runner import OmxRunner
 from dani.service import DaniService
 from dani.session_bridge import BridgeContext, OmoSessionBridge
@@ -2252,3 +2252,398 @@ def test_implementation_without_issue_drops_untracked_pr(tmp_path: Path) -> None
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=42) == []
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=42) == []
     assert omx_runner.launches == []
+
+
+class MissingIssueCommentRunner(FakeOmxRunner):
+    def __init__(self, github: FakeGitHubCLI, *, recover: bool = True, resumable: bool = True) -> None:
+        super().__init__(github)
+        self.recover = recover
+        self.resumable = resumable
+
+    def launch(self, repo_path: Path, job: JobRecord, prompt: str):
+        if job.stage in {"issue_request", "issue_followup"}:
+            self.launches.append({"repo_path": str(repo_path), "job": job, "prompt": prompt})
+            return SessionRecord(
+                repo_full_name=job.repo_full_name,
+                stage=job.stage,
+                runtime_handle=f"runtime-{job.id}",
+                prompt_path=str(repo_path / "prompt.txt"),
+                script_path=str(repo_path / "run.sh"),
+                worktree_path=str(repo_path),
+                job_id=job.id,
+                issue_number=job.issue_number,
+                pr_number=job.pr_number,
+                review_round=job.review_round,
+                omx_session_id=f"omx-{job.id}" if self.resumable else None,
+            )
+        if job.stage in {"issue_request_recovery", "issue_followup_recovery"} and self.recover:
+            self._post_recovery_signature(job)
+        return super().launch(repo_path, job, prompt)
+
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str):
+        if job.stage in {"issue_request_recovery", "issue_followup_recovery"} and self.recover:
+            self._post_recovery_signature(job)
+        self.resumes.append({
+            "repo_path": str(repo_path),
+            "job": job,
+            "prompt": prompt,
+            "omx_session_id": omx_session_id,
+        })
+        return SessionRecord(
+            repo_full_name=job.repo_full_name,
+            stage=job.stage,
+            runtime_handle=f"runtime-{job.id}",
+            prompt_path=str(repo_path / "prompt.txt"),
+            script_path=str(repo_path / "run.sh"),
+            worktree_path=str(repo_path),
+            job_id=job.id,
+            issue_number=job.issue_number,
+            pr_number=job.pr_number,
+            review_round=job.review_round,
+            omx_session_id=omx_session_id,
+        )
+
+    def can_resume(self, session_id: str) -> bool:
+        return self.resumable and super().can_resume(session_id)
+
+    def _post_recovery_signature(self, job: JobRecord) -> None:
+        expected_signature = str(job.metadata["expected_signature"])
+        self.github.add_issue_signature(job.repo_full_name, int(job.issue_number or 0), expected_signature)
+
+    def _post_recovery_side_effect(self, repo_full_name: str, job: JobRecord) -> None:
+        if self.recover:
+            self._post_recovery_signature(job)
+
+
+def make_missing_comment_service(
+    tmp_path: Path, *, recover: bool = True, resumable: bool = True
+) -> tuple[DaniService, FakeGitHubCLI, MissingIssueCommentRunner]:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    github = FakeGitHubCLI()
+    omx_runner = MissingIssueCommentRunner(github, recover=recover, resumable=resumable)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github),
+        omx_runner=cast(AgentRunner, omx_runner),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+    return service, github, omx_runner
+
+
+def test_issue_request_missing_signature_recovers_with_original_signature(tmp_path: Path) -> None:
+    service, github, omx_runner = make_missing_comment_service(tmp_path)
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=40,
+            actor_login="human",
+            payload={},
+            body="Need planning",
+            title="Need planning",
+        )
+    )
+    service.wait_for_idle()
+
+    jobs = service.storage.list_jobs()
+    source_job = jobs[0]
+    recovery_job = jobs[1]
+    expected_signature = build_signature(stage="issue_request", job=source_job.id, issue=40)
+    assert source_job.stage == "issue_request"
+    assert source_job.status == "completed"
+    assert source_job.metadata["comment_recovery_attempts"] == 1
+    assert source_job.metadata["comment_recovery_job_id"] == recovery_job.id
+    assert recovery_job.stage == "issue_request_recovery"
+    assert recovery_job.status == "completed"
+    assert recovery_job.metadata["source_job_id"] == source_job.id
+    assert recovery_job.metadata["expected_signature"] == expected_signature
+    assert github.find_comments_by_signature("acme/demo", 40, kind="issue", signature_fragment=expected_signature)
+    recovery_prompt = omx_runner.resumes[-1]["prompt"]
+    assert expected_signature in recovery_prompt
+    assert "Do not write code" in recovery_prompt
+    assert "GitHub issue comment exactly once" in recovery_prompt
+
+
+def test_issue_request_recovery_failure_is_bounded_and_records_details(tmp_path: Path) -> None:
+    service, _, _ = make_missing_comment_service(tmp_path, recover=False)
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=41,
+            actor_login="human",
+            payload={},
+            body="Need planning",
+            title="Need planning",
+        )
+    )
+    service.wait_for_idle()
+
+    source_job, recovery_job = service.storage.list_jobs()
+    assert source_job.status == "failed"
+    assert source_job.metadata["error"] == "issue-request-comment-missing"
+    assert source_job.metadata["original_error"] == "issue-request-comment-missing"
+    assert source_job.metadata["comment_recovery_attempts"] == 1
+    assert source_job.metadata["comment_recovery_job_id"] == recovery_job.id
+    assert source_job.metadata["comment_recovery_session_id"] == recovery_job.session_id
+    assert source_job.metadata["comment_recovery_last_error"] == "issue-request-comment-missing"
+    assert recovery_job.status == "failed"
+
+
+def test_issue_request_recovery_uses_fresh_launch_when_original_session_cannot_resume(tmp_path: Path) -> None:
+    service, _, omx_runner = make_missing_comment_service(tmp_path, resumable=False)
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=42,
+            actor_login="human",
+            payload={},
+            body="Need planning",
+            title="Need planning",
+        )
+    )
+    service.wait_for_idle()
+
+    assert not omx_runner.resumes
+    assert [record["job"].stage for record in omx_runner.launches] == ["issue_request", "issue_request_recovery"]
+    source_job, recovery_job = service.storage.list_jobs()
+    assert source_job.status == "completed"
+    assert recovery_job.status == "completed"
+
+
+def test_missing_issue_comment_recovery_is_not_duplicated_for_same_job(tmp_path: Path) -> None:
+    service, _, _ = make_missing_comment_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(
+        repo_full_name=repo.full_name,
+        stage="issue_request",
+        issue_number=44,
+        metadata={"title": "Need planning", "body": "Need planning"},
+    )
+    service.storage.create_job(job)
+    service.queue_manager.submit = lambda queued_job: None  # type: ignore[method-assign]
+
+    assert service._handle_job_failure(job, RuntimeError("issue-request-comment-missing"), 1, [])
+    assert service._handle_job_failure(job, RuntimeError("issue-request-comment-missing"), 1, [])
+
+    recovery_jobs = [
+        candidate for candidate in service.storage.list_jobs() if candidate.stage == "issue_request_recovery"
+    ]
+    assert len(recovery_jobs) == 1
+    source_job = service.storage.get_job(job.id)
+    assert source_job is not None
+    assert source_job.status == "recovering"
+    assert source_job.metadata["comment_recovery_job_id"] == recovery_jobs[0].id
+
+
+def test_issue_followup_missing_signature_recovers_with_original_signature(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=43,
+            actor_login="human",
+            payload={},
+            body="Need planning",
+            title="Need planning",
+        )
+    )
+    service.wait_for_idle()
+    omx_runner.resume_error = RuntimeError("issue-followup-comment-missing")
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=43,
+            actor_login="human",
+            payload={"issue": {"body": "Need planning"}},
+            body="Please clarify scope.",
+            title="Need planning",
+        )
+    )
+    service.wait_for_idle()
+
+    jobs = service.storage.list_jobs()
+    followup_job = next(job for job in jobs if job.stage == "issue_followup")
+    recovery_job = next(job for job in jobs if job.stage == "issue_followup_recovery")
+    expected_signature = build_signature(stage="issue_followup", job=followup_job.id, issue=43)
+    assert followup_job.status == "completed"
+    assert recovery_job.status == "completed"
+    assert recovery_job.metadata["expected_signature"] == expected_signature
+    assert github.find_comments_by_signature("acme/demo", 43, kind="issue", signature_fragment=expected_signature)
+    assert expected_signature in omx_runner.launches[-1]["prompt"]
+
+
+class ResumeWaitFailureRecoveryRunner(MissingIssueCommentRunner):
+    def __init__(self, github: FakeGitHubCLI, *, post_before_failure: bool = False) -> None:
+        super().__init__(github, recover=False, resumable=True)
+        self._fail_next_resume_wait = False
+        self.post_before_failure = post_before_failure
+
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str):
+        if job.stage in {"issue_request_recovery", "issue_followup_recovery"} and self.post_before_failure:
+            self._post_recovery_signature(job)
+        session = super().resume(repo_path, job, prompt, omx_session_id)
+        if job.stage in {"issue_request_recovery", "issue_followup_recovery"}:
+            self._fail_next_resume_wait = True
+        return session
+
+    def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
+        if self._fail_next_resume_wait:
+            self._fail_next_resume_wait = False
+            raise RuntimeError("resume failed")  # noqa: TRY003
+        return super().wait(runtime_handle, poll_interval=poll_interval, timeout_seconds=timeout_seconds)
+
+    def launch(self, repo_path: Path, job: JobRecord, prompt: str):
+        if job.stage in {"issue_request_recovery", "issue_followup_recovery"}:
+            self._post_recovery_signature(job)
+        return super().launch(repo_path, job, prompt)
+
+
+class RecoveryTransientFailureRunner(MissingIssueCommentRunner):
+    def _post_recovery_side_effect(self, repo_full_name: str, job: JobRecord) -> None:
+        return None
+
+    def launch(self, repo_path: Path, job: JobRecord, prompt: str):
+        session = super().launch(repo_path, job, prompt)
+        if job.stage in {"issue_request_recovery", "issue_followup_recovery"}:
+            self.set_transient_failures(1)
+        return session
+
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str):
+        session = super().resume(repo_path, job, prompt, omx_session_id)
+        if job.stage in {"issue_request_recovery", "issue_followup_recovery"}:
+            self.set_transient_failures(1)
+        return session
+
+
+def test_issue_request_recovery_falls_back_to_fresh_launch_when_resumed_process_fails(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    github = FakeGitHubCLI()
+    omx_runner = ResumeWaitFailureRecoveryRunner(github)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github),
+        omx_runner=cast(AgentRunner, omx_runner),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=45,
+            actor_login="human",
+            payload={},
+            body="Need planning",
+            title="Need planning",
+        )
+    )
+    service.wait_for_idle()
+
+    source_job, recovery_job = service.storage.list_jobs()
+    assert source_job.status == "completed"
+    assert recovery_job.status == "completed"
+    assert [record["job"].stage for record in omx_runner.resumes] == ["issue_request_recovery"]
+    assert [record["job"].stage for record in omx_runner.launches] == ["issue_request", "issue_request_recovery"]
+    assert recovery_job.metadata["comment_recovery_resume_error"] == "resume failed"
+
+
+def test_issue_request_recovery_does_not_fresh_launch_when_failed_resume_posted_signature(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    github = FakeGitHubCLI()
+    omx_runner = ResumeWaitFailureRecoveryRunner(github, post_before_failure=True)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github),
+        omx_runner=cast(AgentRunner, omx_runner),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=47,
+            actor_login="human",
+            payload={},
+            body="Need planning",
+            title="Need planning",
+        )
+    )
+    service.wait_for_idle()
+
+    source_job, recovery_job = service.storage.list_jobs()
+    expected_signature = build_signature(stage="issue_request", job=source_job.id, issue=47)
+    matching_comments = github.find_comments_by_signature(
+        "acme/demo", 47, kind="issue", signature_fragment=expected_signature
+    )
+    assert source_job.status == "completed"
+    assert recovery_job.status == "completed"
+    assert [record["job"].stage for record in omx_runner.resumes] == ["issue_request_recovery"]
+    assert [record["job"].stage for record in omx_runner.launches] == ["issue_request"]
+    assert len(matching_comments) == 1
+    assert recovery_job.metadata["comment_recovery_resume_error"] == "resume failed"
+    assert recovery_job.metadata["note"] == "side_effect_already_posted"
+
+
+def test_recovery_transient_exhaustion_fails_source_job_with_recovery_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    github = FakeGitHubCLI()
+    omx_runner = RecoveryTransientFailureRunner(github, recover=False)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github),
+        omx_runner=cast(AgentRunner, omx_runner),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+    monkeypatch.setattr("dani.service.RETRY_BACKOFF_SECONDS", [])
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=46,
+            actor_login="human",
+            payload={},
+            body="Need planning",
+            title="Need planning",
+        )
+    )
+    service.wait_for_idle()
+
+    source_job, recovery_job = service.storage.list_jobs()
+    assert recovery_job.status == "failed"
+    assert source_job.status == "failed"
+    assert source_job.metadata["original_error"] == "issue-request-comment-missing"
+    assert source_job.metadata["comment_recovery_job_id"] == recovery_job.id
+    assert source_job.metadata["comment_recovery_last_error"].startswith("retry_exhausted:")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2489,6 +2489,20 @@ def test_issue_followup_missing_signature_recovers_with_original_signature(tmp_p
     assert expected_signature in omx_runner.launches[-1]["prompt"]
 
 
+class ResumeExceptionAfterPostingRecoveryRunner(MissingIssueCommentRunner):
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str):
+        if job.stage in {"issue_request_recovery", "issue_followup_recovery"}:
+            self._post_recovery_signature(job)
+            self.resumes.append({
+                "repo_path": str(repo_path),
+                "job": job,
+                "prompt": prompt,
+                "omx_session_id": omx_session_id,
+            })
+            raise RuntimeError("resume raised after posting signature")  # noqa: TRY003
+        return super().resume(repo_path, job, prompt, omx_session_id)
+
+
 class ResumeWaitFailureRecoveryRunner(MissingIssueCommentRunner):
     def __init__(self, github: FakeGitHubCLI, *, post_before_failure: bool = False) -> None:
         super().__init__(github, recover=False, resumable=True)
@@ -2715,6 +2729,48 @@ def test_issue_request_recovery_falls_back_to_fresh_launch_when_resumed_process_
     assert [record["job"].stage for record in omx_runner.resumes] == ["issue_request_recovery"]
     assert [record["job"].stage for record in omx_runner.launches] == ["issue_request", "issue_request_recovery"]
     assert recovery_job.metadata["comment_recovery_resume_error"] == "resume failed"
+
+
+def test_issue_request_recovery_does_not_fresh_launch_when_resume_exception_posted_signature(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    github = FakeGitHubCLI()
+    omx_runner = ResumeExceptionAfterPostingRecoveryRunner(github)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github),
+        omx_runner=cast(AgentRunner, omx_runner),
+        dev_syncer=FakeGitDevSyncer(),
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=50,
+            actor_login="human",
+            payload={},
+            body="Need planning",
+            title="Need planning",
+        )
+    )
+    service.wait_for_idle()
+
+    source_job, recovery_job = service.storage.list_jobs()
+    expected_signature = build_signature(stage="issue_request", job=source_job.id, issue=50)
+    matching_comments = github.find_comments_by_signature(
+        "acme/demo", 50, kind="issue", signature_fragment=expected_signature
+    )
+    assert source_job.status == "completed"
+    assert recovery_job.status == "completed"
+    assert [record["job"].stage for record in omx_runner.resumes] == ["issue_request_recovery"]
+    assert [record["job"].stage for record in omx_runner.launches] == ["issue_request"]
+    assert len(matching_comments) == 1
+    assert recovery_job.metadata["comment_recovery_resume_error"] == "resume raised after posting signature"
+    assert recovery_job.metadata["note"] == "side_effect_already_posted"
 
 
 def test_issue_request_recovery_does_not_fresh_launch_when_failed_resume_posted_signature(tmp_path: Path) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2532,6 +2532,78 @@ class RecoveryTransientFailureRunner(MissingIssueCommentRunner):
         return session
 
 
+class CommentRecoveryRuntimeRunner(FakeRuntimeRunner):
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
+        if job.stage in {"issue_request_recovery", "issue_followup_recovery"}:
+            expected_signature = str(job.metadata["expected_signature"])
+            self.github.add_issue_signature(job.repo_full_name, int(job.issue_number or 0), expected_signature)
+        return super().resume(repo_path, job, prompt, omx_session_id)
+
+
+def test_issue_request_recovery_resumes_source_effective_omx_session_when_preferred_runtime_is_omo(
+    tmp_path: Path,
+) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET, agent_runtime=RUNTIME_OMO)
+    storage = JsonStorage(config)
+    github = FakeGitHubCLI()
+    omo_runner = CommentRecoveryRuntimeRunner(github, runtime_name=RUNTIME_OMO)
+    omx_runner = CommentRecoveryRuntimeRunner(github, runtime_name=RUNTIME_OMX)
+    service = DaniService(
+        config,
+        storage=storage,
+        github=cast(GitHubCLI, github),
+        omx_runner=cast(AgentRunner, omo_runner),
+        dev_syncer=FakeGitDevSyncer(),
+        runtime_runners={RUNTIME_OMX: cast(AgentRunner, omx_runner)},
+    )
+    service.register_repo("acme/demo", str(tmp_path))
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    source_job = JobRecord(
+        repo_full_name="acme/demo",
+        stage="issue_request",
+        issue_number=48,
+        status="failed",
+        metadata={
+            "title": "Need planning",
+            "body": "Need planning",
+            "preferred_runtime": RUNTIME_OMO,
+            "effective_runtime": RUNTIME_OMX,
+        },
+    )
+    service.storage.create_job(source_job)
+    service.storage.create_session(
+        SessionRecord(
+            repo_full_name="acme/demo",
+            stage="issue_request",
+            runtime_handle=f"omx-runtime-{source_job.id}",
+            prompt_path=str(tmp_path / "prompt.txt"),
+            script_path=str(tmp_path / "run.sh"),
+            worktree_path=str(tmp_path),
+            job_id=source_job.id,
+            issue_number=48,
+            omx_session_id="omx-original",
+            preferred_runtime=RUNTIME_OMO,
+            effective_runtime=RUNTIME_OMX,
+            native_session_runtime=RUNTIME_OMX,
+        )
+    )
+    service.queue_manager.submit = lambda queued_job: None  # type: ignore[method-assign]
+
+    assert service._handle_job_failure(source_job, RuntimeError("issue-request-comment-missing"), 1, [])
+    recovery_job = next(job for job in service.storage.list_jobs() if job.stage == "issue_request_recovery")
+
+    service._run_comment_recovery_attempt(repo, recovery_job)
+
+    assert omo_runner.resumes == []
+    assert omo_runner.launches == []
+    assert [record["omx_session_id"] for record in omx_runner.resumes] == ["omx-original"]
+    assert omx_runner.launches == []
+    assert recovery_job.metadata["preferred_runtime"] == RUNTIME_OMO
+    assert recovery_job.metadata["source_effective_runtime"] == RUNTIME_OMX
+    assert recovery_job.metadata["effective_runtime"] == RUNTIME_OMX
+
+
 def test_issue_request_recovery_falls_back_to_fresh_launch_when_resumed_process_fails(tmp_path: Path) -> None:
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -87,3 +87,49 @@ def test_storage_round_trips_runtime_metadata_and_filters_by_effective_runtime(t
     assert latest_omx.fallback_reason == "claude_weekly_limit"
     assert latest_omx.bridge_source_runtime == "omo"
     assert latest_omx.bridge_source_session_id == "ses_omo123"
+
+
+def test_find_latest_session_can_filter_by_source_job_id(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    repo = RepoConfig(full_name="acme/demo", local_path=str(tmp_path))
+    storage.register_repo(repo)
+    first_job = storage.create_job(JobRecord(repo_full_name=repo.full_name, stage="issue_request", issue_number=40))
+    second_job = storage.create_job(JobRecord(repo_full_name=repo.full_name, stage="issue_request", issue_number=40))
+    storage.create_session(
+        SessionRecord(
+            repo_full_name=repo.full_name,
+            stage="issue_request",
+            runtime_handle="runtime-first",
+            prompt_path=str(tmp_path / "prompt-first.txt"),
+            script_path=str(tmp_path / "run-first.sh"),
+            worktree_path=str(tmp_path),
+            job_id=first_job.id,
+            issue_number=40,
+            omx_session_id="omx-first",
+        )
+    )
+    storage.create_session(
+        SessionRecord(
+            repo_full_name=repo.full_name,
+            stage="issue_request",
+            runtime_handle="runtime-second",
+            prompt_path=str(tmp_path / "prompt-second.txt"),
+            script_path=str(tmp_path / "run-second.sh"),
+            worktree_path=str(tmp_path),
+            job_id=second_job.id,
+            issue_number=40,
+            omx_session_id="omx-second",
+        )
+    )
+
+    source_session = storage.find_latest_session(
+        repo_full_name=repo.full_name,
+        stage="issue_request",
+        issue_number=40,
+        job_id=first_job.id,
+    )
+
+    assert source_session is not None
+    assert source_session.job_id == first_job.id
+    assert source_session.omx_session_id == "omx-first"


### PR DESCRIPTION
## Summary
- Add bounded recovery jobs for missing `issue_request` / `issue_followup` signature comments.
- Reuse the source job's exact Dani signature in recovery prompts.
- Resume the original OMX session when possible, fall back to a fresh recovery launch when needed, and avoid duplicate comments if a failed resume already posted the signature, including direct resume exceptions.
- Record recovery attempt/session/runtime/error metadata on source job failure.

## Verification
- `uv run pytest` — 220 passed, 2 skipped
- `uv run ruff check dani tests`
- `uv run ruff format --check dani tests`
- `uv run ty check`
- Architect verification: APPROVED

<!-- dani:stage=implementation;job=7171dd6100004cbf871a0e7b7297804d;issue=40 -->
