### PR TITLE
Merge dev into main

### DIFF
--- a/dani/models.py
+++ b/dani/models.py
@@ -119,7 +119,6 @@ class DaniConfig:
     host: str = "127.0.0.1"
     port: int = 8787
     review_rounds: int = 3
-    external_review_limit: int = 10
     agent_runtime: str = "omx"
     agent_timeout_seconds: float = DEFAULT_AGENT_TIMEOUT_SECONDS
 

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -209,28 +209,6 @@ gh pr comment $pr_number --repo $repo --body-file <final-verdict.md>
 After posting the PR comment, exit.
         """.strip()
     ),
-    "human_escalation": Template(
-        """
-You are escalating PR #$pr_number in $repo to a human maintainer.
-Review limit reached: $review_limit
-PR title: $pr_title
-PR body:
-$pr_body
-
-Recent review history:
-$discussion
-
-Leave exactly one GitHub PR comment that:
-- [ ] States automated review stopped after $review_limit review passes
-- [ ] Asks a human maintainer to take over triage / scope / merge judgment
-- [ ] Includes this exact signature: $signature
-
-Post it with gh:
-gh pr comment $pr_number --repo $repo --body-file <human-escalation.md>
-
-After posting the PR comment, exit.
-        """.strip()
-    ),
     "dev_sync_conflict": Template(
         """
 You are operating inside repository: $repo

--- a/dani/service.py
+++ b/dani/service.py
@@ -255,6 +255,8 @@ class DaniService:
             return {"status": "ignored", "reason": "untracked_pr"}
         latest_review_round = self._latest_review_round(event.repo_full_name, pr_number)
         pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
+        source_job = self.storage.get_job(signature.get("job", ""))
+        lineage_metadata = self._automation_lineage_metadata(source_job)
         if latest_review_round >= self.config.review_rounds:
             verdict_job = self._enqueue_job(
                 repo,
@@ -263,6 +265,7 @@ class DaniService:
                 pr_number=pr_number,
                 metadata={
                     **pr_metadata,
+                    **lineage_metadata,
                     "title": (pr_metadata.get("title") or event.title or ""),
                 },
             )
@@ -277,6 +280,7 @@ class DaniService:
             review_round=next_round,
             metadata={
                 **pr_metadata,
+                **lineage_metadata,
                 "title": (pr_metadata.get("title") or event.title or ""),
             },
         )
@@ -310,6 +314,32 @@ class DaniService:
         )
         return {"status": "queued", "job_id": verdict_job.id, "stage": verdict_job.stage}
 
+    def _automation_lineage_metadata(self, source_job: JobRecord | None) -> dict[str, Any]:
+        if source_job is None:
+            return {}
+        keys = ("external_contribution", "pr_author_login", "pr_author_association")
+        return {key: source_job.metadata[key] for key in keys if key in source_job.metadata}
+
+    def _external_pr_metadata(self, event: NormalizedEvent) -> dict[str, Any]:
+        pull_request = event.payload.get("pull_request") or {}
+        user = pull_request.get("user") or {}
+        metadata: dict[str, Any] = {"external_contribution": True}
+        if isinstance(user, dict) and user.get("login"):
+            metadata["pr_author_login"] = str(user["login"])
+        author_association = pull_request.get("author_association")
+        if author_association:
+            metadata["pr_author_association"] = str(author_association)
+        return metadata
+
+    def _pull_request_author_is_repo_owner(self, repo_full_name: str, pull_request: dict[str, Any]) -> bool:
+        repo_owner = repo_full_name.split("/", 1)[0].lower()
+        author_association = str(pull_request.get("author_association") or "").upper()
+        if author_association == "OWNER":
+            return True
+        user = pull_request.get("user") or {}
+        login = str(user.get("login") or "").lower() if isinstance(user, dict) else ""
+        return bool(login) and login == repo_owner
+
     def _handle_final_verdict_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         pr_number = int(signature["pr"])
         event_key = self._agent_event_key(signature, default_pr=pr_number)
@@ -317,13 +347,16 @@ class DaniService:
             return {"status": "ignored", "reason": "duplicate_agent_event"}
         if not self._is_pr_open(event.repo_full_name, pr_number):
             return {"status": "ignored", "reason": "pr_not_open"}
