### PR TITLE
Feature/#183

### DIFF
--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -56,7 +56,7 @@ Checklist:
 - [ ] Why this issue may not be needed
 - [ ] Expected Outcome
 - [ ] Evidence-based implementation plan (phrased as instructions for the implementation agent)
-- [ ] Open questions for the human (if any) — they must answer in a follow-up comment before /approve
+- [ ] Assumptions / human decisions to resolve asynchronously before /approve (if any)
 - [ ] Reminder that implementation starts only after a human comment containing "/approve"
 - [ ] Agent Signature
 
@@ -97,7 +97,7 @@ Continue the existing issue discussion instead of restarting the analysis from s
 Write exactly one GitHub issue comment that addresses the new follow-up. The comment must:
 - Answer or clarify the user's follow-up directly.
 - Update the implementation plan if the follow-up changes scope/approach.
-- Note any remaining open questions the human must resolve before "/approve".
+- Note any assumptions / human decisions to resolve asynchronously before "/approve".
 - Remind the human that implementation starts only after a comment containing "/approve".
 - Include this exact signature on its own line:
 $signature
@@ -271,6 +271,13 @@ def ensure_non_interactive_guard(prompt: str) -> str:
     if prompt.startswith(NON_INTERACTIVE_GUARD):
         return prompt
     return f"{NON_INTERACTIVE_GUARD}\n{prompt}"
+
+
+def split_non_interactive_guard(prompt: str) -> str:
+    """Return the prompt body after the non-interactive guard, if present."""
+    if not prompt.startswith(NON_INTERACTIVE_GUARD):
+        return prompt
+    return prompt.removeprefix(NON_INTERACTIVE_GUARD).lstrip("\n")
 
 
 def render_prompt(template_name: str, context: dict[str, Any], *, runtime: str = "omx") -> str:

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -266,6 +266,13 @@ _RUNTIME_SUBSTITUTIONS: dict[str, tuple[tuple[str, str], ...]] = {
 }
 
 
+def ensure_non_interactive_guard(prompt: str) -> str:
+    """Return *prompt* with the non-interactive guard at the very top, once."""
+    if prompt.startswith(NON_INTERACTIVE_GUARD):
+        return prompt
+    return f"{NON_INTERACTIVE_GUARD}\n{prompt}"
+
+
 def render_prompt(template_name: str, context: dict[str, Any], *, runtime: str = "omx") -> str:
     template = TEMPLATES[template_name]
     context = dict(context)
