### PR TITLE
Forbid the `question` tool in every dani prompt

### DIFF
--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -5,6 +5,23 @@ from typing import Any
 
 from dani.signatures import build_signature
 
+# Non-interactive automation guard.
+#
+# dani drives agents in a non-interactive webhook-triggered loop. There is no
+# human attached to the session: any tool that waits for human input (notably
+# opencode's `question` tool) will block the session forever, eventually
+# tripping `agent_timeout_seconds` and failing the job. omx (codex) does not
+# expose `question` today, but the guard is run-time-agnostic so future omx
+# tool surface changes can't reintroduce the same stall.
+NON_INTERACTIVE_GUARD = (
+    "NON-INTERACTIVE AUTOMATION CONTRACT (read first):\n"
+    "- You are running inside dani's non-interactive automation loop. There is NO human attached to this session.\n"
+    "- DO NOT call the `question` tool, DO NOT ask the user for clarification, DO NOT request approval mid-task. Any tool that waits for a human reply will hang the session until it is force-killed by timeout, and the job will be marked failed.\n"
+    "- If scope or intent is ambiguous, pick the most conservative reasonable interpretation, state your assumption explicitly in the comment/PR you post, and proceed. Do not stop to ask.\n"
+    "- If a blocker is genuinely unresolvable (missing credential, destructive action you must not take, etc.), document it inline in the comment/PR body you post and exit normally. Do not call `question` to surface it.\n"
+)
+
+
 TEMPLATES = {
     "issue_request": Template(
         """
@@ -265,4 +282,4 @@ def render_prompt(template_name: str, context: dict[str, Any], *, runtime: str =
     if substitutions:
         for needle, replacement in substitutions:
             rendered = rendered.replace(needle, replacement)
-    return rendered
+    return f"{NON_INTERACTIVE_GUARD}\n{rendered}"

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dani.prompts import render_prompt
 
 
@@ -464,3 +466,100 @@ def test_merge_conflict_resolution_prompt_requires_recheck_without_direct_merge(
     assert "Do not merge the PR yourself" in prompt
     assert "stage=merge_conflict_resolution" in prompt
     assert "gh pr comment 5 --repo acme/demo --body-file <merge-conflict-comment.md>" in prompt
+
+
+def _final_verdict_context() -> dict[str, object]:
+    return {
+        "repo": "acme/demo",
+        "pr_number": 5,
+        "pr_title": "Feature",
+        "pr_body": "Body",
+        "discussion": "history",
+        "approve_signature": "<!-- dani:stage=final_verdict;job=abc;pr=5;verdict=APPROVE -->",
+        "reject_signature": "<!-- dani:stage=final_verdict;job=abc;pr=5;verdict=REJECT -->",
+    }
+
+
+def _review_round_context() -> dict[str, object]:
+    return {
+        "repo": "acme/demo",
+        "pr_number": 5,
+        "pr_title": "Feature",
+        "pr_body": "Body",
+        "discussion": "history",
+        "round_number": 2,
+        "signature": "<!-- dani:stage=review_round;job=abc;pr=5;round=2 -->",
+    }
+
+
+def _implementation_context() -> dict[str, object]:
+    return {
+        "repo": "acme/demo",
+        "local_path": "workspace/demo",
+        "issue_number": 7,
+        "issue_title": "Need a bot",
+        "issue_body": "Implement it",
+        "discussion": "approved",
+        "pr_context": "",
+        "pr_number": "",
+        "dev_branch": "dev",
+        "signature": "<!-- dani:stage=implementation;job=abc;issue=7 -->",
+        "signature_instructions": "Use this signature in the PR body:\n<!-- dani:stage=implementation;job=abc;issue=7 -->",
+    }
+
+
+def _merge_conflict_resolution_context() -> dict[str, object]:
+    return {
+        "repo": "acme/demo",
+        "local_path": "workspace/demo",
+        "issue_number": 7,
+        "pr_number": 5,
+        "pr_title": "Feature",
+        "pr_body": "Body",
+        "head_branch": "Feature/#7",
+        "base_branch": "dev",
+        "conflict_reason": "merge conflict with base branch",
+        "signature": "<!-- dani:stage=merge_conflict_resolution;job=abc;pr=5 -->",
+    }
+
+
+def _dev_sync_conflict_context() -> dict[str, object]:
+    return {
+        "repo": "acme/demo",
+        "local_path": "workspace/demo",
+        "main_branch": "main",
+        "main_sha": "abc123",
+        "dev_branch": "dev",
+        "temp_branch": "dani/dev-sync/abc123",
+        "commit_message": "Merge main into dev",
+    }
+
+
+_NON_INTERACTIVE_TEMPLATES: tuple[tuple[str, dict[str, object]], ...] = (
+    ("issue_request", _issue_request_context()),
+    ("issue_followup", _issue_followup_context()),
+    ("implementation", _implementation_context()),
+    ("review_round", _review_round_context()),
+    ("merge_conflict_resolution", _merge_conflict_resolution_context()),
+    ("final_verdict", _final_verdict_context()),
+    ("dev_sync_conflict", _dev_sync_conflict_context()),
+)
+
+
+@pytest.mark.parametrize("template_name,context", _NON_INTERACTIVE_TEMPLATES)
+@pytest.mark.parametrize("runtime", ["omx", "omo"])
+def test_every_template_prepends_non_interactive_guard(
+    template_name: str,
+    context: dict[str, object],
+    runtime: str,
+) -> None:
+    prompt = render_prompt(template_name, context, runtime=runtime)
+
+    assert prompt.startswith("NON-INTERACTIVE AUTOMATION CONTRACT"), (
+        f"{template_name}/{runtime}: guard must be the first thing the agent reads"
+    )
+    assert "DO NOT call the `question` tool" in prompt, (
+        f"{template_name}/{runtime}: must explicitly forbid the question tool by name"
+    )
+    assert "DO NOT ask the user for clarification" in prompt
+    assert "most conservative reasonable interpretation" in prompt


### PR DESCRIPTION
## Summary

- Prepend a **non-interactive automation contract** to every rendered prompt that explicitly forbids the opencode `question` tool by name and tells the agent to pick a conservative default + document the assumption inline instead of asking.
- Add parametric tests that assert the guard is present at the top of *every* template (`issue_request`, `issue_followup`, `implementation`, `review_round`, `merge_conflict_resolution`, `final_verdict`, `dev_sync_conflict`) under both `omx` and `omo` runtimes.

## Why

Agent sessions launched by dani run inside a webhook-driven loop. There is no human attached. When the **omo (opencode)** runtime exposes the `question` tool, the agent can call it mid-task and the session never reaches `idle` — dani's `agent_timeout_seconds` (default 3600s) eventually trips, the job is marked `failed`, and no follow-up stage is ever scheduled.

PR `NomaDamas/k-skill#183`'s implementation follow-up died this exact way:

```
job_id    : be48fe0025ae434899349a0e028d49bc
stage     : implementation
runtime   : omo
status    : failed
error     : opencode session did not reach idle/error before timeout: dani-implementation-74d8c28117
```

`runs/dani-implementation-74d8c28117/events.jsonl` shows the agent fired `tool=question` at `07:44:08` with 4 multiple-choice options, sat in `busy` state for an hour, and was killed with `MessageAbortedError "Aborted"` at `08:43:42`. dani never retried.

`omx` (codex) doesn't expose `question` today, so it has been accidentally safe — but a runtime-agnostic guard is cheap insurance and a future omx tool-surface change won't reintroduce the same stall.

## What changed

- **`dani/prompts.py`**:
  - Add module-level `NON_INTERACTIVE_GUARD` constant (the contract text).
  - `render_prompt()` now prepends it to every rendered prompt, *after* runtime substitutions, so omo/omx behavior is unchanged in every other respect.
- **`tests/test_prompts.py`**:
  - Add factory helpers for the templates that didn't have one (`_implementation_context`, `_merge_conflict_resolution_context`, `_dev_sync_conflict_context`, `_final_verdict_context`, `_review_round_context`).
  - Add `test_every_template_prepends_non_interactive_guard`, parametrized over **all 7 templates × {omx, omo}** (14 cases). Asserts:
    - prompt starts with `NON-INTERACTIVE AUTOMATION CONTRACT`
    - includes the literal phrase `` DO NOT call the `question` tool ``
    - includes `DO NOT ask the user for clarification`
    - includes the conservative-default fallback clause

## Verification

- `uv run pytest tests/test_prompts.py -x -q` → **40 passed** (was 26; +14 new parametric cases).
- `uv run pytest --ignore=tests/test_omo_live.py -x -q` → **235 passed**, no regressions.
- `uv run ruff check dani/prompts.py tests/test_prompts.py` → clean.
- `uv run ruff format --check dani/prompts.py tests/test_prompts.py` → already formatted.
- Manual render of `implementation` prompt under `runtime=omo`:
  - prompt now starts with the guard
  - `\$ralph` → `ultrawork` substitution still works
  - signature is preserved end-to-end
  - total length ~1.7 KB (≈600 byte guard prepended to the existing template)

## Out of scope (filed as separate follow-up)

- Auto-resolving `question.asked` events at the omo HTTP runner layer (e.g. auto-rejecting them so a misbehaving agent fails fast instead of timing out after an hour). Belt-and-braces; the prompt-level guard is the primary fix.
- Recovering the already-stuck PR #183 / #179 jobs (handled out-of-band by re-triggering them once dani is back on omx).