+        pull_request = self.github.get_pull_request(event.repo_full_name, pr_number)
+        if not self._pull_request_author_is_repo_owner(event.repo_full_name, pull_request):
+            self.storage.record_processed_event(event_key)
+            return {"status": "approved", "reason": "human_merge_required", "pr_number": pr_number}
         try:
             self.github.merge_pull_request(event.repo_full_name, pr_number)
         except MergeConflictError as exc:
             repo = self.storage.get_repo(event.repo_full_name)
             if repo is None:
                 return {"status": "ignored", "reason": "missing_repo"}
-            pull_request = self.github.get_pull_request(event.repo_full_name, pr_number)
             issue_number = self._issue_number_for_signature_event(event.repo_full_name, signature, pr_number=pr_number)
             if issue_number is None:
                 issue_number = self._extract_issue_number(pull_request.get("body"))
@@ -361,16 +394,7 @@ class DaniService:
         if not self._is_pr_open(event.repo_full_name, pr_number):
             return {"status": "ignored", "reason": "pr_not_open"}
         pr_metadata = self._pull_request_metadata(event.repo_full_name, pr_number)
-        if bool(source_job and source_job.metadata.get("external_contribution")):
-            return self._handle_external_review_round_event(
-                repo,
-                event,
-                source_job=source_job,
-                pr_metadata=pr_metadata,
-                issue_number=issue_number,
-                pr_number=pr_number,
-                review_round=review_round,
-            )
+        lineage_metadata = self._automation_lineage_metadata(source_job)
         if issue_number is None:
             return {"status": "ignored", "reason": "untracked_pr"}
         if not self._is_pr_open(event.repo_full_name, pr_number):
@@ -383,57 +407,13 @@ class DaniService:
             review_round=review_round,
             metadata={
                 **pr_metadata,
+                **lineage_metadata,
                 "title": (pr_metadata.get("title") or event.title or ""),
                 "review_comment_body": event.body or "",
                 "triggering_review_round": review_round,
             },
         )
         return {"status": "queued", "job_id": next_job.id, "stage": next_job.stage}
-
-    def _handle_external_review_round_event(
-        self,
-        repo: RepoConfig,
-        event: NormalizedEvent,
-        *,
-        source_job: JobRecord,
-        pr_metadata: dict[str, str],
-        issue_number: int | None,
-        pr_number: int,
-        review_round: int,
-    ) -> dict[str, Any]:
-        if self._is_approve_comment(event.body):
-            verdict_job = self._enqueue_job(
-                repo,
-                stage="final_verdict",
-                issue_number=issue_number,
-                pr_number=pr_number,
-                review_round=review_round,
-                metadata={
-                    **pr_metadata,
-                    "title": (pr_metadata.get("title") or event.title or ""),
-                    "external_contribution": True,
-                },
-            )
-            return {"status": "queued", "job_id": verdict_job.id, "stage": verdict_job.stage}
-
-        completed_reviews = self._completed_external_review_count(event.repo_full_name, pr_number)
-        if source_job.status != "completed":
-            completed_reviews += 1
-        if completed_reviews >= self.config.external_review_limit and not self._has_human_escalation(
-            event.repo_full_name, pr_number
-        ):
-            escalation_job = self._enqueue_external_human_escalation(
-                repo,
-                issue_number=issue_number,
-                pr_number=pr_number,
-                metadata={
-                    **pr_metadata,
-                    "title": (pr_metadata.get("title") or event.title or ""),
-                    "external_contribution": True,
-                },
-            )
-            return {"status": "queued", "job_id": escalation_job.id, "stage": escalation_job.stage}
-        return {"status": "updated", "stage": "review_round"}
 
     def _enqueue_job(
         self,
@@ -1323,18 +1303,6 @@ class DaniService:
             )
             return self._apply_bridge_context(prompt, bridge_prompt)
 