@@ -282,4 +289,4 @@ def render_prompt(template_name: str, context: dict[str, Any], *, runtime: str =
     if substitutions:
         for needle, replacement in substitutions:
             rendered = rendered.replace(needle, replacement)
-    return f"{NON_INTERACTIVE_GUARD}\n{rendered}"
+    return ensure_non_interactive_guard(rendered)

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -5,6 +5,23 @@ from typing import Any
 
 from dani.signatures import build_signature
 
+# Non-interactive automation guard.
+#
+# dani drives agents in a non-interactive webhook-triggered loop. There is no
+# human attached to the session: any tool that waits for human input (notably
+# opencode's `question` tool) will block the session forever, eventually
+# tripping `agent_timeout_seconds` and failing the job. omx (codex) does not
+# expose `question` today, but the guard is run-time-agnostic so future omx
+# tool surface changes can't reintroduce the same stall.
+NON_INTERACTIVE_GUARD = (
+    "NON-INTERACTIVE AUTOMATION CONTRACT (read first):\n"
+    "- You are running inside dani's non-interactive automation loop. There is NO human attached to this session.\n"
+    "- DO NOT call the `question` tool, DO NOT ask the user for clarification, DO NOT request approval mid-task. Any tool that waits for a human reply will hang the session until it is force-killed by timeout, and the job will be marked failed.\n"
+    "- If scope or intent is ambiguous, pick the most conservative reasonable interpretation, state your assumption explicitly in the comment/PR you post, and proceed. Do not stop to ask.\n"
+    "- If a blocker is genuinely unresolvable (missing credential, destructive action you must not take, etc.), document it inline in the comment/PR body you post and exit normally. Do not call `question` to surface it.\n"
+)
+
+
 TEMPLATES = {
     "issue_request": Template(
         """
@@ -265,4 +282,4 @@ def render_prompt(template_name: str, context: dict[str, Any], *, runtime: str =
     if substitutions:
         for needle, replacement in substitutions:
             rendered = rendered.replace(needle, replacement)
-    return rendered
+    return f"{NON_INTERACTIVE_GUARD}\n{rendered}"

--- a/dani/service.py
+++ b/dani/service.py
@@ -29,7 +29,7 @@ from dani.models import (
     effective_session_runtime,
     utc_now,
 )
-from dani.prompts import NON_INTERACTIVE_GUARD, ensure_non_interactive_guard, render_prompt
+from dani.prompts import NON_INTERACTIVE_GUARD, ensure_non_interactive_guard, render_prompt, split_non_interactive_guard
 from dani.queue import RepoQueueManager
 from dani.session_bridge import BridgeContext, OmoSessionBridge
 from dani.signatures import build_signature, is_opt_out_comment, parse_signature
@@ -1327,7 +1327,7 @@ class DaniService:
             "Use the imported OMO context above only as bounded background context. "
             "This is not a native resume; continue from it conservatively."
         )
-        prompt_body = guarded_prompt[len(NON_INTERACTIVE_GUARD) :].lstrip("\n")
+        prompt_body = split_non_interactive_guard(guarded_prompt)
         return f"{NON_INTERACTIVE_GUARD}\n{bridge_block}\n\n{prompt_body}"
 
     def _verify_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:

--- a/dani/service.py
+++ b/dani/service.py
@@ -29,7 +29,7 @@ from dani.models import (
     effective_session_runtime,
     utc_now,
 )
-from dani.prompts import render_prompt
+from dani.prompts import NON_INTERACTIVE_GUARD, ensure_non_interactive_guard, render_prompt
 from dani.queue import RepoQueueManager
 from dani.session_bridge import BridgeContext, OmoSessionBridge
 from dani.signatures import build_signature, is_opt_out_comment, parse_signature
@@ -1319,14 +1319,16 @@ class DaniService:
         return self._apply_bridge_context(prompt, bridge_prompt)
 
     def _apply_bridge_context(self, prompt: str, bridge_prompt: str) -> str:
+        guarded_prompt = ensure_non_interactive_guard(prompt)
         if not bridge_prompt.strip():
-            return prompt
-        return (
+            return guarded_prompt
+        bridge_block = (
             f"{bridge_prompt}\n\n"
             "Use the imported OMO context above only as bounded background context. "
-            "This is not a native resume; continue from it conservatively.\n\n"
-            f"{prompt}"
+            "This is not a native resume; continue from it conservatively."
         )
+        prompt_body = guarded_prompt[len(NON_INTERACTIVE_GUARD) :].lstrip("\n")
+        return f"{NON_INTERACTIVE_GUARD}\n{bridge_block}\n\n{prompt_body}"
 
     def _verify_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
         if job.stage == "issue_request":
@@ -1475,7 +1477,7 @@ class DaniService:
         expected_signature = str(job.metadata.get("expected_signature", ""))
         original_error = str(job.metadata.get("original_error", ""))
         comment_body = str(job.metadata.get("comment_body", ""))
-        return (
+        prompt = (
             f"You are operating inside repository: {repo.full_name}\n"
             f"Local path: {repo.local_path}\n"
             f"Recovery task for GitHub issue #{issue_number}: {issue_title}\n\n"
@@ -1499,6 +1501,7 @@ class DaniService:
             f"gh issue comment {issue_number} --repo {repo.full_name} --body-file <recovery-comment.md>\n\n"
             "After posting the comment, exit."
         )
+        return ensure_non_interactive_guard(prompt)
 
     def _build_review_round_prompt(
         self,

--- a/tests/test_omo_http_runner.py
+++ b/tests/test_omo_http_runner.py
@@ -21,6 +21,7 @@ from dani.opencode_http import (
     OpencodeServerManager,
     OpencodeSessionInfo,
 )
+from dani.prompts import NON_INTERACTIVE_GUARD
 
 
 class FakeOpencodeClient:
@@ -213,6 +214,17 @@ def test_launch_implementation_stage_prepends_ultrawork_prefix(runner_factory, t
     assert session.omx_session_id == client.created_sessions[0]["id"]
     assert consumer.registered == [session.omx_session_id]
     assert Path(session.prompt_path).read_text(encoding="utf-8") == "ultrawork\n\nImplement Issue #1."
+
+
+def test_launch_implementation_places_ultrawork_before_guard_as_control_prefix(runner_factory, tmp_path: Path) -> None:
+    runner, client, _ = runner_factory()
+    job = JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=1)
+
+    runner.launch(tmp_path, job, f"{NON_INTERACTIVE_GUARD}\nImplement Issue #1.")
+
+    prompt_text = client.prompt_calls[0]["prompt_text"]
+    assert prompt_text.startswith("ultrawork\n\n" + NON_INTERACTIVE_GUARD)
+    assert prompt_text.count("NON-INTERACTIVE AUTOMATION CONTRACT") == 1
 
 
 def test_launch_issue_request_stage_skips_ultrawork_prefix(runner_factory, tmp_path: Path) -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dani.prompts import TEMPLATES, render_prompt
+from dani.prompts import NON_INTERACTIVE_GUARD, TEMPLATES, render_prompt, split_non_interactive_guard
 
 
 def test_implementation_prompt_keeps_ralph_literal() -> None:
@@ -286,10 +286,11 @@ def test_issue_request_prompt_forbids_self_handoff_promises() -> None:
     assert "does not inherit your reasoning trace" in prompt
 
 
-def test_issue_request_prompt_checklist_mentions_approve_gate_and_open_questions() -> None:
+def test_issue_request_prompt_checklist_mentions_approve_gate_and_async_decisions() -> None:
     prompt = render_prompt("issue_request", _issue_request_context())
 
-    assert "Open questions for the human" in prompt
+    assert "Assumptions / human decisions to resolve asynchronously before /approve" in prompt
+    assert "Open questions for the human" not in prompt
     assert 'implementation starts only after a human comment containing "/approve"' in prompt
 
 
@@ -298,6 +299,13 @@ def test_issue_followup_prompt_declares_planning_only_role() -> None:
 
     assert "PLANNING AGENT" in prompt
     assert "DO NOT write code" in prompt
+
+
+def test_issue_followup_prompt_mentions_async_decisions_not_open_questions() -> None:
+    prompt = render_prompt("issue_followup", _issue_followup_context())
+
+    assert 'assumptions / human decisions to resolve asynchronously before "/approve"' in prompt
+    assert "remaining open questions" not in prompt
     assert "/approve" in prompt
     assert "NEW, SEPARATE agent session" in prompt
 
@@ -544,6 +552,18 @@ _NON_INTERACTIVE_TEMPLATE_CONTEXTS: dict[str, dict[str, object]] = {
     "final_verdict": _final_verdict_context(),
     "dev_sync_conflict": _dev_sync_conflict_context(),
 }
+
+
+def test_split_non_interactive_guard_returns_body_without_raw_string_slicing() -> None:
+    prompt = f"{NON_INTERACTIVE_GUARD}\nPrompt body"
+
+    body = split_non_interactive_guard(prompt)
+
+    assert body == "Prompt body"
+
+
+def test_split_non_interactive_guard_accepts_unguarded_prompt() -> None:
+    assert split_non_interactive_guard("Prompt body") == "Prompt body"
 
 
 @pytest.mark.parametrize("template_name", sorted(TEMPLATES))

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dani.prompts import render_prompt
 
 
@@ -464,3 +466,100 @@ def test_merge_conflict_resolution_prompt_requires_recheck_without_direct_merge(
     assert "Do not merge the PR yourself" in prompt
     assert "stage=merge_conflict_resolution" in prompt
     assert "gh pr comment 5 --repo acme/demo --body-file <merge-conflict-comment.md>" in prompt
+
+
+def _final_verdict_context() -> dict[str, object]:
+    return {
+        "repo": "acme/demo",
+        "pr_number": 5,
+        "pr_title": "Feature",
+        "pr_body": "Body",
+        "discussion": "history",
+        "approve_signature": "<!-- dani:stage=final_verdict;job=abc;pr=5;verdict=APPROVE -->",
+        "reject_signature": "<!-- dani:stage=final_verdict;job=abc;pr=5;verdict=REJECT -->",
+    }
+
+
+def _review_round_context() -> dict[str, object]:
+    return {
+        "repo": "acme/demo",
+        "pr_number": 5,
+        "pr_title": "Feature",
+        "pr_body": "Body",
+        "discussion": "history",
+        "round_number": 2,
+        "signature": "<!-- dani:stage=review_round;job=abc;pr=5;round=2 -->",
+    }
+
+
+def _implementation_context() -> dict[str, object]:
+    return {
+        "repo": "acme/demo",
+        "local_path": "workspace/demo",
+        "issue_number": 7,
+        "issue_title": "Need a bot",
+        "issue_body": "Implement it",
+        "discussion": "approved",
+        "pr_context": "",
+        "pr_number": "",
+        "dev_branch": "dev",
+        "signature": "<!-- dani:stage=implementation;job=abc;issue=7 -->",
+        "signature_instructions": "Use this signature in the PR body:\n<!-- dani:stage=implementation;job=abc;issue=7 -->",
+    }
+
+
+def _merge_conflict_resolution_context() -> dict[str, object]:
+    return {
+        "repo": "acme/demo",
+        "local_path": "workspace/demo",
+        "issue_number": 7,
+        "pr_number": 5,
+        "pr_title": "Feature",
+        "pr_body": "Body",
+        "head_branch": "Feature/#7",
+        "base_branch": "dev",
+        "conflict_reason": "merge conflict with base branch",
+        "signature": "<!-- dani:stage=merge_conflict_resolution;job=abc;pr=5 -->",
+    }
+
+
+def _dev_sync_conflict_context() -> dict[str, object]:
+    return {
+        "repo": "acme/demo",
+        "local_path": "workspace/demo",
+        "main_branch": "main",
+        "main_sha": "abc123",
+        "dev_branch": "dev",
+        "temp_branch": "dani/dev-sync/abc123",
+        "commit_message": "Merge main into dev",
+    }
+
+
+_NON_INTERACTIVE_TEMPLATES: tuple[tuple[str, dict[str, object]], ...] = (
+    ("issue_request", _issue_request_context()),
+    ("issue_followup", _issue_followup_context()),
+    ("implementation", _implementation_context()),
+    ("review_round", _review_round_context()),
+    ("merge_conflict_resolution", _merge_conflict_resolution_context()),
+    ("final_verdict", _final_verdict_context()),
+    ("dev_sync_conflict", _dev_sync_conflict_context()),
+)
+
+
+@pytest.mark.parametrize("template_name,context", _NON_INTERACTIVE_TEMPLATES)
+@pytest.mark.parametrize("runtime", ["omx", "omo"])
+def test_every_template_prepends_non_interactive_guard(
+    template_name: str,
+    context: dict[str, object],
+    runtime: str,
+) -> None:
+    prompt = render_prompt(template_name, context, runtime=runtime)
+
+    assert prompt.startswith("NON-INTERACTIVE AUTOMATION CONTRACT"), (
+        f"{template_name}/{runtime}: guard must be the first thing the agent reads"
+    )
+    assert "DO NOT call the `question` tool" in prompt, (
+        f"{template_name}/{runtime}: must explicitly forbid the question tool by name"
+    )
+    assert "DO NOT ask the user for clarification" in prompt
+    assert "most conservative reasonable interpretation" in prompt

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dani.prompts import render_prompt
+from dani.prompts import TEMPLATES, render_prompt
 
 
 def test_implementation_prompt_keeps_ralph_literal() -> None:
@@ -535,25 +535,25 @@ def _dev_sync_conflict_context() -> dict[str, object]:
     }
 
 
-_NON_INTERACTIVE_TEMPLATES: tuple[tuple[str, dict[str, object]], ...] = (
-    ("issue_request", _issue_request_context()),
-    ("issue_followup", _issue_followup_context()),
-    ("implementation", _implementation_context()),
-    ("review_round", _review_round_context()),
-    ("merge_conflict_resolution", _merge_conflict_resolution_context()),
-    ("final_verdict", _final_verdict_context()),
-    ("dev_sync_conflict", _dev_sync_conflict_context()),
-)
+_NON_INTERACTIVE_TEMPLATE_CONTEXTS: dict[str, dict[str, object]] = {
+    "issue_request": _issue_request_context(),
+    "issue_followup": _issue_followup_context(),
+    "implementation": _implementation_context(),
+    "review_round": _review_round_context(),
+    "merge_conflict_resolution": _merge_conflict_resolution_context(),
+    "final_verdict": _final_verdict_context(),
+    "dev_sync_conflict": _dev_sync_conflict_context(),
+}
 
 
-@pytest.mark.parametrize("template_name,context", _NON_INTERACTIVE_TEMPLATES)
+@pytest.mark.parametrize("template_name", sorted(TEMPLATES))
 @pytest.mark.parametrize("runtime", ["omx", "omo"])
 def test_every_template_prepends_non_interactive_guard(
     template_name: str,
-    context: dict[str, object],
     runtime: str,
 ) -> None:
-    prompt = render_prompt(template_name, context, runtime=runtime)
+    assert set(_NON_INTERACTIVE_TEMPLATE_CONTEXTS) == set(TEMPLATES)
+    prompt = render_prompt(template_name, _NON_INTERACTIVE_TEMPLATE_CONTEXTS[template_name], runtime=runtime)
 
     assert prompt.startswith("NON-INTERACTIVE AUTOMATION CONTRACT"), (
         f"{template_name}/{runtime}: guard must be the first thing the agent reads"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9,6 +9,7 @@ from dani.errors import ClaudeUsageLimitError, RolloutMissingError
 from dani.github import GitHubCLI
 from dani.models import RUNTIME_OMO, RUNTIME_OMX, DaniConfig, JobRecord, NormalizedEvent, SessionRecord
 from dani.omx_runner import OmxRunner
+from dani.prompts import NON_INTERACTIVE_GUARD
 from dani.service import DaniService
 from dani.session_bridge import BridgeContext, OmoSessionBridge
 from dani.signatures import build_signature
@@ -408,6 +409,43 @@ def test_service_build_prompt_uses_effective_runtime_not_configured_runtime(tmp_
     assert "$ralph" in omx_prompt
     assert "$ralph" not in omo_prompt
     assert "ultrawork" in omo_prompt
+
+
+def test_service_bridge_context_keeps_non_interactive_guard_first(tmp_path: Path) -> None:
+    service, _, _, _ = make_omo_preferred_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=54)
+
+    prompt = service._build_prompt(repo, job, runtime=RUNTIME_OMO, bridge_prompt="IMPORTED OMO CONTEXT")
+
+    assert prompt.startswith(NON_INTERACTIVE_GUARD)
+    assert prompt.index("IMPORTED OMO CONTEXT") > prompt.index("DO NOT call the `question` tool")
+    assert prompt.count("NON-INTERACTIVE AUTOMATION CONTRACT") == 1
+
+
+@pytest.mark.parametrize("stage", ["issue_request_recovery", "issue_followup_recovery"])
+def test_issue_comment_recovery_prompt_includes_non_interactive_guard_first(tmp_path: Path, stage: str) -> None:
+    service, _, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(
+        repo_full_name="acme/demo",
+        stage=stage,
+        issue_number=41,
+        metadata={
+            "source_job_id": "source-job",
+            "expected_signature": "<!-- dani:stage=issue_request;job=source-job;issue=41 -->",
+            "original_error": "missing comment",
+        },
+    )
+
+    prompt = service._build_prompt(repo, job, runtime=RUNTIME_OMO)
+
+    assert prompt.startswith(NON_INTERACTIVE_GUARD)
+    assert "DO NOT call the `question` tool" in prompt
+    assert "Recovery task for GitHub issue #41" in prompt
+    assert prompt.count("NON-INTERACTIVE AUTOMATION CONTRACT") == 1
 
 
 def test_issue_followup_verification_requires_exact_signature(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Prepend a **non-interactive automation contract** to every rendered prompt that explicitly forbids the opencode `question` tool by name and tells the agent to pick a conservative default + document the assumption inline instead of asking.
- Enforce the guard at prompt assembly boundaries that can bypass or wrap templates: bridged OMO fallback context and issue-comment recovery prompts.
- Add parametric and launch-boundary tests covering all registered templates under both `omx` and `omo`, bridge composition, recovery prompts, and the intentional OMO `ultrawork` control-prefix exception.

## Why

Agent sessions launched by dani run inside a webhook-driven loop. There is no human attached. When the **omo (opencode)** runtime exposes the `question` tool, the agent can call it mid-task and the session never reaches `idle` — dani's `agent_timeout_seconds` eventually trips, the job is marked `failed`, and no follow-up stage is ever scheduled.

`omx` (codex) doesn't expose `question` today, so it has been accidentally safe — but a runtime-agnostic guard is cheap insurance and a future omx tool-surface change won't reintroduce the same stall.

## What changed

- **`dani/prompts.py`**:
  - Add module-level `NON_INTERACTIVE_GUARD` constant and idempotent guard helpers.
  - `render_prompt()` prepends the guard after runtime substitutions.
  - Planning/follow-up wording now frames unresolved items as asynchronous assumptions/decisions instead of live open questions.
- **`dani/service.py`**:
  - Keep bridge context below the guard so imported OMO context cannot be first instructional content.
  - Wrap issue-comment recovery prompts with the same guard.
- **`tests/test_prompts.py` / `tests/test_service.py` / `tests/test_omo_http_runner.py`**:
  - Derive template coverage from `TEMPLATES`.
  - Cover all template/runtime pairs, bridge ordering, recovery prompts, and OMO `ultrawork` prefix ordering.

## Verification

- `uv run pytest tests/test_prompts.py -x -q` → 43 passed
- `uv run pytest tests/test_prompts.py tests/test_service.py tests/test_omo_http_runner.py -q` → 176 passed
- `uv run pytest --ignore=tests/test_omo_live.py -x -q` → 242 passed
- `uv run ruff check dani/prompts.py dani/service.py tests/test_prompts.py tests/test_service.py tests/test_omo_http_runner.py` → clean
- `uv run ruff format --check dani/prompts.py dani/service.py tests/test_prompts.py tests/test_service.py tests/test_omo_http_runner.py` → already formatted
- `uv run ty check` → clean
- Manual render/service check confirmed the guard starts rendered prompts, bridged prompts keep imported context after the `question` prohibition, OMO non-comment prompts place `ultrawork` immediately before the guard, and the guard is not duplicated.