-        if job.stage == "human_escalation":
-            prompt = self._build_human_escalation_prompt(
-                repo,
-                job,
-                issue_number,
-                pr_number,
-                pr_title,
-                pr_body,
-                resolved_runtime,
-            )
-            return self._apply_bridge_context(prompt, bridge_prompt)
-
         if job.stage == "merge_conflict_resolution":
             prompt = self._build_merge_conflict_resolution_prompt(
                 repo,
@@ -1375,9 +1343,6 @@ class DaniService:
             return
         if job.stage == "review_round":
             self._verify_review_round_side_effect(repo, job)
-            return
-        if job.stage == "human_escalation":
-            self._verify_human_escalation_side_effect(repo, job)
             return
         if job.stage == "merge_conflict_resolution":
             self._verify_merge_conflict_resolution_side_effect(repo, job)
@@ -1559,7 +1524,6 @@ class DaniService:
         pr_discussion = self._render_pr_discussion(repo.full_name, pr_number)
         if pr_discussion:
             discussion_parts.append(pr_discussion)
-        is_external_review = bool(job.metadata.get("external_contribution"))
         return render_prompt(
             "review_round",
             {
@@ -1569,13 +1533,8 @@ class DaniService:
                 "pr_body": pr_body,
                 "discussion": "\n\n".join(discussion_parts),
                 "round_number": job.review_round or 1,
-                "round_total": self.config.external_review_limit if is_external_review else self.config.review_rounds,
-                "review_mode_note": (
-                    "This is an external contribution PR. The contributor owns any follow-up implementation. "
-                    "If the PR is ready to merge, include /approve in your review comment so dani can run the final verdict pass."
-                    if is_external_review
-                    else ""
-                ),
+                "round_total": self.config.review_rounds,
+                "review_mode_note": "",
                 "signature": build_signature(**signature_fields),
             },
             runtime=runtime,
@@ -1631,45 +1590,11 @@ class DaniService:
                 "pr_title": pr_title,
                 "pr_body": pr_body,
                 "discussion": "\n\n".join(discussion_parts),
-                "review_cycle": (
-                    f"Review pass: {job.review_round} / {self.config.external_review_limit}"
-                    if job.review_round and job.metadata.get("external_contribution")
-                    else ""
-                ),
+                "review_cycle": "",
                 "approve_signature": build_signature(
                     stage="final_verdict", job=job.id, pr=pr_number, verdict="APPROVE"
                 ),
                 "reject_signature": build_signature(stage="final_verdict", job=job.id, pr=pr_number, verdict="REJECT"),
-            },
-            runtime=runtime,
-        )
-
-    def _build_human_escalation_prompt(
-        self,
-        repo: RepoConfig,
-        job: JobRecord,
-        issue_number: int,
-        pr_number: int,
-        pr_title: str,
-        pr_body: str,
-        runtime: str,
-    ) -> str:
-        discussion_parts = []
-        if issue_number:
-            discussion_parts.append(f"Related issue: #{issue_number}")
-        pr_discussion = self._render_pr_discussion(repo.full_name, pr_number)
-        if pr_discussion:
-            discussion_parts.append(pr_discussion)
-        return render_prompt(
-            "human_escalation",
-            {
-                "repo": repo.full_name,
-                "pr_number": pr_number,
-                "pr_title": pr_title,
-                "pr_body": pr_body,
-                "discussion": "\n\n".join(discussion_parts),
-                "review_limit": self.config.external_review_limit,
-                "signature": build_signature(stage="human_escalation", job=job.id, pr=pr_number),
             },
             runtime=runtime,
         )
@@ -1745,11 +1670,6 @@ class DaniService:
             or self._has_exact_pr_signature(repo.full_name, int(job.pr_number or 0), reject_signature)
         ):
             raise RuntimeError("final-verdict-comment-missing")
-
-    def _verify_human_escalation_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
-        signature = build_signature(stage="human_escalation", job=job.id, pr=int(job.pr_number or 0))
-        if not self._has_exact_pr_signature(repo.full_name, int(job.pr_number or 0), signature):
-            raise RuntimeError("human-escalation-comment-missing")
 
     def _has_exact_pr_signature(self, repo_full_name: str, pr_number: int, signature: str) -> bool:
         return bool(
@@ -1970,22 +1890,10 @@ class DaniService:
         if not self.storage.record_processed_event(event_key):
             return {"status": "ignored", "reason": "duplicate_external_pr_event"}
 
-        if self._has_human_escalation(event.repo_full_name, event.number):
-            return {"status": "ignored", "reason": "human_review_required"}
-
-        completed_reviews = self._completed_external_review_count(event.repo_full_name, event.number)
         consumed_review_rounds = self._consumed_external_review_rounds(event.repo_full_name, event.number)
-        if completed_reviews >= self.config.external_review_limit:
-            escalation_job = self._enqueue_external_human_escalation(
-                repo,
-                issue_number=issue_number,
-                pr_number=event.number,
-                metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
-            )
-            return {"status": "queued", "job_id": escalation_job.id, "stage": escalation_job.stage}
 
-        if len(consumed_review_rounds) >= self.config.external_review_limit:
-            return {"status": "ignored", "reason": "external_review_limit_pending"}
+        if len(consumed_review_rounds) >= self.config.review_rounds:
+            return {"status": "ignored", "reason": "external_review_rounds_exhausted"}
 
         next_review_round = max(consumed_review_rounds, default=0) + 1
         job = self._enqueue_job(
@@ -1994,7 +1902,11 @@ class DaniService:
             issue_number=issue_number,
             pr_number=event.number,
             review_round=next_review_round,
-            metadata={"title": event.title or "", "body": event.body or "", "external_contribution": True},
+            metadata={
+                "title": event.title or "",
+                "body": event.body or "",
+                **self._external_pr_metadata(event),
+            },
         )
         return {"status": "queued", "job_id": job.id, "stage": job.stage}
 
@@ -2055,22 +1967,6 @@ class DaniService:
         self.github.close_pull_request(event.repo_full_name, event.number)
         return {"status": "closed", "reason": "contributor_account_too_new", "pr_number": event.number}
 
-    def _enqueue_external_human_escalation(
-        self,
-        repo: RepoConfig,
-        *,
-        issue_number: int | None,
-        pr_number: int,
-        metadata: dict[str, Any],
-    ) -> JobRecord:
-        return self._enqueue_job(
-            repo,
-            stage="human_escalation",
-            issue_number=issue_number,
-            pr_number=pr_number,
-            metadata=metadata,
-        )
-
     def _agent_event_key(self, signature: dict[str, str], *, default_pr: int | None = None) -> str:
         fields = [("stage", signature.get("stage", ""))]
         for key in ("pr", "round", "job", "verdict"):
@@ -2115,13 +2011,6 @@ class DaniService:
         ]
         return max(rounds, default=0)
 
-    def _completed_external_review_count(self, repo_full_name: str, pr_number: int) -> int:
-        return sum(
-            1
-            for job in self.storage.find_jobs(repo_full_name=repo_full_name, stage="review_round", pr_number=pr_number)
-            if job.metadata.get("external_contribution") and job.status == "completed"
-        )
-
     def _consumed_external_review_rounds(self, repo_full_name: str, pr_number: int) -> set[int]:
         return {
             int(job.review_round)
@@ -2132,11 +2021,6 @@ class DaniService:
                 and job.status in {"queued", "launched", "completed"}
             )
         }
-
-    def _has_human_escalation(self, repo_full_name: str, pr_number: int) -> bool:
-        return bool(
-            self.storage.find_jobs(repo_full_name=repo_full_name, stage="human_escalation", pr_number=pr_number)
-        )
 
     def _issue_number_for_signature_event(
         self,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -197,9 +197,7 @@ class FakeOmxRunner:
             omx_session_id=f"omx-{job.id}",
         )
 
-    def _post_side_effect(  # noqa: C901
-        self, repo_full_name: str, job: JobRecord, signature: dict[str, str] | None
-    ) -> None:
+    def _post_side_effect(self, repo_full_name: str, job: JobRecord, signature: dict[str, str] | None) -> None:
         if job.stage == "issue_request":
             issue_number = int((signature or {}).get("issue", job.issue_number or 0))
             self.github.add_issue_signature(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -54,6 +54,8 @@ class FakeGitHubCLI:
             "state": "open",
             "head": {"ref": f"Feature/#{pr_number}"},
             "base": {"ref": "dev"},
+            "user": {"login": repo_full_name.split("/", 1)[0]},
+            "author_association": "OWNER",
         }
 
     def get_user(self, login: str) -> dict[str, Any]:
@@ -120,6 +122,8 @@ class FakeGitHubCLI:
         title: str | None = None,
         head_branch: str | None = None,
         base_branch: str = "dev",
+        user_login: str | None = None,
+        author_association: str = "OWNER",
     ) -> None:
         self.prs.setdefault(repo_full_name, []).append({
             "number": pr_number,
@@ -128,6 +132,8 @@ class FakeGitHubCLI:
             "state": "open",
             "head": {"ref": head_branch or f"Feature/#{pr_number}"},
             "base": {"ref": base_branch},
+            "user": {"login": user_login or repo_full_name.split("/", 1)[0]},
+            "author_association": author_association,
         })
 
     def close_pull_request(self, repo_full_name: str, pr_number: int) -> None:
@@ -229,13 +235,6 @@ class FakeOmxRunner:
                 repo_full_name,
                 pr_number,
                 build_signature(stage="merge_conflict_resolution", job=job.id, pr=pr_number),
-            )
-        elif job.stage == "human_escalation":
-            pr_number = int((signature or {}).get("pr", job.pr_number or 0))
-            self.github.add_pr_signature(
-                repo_full_name,
-                pr_number,
-                build_signature(stage="human_escalation", job=job.id, pr=pr_number),
             )
         elif job.stage != "dev_sync":
             self.github.add_pr_signature(

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -464,23 +464,3 @@ def test_merge_conflict_resolution_prompt_requires_recheck_without_direct_merge(
     assert "Do not merge the PR yourself" in prompt
     assert "stage=merge_conflict_resolution" in prompt
     assert "gh pr comment 5 --repo acme/demo --body-file <merge-conflict-comment.md>" in prompt
-
-
-def test_human_escalation_prompt_mentions_review_limit_and_signature() -> None:
-    prompt = render_prompt(
-        "human_escalation",
-        {
-            "repo": "acme/demo",
-            "pr_number": 5,
-            "pr_title": "Feature",
-            "pr_body": "Body",
-            "discussion": "history",
-            "review_limit": 10,
-            "signature": "<!-- dani:stage=human_escalation;job=abc;pr=5 -->",
-        },
-    )
-
-    assert "10" in prompt
-    assert "human maintainer" in prompt.lower()
-    assert "gh pr comment 5 --repo acme/demo --body-file <human-escalation.md>" in prompt
-    assert "stage=human_escalation" in prompt

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -952,7 +952,7 @@ def test_duplicate_external_pr_activity_event_is_ignored(tmp_path: Path) -> None
 
 def test_duplicate_external_pr_activity_does_not_consume_review_limit(tmp_path: Path) -> None:
     service, _, _ = make_service(tmp_path)
-    for round_number in range(1, 10):
+    for round_number in range(1, 3):
         service.storage.create_job(
             JobRecord(
                 repo_full_name="acme/demo",
@@ -965,18 +965,18 @@ def test_duplicate_external_pr_activity_does_not_consume_review_limit(tmp_path: 
         )
 
     first = service.handle_event(
-        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-10")
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-3")
     )
     service.wait_for_idle()
     duplicate = service.handle_event(
-        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-10")
+        make_pr_event(pr_number=88, action="synchronize", body="Implements #21", commit_sha="sha-3")
     )
     service.wait_for_idle()
 
     assert first["stage"] == "review_round"
     assert duplicate == {"status": "ignored", "reason": "duplicate_external_pr_event"}
     review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
-    assert [job.review_round for job in review_jobs if job.metadata.get("external_contribution")] == list(range(1, 11))
+    assert [job.review_round for job in review_jobs if job.metadata.get("external_contribution")] == [1, 2, 3]
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
 
 
@@ -1090,7 +1090,7 @@ def test_external_pr_from_account_at_least_one_year_old_queues_review_round(tmp_
     assert omx_runner.launches[-1]["job"].stage == "review_round"
 
 
-def test_external_review_comment_does_not_queue_implementation(tmp_path: Path) -> None:
+def test_external_review_comment_queues_implementation_like_internal_pr(tmp_path: Path) -> None:
     service, github, omx_runner = make_service(tmp_path)
     service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
     service.wait_for_idle()
@@ -1104,13 +1104,15 @@ def test_external_review_comment_does_not_queue_implementation(tmp_path: Path) -
     )
     service.wait_for_idle()
 
-    assert result == {"status": "updated", "stage": "review_round"}
-    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
-    assert len(omx_runner.launches) == 1
+    assert result["stage"] == "implementation"
+    implementation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88)
+    assert len(implementation_jobs) == 1
+    assert implementation_jobs[0].metadata["external_contribution"] is True
+    assert omx_runner.launches[-1]["job"].stage == "implementation"
     assert github.merged == []
 
 
-def test_external_review_approve_comment_queues_final_verdict(tmp_path: Path) -> None:
+def test_external_review_approve_comment_still_follows_internal_implementation_path(tmp_path: Path) -> None:
     service, github, omx_runner = make_service(tmp_path)
     service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
     service.wait_for_idle()
@@ -1124,15 +1126,22 @@ def test_external_review_approve_comment_queues_final_verdict(tmp_path: Path) ->
     )
     service.wait_for_idle()
 
-    assert result["stage"] == "final_verdict"
-    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
-    assert len(service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=88)) == 1
-    assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+    assert result["stage"] == "implementation"
+    assert len(service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88)) == 1
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=88) == []
+    assert omx_runner.launches[-1]["job"].stage == "implementation"
     assert github.merged == []
 
 
-def test_external_final_verdict_approve_merges_without_implementation_job(tmp_path: Path) -> None:
+def test_external_final_verdict_approve_requires_human_merge_for_non_owner_pr(tmp_path: Path) -> None:
     service, github, omx_runner = make_service(tmp_path)
+    github.add_pull_request(
+        "acme/demo",
+        88,
+        "Implements #21",
+        user_login="contributor",
+        author_association="CONTRIBUTOR",
+    )
 
     result = service.handle_event(
         make_pr_comment_event(
@@ -1142,20 +1151,21 @@ def test_external_final_verdict_approve_merges_without_implementation_job(tmp_pa
     )
     service.wait_for_idle()
 
-    assert result == {"status": "merged", "pr_number": 88}
+    assert result == {"status": "approved", "reason": "human_merge_required", "pr_number": 88}
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
     assert omx_runner.launches == []
-    assert github.merged == [("acme/demo", 88)]
+    assert github.merged == []
 
 
-def test_external_pr_escalates_after_ten_review_passes(tmp_path: Path) -> None:
+def test_external_pr_activity_stops_at_standard_review_round_limit(tmp_path: Path) -> None:
     service, _, omx_runner = make_service(tmp_path)
-    for _ in range(10):
+    for round_number in range(1, 4):
         service.storage.create_job(
             JobRecord(
                 repo_full_name="acme/demo",
                 stage="review_round",
                 pr_number=88,
+                review_round=round_number,
                 metadata={"external_contribution": True},
                 status="completed",
             )
@@ -1164,23 +1174,18 @@ def test_external_pr_escalates_after_ten_review_passes(tmp_path: Path) -> None:
     result = service.handle_event(make_pr_event(pr_number=88, action="synchronize", body="Implements #21"))
     service.wait_for_idle()
 
-    assert result["stage"] == "human_escalation"
-    escalation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)
-    assert len(escalation_jobs) == 1
-    assert omx_runner.launches[-1]["job"].stage == "human_escalation"
+    assert result == {"status": "ignored", "reason": "external_review_rounds_exhausted"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
+    assert omx_runner.launches == []
 
 
-def test_external_review_comment_queues_human_escalation_on_tenth_completed_pass(tmp_path: Path) -> None:
+def test_external_review_chain_reaches_final_verdict_like_internal_pr(tmp_path: Path) -> None:
     service, _, omx_runner = make_service(tmp_path)
 
-    for round_number in range(1, 11):
-        action = "opened" if round_number == 1 else "synchronize"
-        result = service.handle_event(
-            make_pr_event(pr_number=88, action=action, body="Implements #21", commit_sha=f"sha-{round_number}")
-        )
-        service.wait_for_idle()
+    service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21", commit_sha="sha-1"))
+    service.wait_for_idle()
 
-        assert result["stage"] == "review_round"
+    for round_number in (1, 2, 3):
         review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
         comment_result = service.handle_event(
             make_pr_comment_event(
@@ -1189,38 +1194,31 @@ def test_external_review_comment_queues_human_escalation_on_tenth_completed_pass
             )
         )
         service.wait_for_idle()
+        assert comment_result["stage"] == "implementation"
 
-        if round_number < 10:
-            assert comment_result == {"status": "updated", "stage": "review_round"}
-            assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
-            continue
-
-        assert comment_result["stage"] == "human_escalation"
+        implementation_job = service.storage.find_jobs(
+            repo_full_name="acme/demo", stage="implementation", pr_number=88
+        )[-1]
+        implementation_result = service.handle_event(
+            make_pr_comment_event(
+                pr_number=88,
+                body=build_signature(stage="implementation", job=implementation_job.id, pr=88, issue=21),
+            )
+        )
+        service.wait_for_idle()
+        assert implementation_result["stage"] == ("final_verdict" if round_number == 3 else "review_round")
 
     review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
-    assert [job.review_round for job in review_jobs] == list(range(1, 11))
-    assert all(job.status == "completed" for job in review_jobs)
-
-    escalation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)
-    assert len(escalation_jobs) == 1
-    assert omx_runner.launches[-1]["job"].stage == "human_escalation"
-
-    post_limit = service.handle_event(
-        make_pr_event(
-            pr_number=88,
-            action="synchronize",
-            body="Implements #21",
-            commit_sha="sha-11",
-        )
-    )
-    service.wait_for_idle()
-
-    assert post_limit == {"status": "ignored", "reason": "human_review_required"}
-    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88) == review_jobs
-    assert len(service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88)) == 1
+    implementation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88)
+    verdict_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=88)
+    assert [job.review_round for job in review_jobs] == [1, 2, 3]
+    assert len(implementation_jobs) == 3
+    assert len(verdict_jobs) == 1
+    assert verdict_jobs[0].metadata["external_contribution"] is True
+    assert omx_runner.launches[-1]["job"].stage == "final_verdict"
 
 
-def test_external_pr_unique_activity_never_queues_an_eleventh_automated_review(tmp_path: Path) -> None:
+def test_external_pr_unique_activity_never_queues_beyond_standard_review_limit(tmp_path: Path) -> None:
     class BlockingOmxRunner(FakeOmxRunner):
         def __init__(self, github: FakeGitHubCLI) -> None:
             super().__init__(github)
@@ -1262,7 +1260,7 @@ def test_external_pr_unique_activity_never_queues_an_eleventh_automated_review(t
     assert omx_runner.review_started.wait(timeout=1)
 
     results = []
-    for round_number in range(2, 12):
+    for round_number in range(2, 6):
         results.append(
             service.handle_event(
                 make_pr_event(
@@ -1274,18 +1272,21 @@ def test_external_pr_unique_activity_never_queues_an_eleventh_automated_review(t
             )
         )
 
-    assert all(result["stage"] == "review_round" for result in results[:9])
-    assert results[9] == {"status": "ignored", "reason": "external_review_limit_pending"}
+    assert all(result["stage"] == "review_round" for result in results[:2])
+    assert results[2:] == [
+        {"status": "ignored", "reason": "external_review_rounds_exhausted"},
+        {"status": "ignored", "reason": "external_review_rounds_exhausted"},
+    ]
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
 
     omx_runner.release_review.set()
     service.wait_for_idle()
 
     review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
-    assert [job.review_round for job in review_jobs] == list(range(1, 11))
+    assert [job.review_round for job in review_jobs] == [1, 2, 3]
     assert all(job.status == "completed" for job in review_jobs)
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88) == review_jobs
-    assert [job.review_round for job in review_jobs] == list(range(1, 11))
+    assert [job.review_round for job in review_jobs] == [1, 2, 3]
 
 
 def test_review_chain_reaches_verdict_and_merges_on_approve(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Promotes the dead-code cleanup commit on `dev` to `main`.

`dev` is one commit ahead of `main` (`f3919ff`). The cleanup removes the now-unreachable `human_escalation` stage and the obsolete `external_review_limit` config, which became dead code after external PR handling was unified onto the standard 3-round review policy with an owner-only auto-merge gate at final verdict.

## What changes on main

- Removes `human_escalation` prompt template, dispatcher branch, builder, and verifier
- Removes `_enqueue_external_human_escalation`, `_completed_external_review_count`, `_has_human_escalation`
- Removes `external_review_limit` config field (forward-compatible config parsing preserved)
- Drops the obsolete prompt test for `human_escalation`
- Keeps the 3 policy-guard assertions in `tests/test_service.py` that prove `human_escalation` jobs are never auto-queued

Net: 6 files, +115 / −274 (~159 lines removed).

## Verification

- `uv run pytest`: 221 passed, 2 skipped
- pyright: no new diagnostics introduced (only pre-existing `str | None` warnings around prompt builders remain)
- Working tree clean, fast-forward merge available