### PR TITLE
Guard closed/terminal issue and PR events from re-firing dani jobs

### DIFF
--- a/dani/cli.py
+++ b/dani/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import typer
 import uvicorn
 
-from dani.models import DEFAULT_AGENT_TIMEOUT_SECONDS, DaniConfig
+from dani.models import DEFAULT_AGENT_TIMEOUT_SECONDS, DEFAULT_MAX_ISSUE_FOLLOWUPS, DaniConfig
 from dani.server import create_app
 from dani.service import DaniService
 
@@ -57,11 +57,44 @@ def _resolve_agent_timeout_seconds(config_payload: dict[str, object]) -> float:
     return _parse_positive_float(value, name="agent_timeout_seconds")
 
 
+def _resolve_bot_login(config_payload: dict[str, object]) -> str | None:
+    env_value = os.environ.get("DANI_BOT_LOGIN")
+    if env_value is not None and env_value != "":
+        return env_value
+    raw = config_payload.get("bot_login")
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    return text or None
+
+
+def _parse_non_negative_int(value: object, *, name: str) -> int:
+    try:
+        parsed = int(str(value))
+    except (TypeError, ValueError) as exc:
+        msg = f"{name} must be an integer"
+        raise typer.BadParameter(msg) from exc
+    if parsed < 0:
+        msg = f"{name} must be greater than or equal to 0"
+        raise typer.BadParameter(msg)
+    return parsed
+
+
+def _resolve_max_issue_followups(config_payload: dict[str, object]) -> int:
+    value: object = config_payload.get("max_issue_followups", DEFAULT_MAX_ISSUE_FOLLOWUPS)
+    env_value = os.environ.get("DANI_MAX_ISSUE_FOLLOWUPS")
+    if env_value:
+        value = env_value
+    return _parse_non_negative_int(value, name="max_issue_followups")
+
+
 def build_config(data_dir: Path, host: str = "127.0.0.1", port: int = 8787) -> DaniConfig:
     config_payload = _load_config_file(data_dir)
     secret = os.environ.get("DANI_WEBHOOK_SECRET", "")
     agent_runtime = os.environ.get("DANI_AGENT_RUNTIME") or str(config_payload.get("agent_runtime", "omx"))
     agent_timeout_seconds = _resolve_agent_timeout_seconds(config_payload)
+    bot_login = _resolve_bot_login(config_payload)
+    max_issue_followups = _resolve_max_issue_followups(config_payload)
     return DaniConfig(
         data_dir=data_dir,
         webhook_secret=secret,
@@ -69,6 +102,8 @@ def build_config(data_dir: Path, host: str = "127.0.0.1", port: int = 8787) -> D
         port=port,
         agent_runtime=agent_runtime,
         agent_timeout_seconds=agent_timeout_seconds,
+        bot_login=bot_login,
+        max_issue_followups=max_issue_followups,
     )
 
 

--- a/dani/models.py
+++ b/dani/models.py
@@ -110,6 +110,13 @@ class NormalizedEvent:
     ref: str | None = None
     commit_sha: str | None = None
     is_pull_request: bool = False
+    issue_state: str | None = None
+    pr_state: str | None = None
+    pr_merged: bool | None = None
+    actor_type: str | None = None
+
+
+DEFAULT_MAX_ISSUE_FOLLOWUPS = 3
 
 
 @dataclass(slots=True)
@@ -121,6 +128,8 @@ class DaniConfig:
     review_rounds: int = 3
     agent_runtime: str = "omx"
     agent_timeout_seconds: float = DEFAULT_AGENT_TIMEOUT_SECONDS
+    bot_login: str | None = None
+    max_issue_followups: int = DEFAULT_MAX_ISSUE_FOLLOWUPS
 
     @property
     def config_path(self) -> Path:
@@ -145,6 +154,10 @@ class DaniConfig:
     @property
     def processed_events_path(self) -> Path:
         return self.data_dir / "processed-events.json"
+
+    @property
+    def terminal_targets_path(self) -> Path:
+        return self.data_dir / "terminal-targets.json"
 
     @property
     def run_dir(self) -> Path:

--- a/dani/service.py
+++ b/dani/service.py
@@ -207,19 +207,62 @@ class DaniService:
         if event.kind == "branch_push":
             return self._queue_dev_sync(repo, event)
 
+        if event.kind == "pull_request_closed":
+            return self._handle_pull_request_closed(repo, event)
+
         if event.kind == "issue_opened":
-            return self._queue_issue_request(repo, event)
+            return self._dispatch_issue_opened(repo, event)
 
         if event.kind == "issue_comment" and self._is_approve_comment(event.body):
-            return self._queue_implementation(repo, event)
+            return self._dispatch_approve_comment(repo, event)
 
         if event.kind == "issue_comment":
-            return self._queue_issue_followup(repo, event)
+            return self._dispatch_issue_followup_comment(repo, event)
 
         if event.kind == "pull_request_opened":
-            return self._queue_pull_request_review(repo, event, signature)
+            return self._dispatch_pull_request_opened(repo, event, signature)
 
         return {"status": "ignored", "reason": "unsupported_event"}
+
+    def _dispatch_issue_opened(self, repo: RepoConfig, event: NormalizedEvent) -> dict[str, Any]:
+        if event.action == "reopened":
+            return {"status": "ignored", "reason": "issue_reopened_no_op"}
+        if event.issue_state == "closed":
+            return {"status": "ignored", "reason": "issue_closed"}
+        if self.storage.is_terminal_issue(repo.full_name, event.number):
+            return {"status": "ignored", "reason": "issue_terminal"}
+        return self._queue_issue_request(repo, event)
+
+    def _dispatch_approve_comment(self, repo: RepoConfig, event: NormalizedEvent) -> dict[str, Any]:
+        if event.issue_state == "closed":
+            return {"status": "ignored", "reason": "issue_closed"}
+        if self.storage.is_terminal_issue(repo.full_name, event.number):
+            return {"status": "ignored", "reason": "issue_terminal"}
+        if self._has_existing_implementation_job(repo.full_name, event.number):
+            return {"status": "ignored", "reason": "duplicate_implementation"}
+        return self._queue_implementation(repo, event)
+
+    def _dispatch_issue_followup_comment(self, repo: RepoConfig, event: NormalizedEvent) -> dict[str, Any]:
+        if event.issue_state == "closed":
+            return {"status": "ignored", "reason": "issue_closed"}
+        if self.storage.is_terminal_issue(repo.full_name, event.number):
+            return {"status": "ignored", "reason": "issue_terminal"}
+        if self._is_dani_self_authored(event):
+            return {"status": "ignored", "reason": "self_authored_comment"}
+        if self._completed_followup_count(repo.full_name, event.number) >= self.config.max_issue_followups:
+            return {"status": "ignored", "reason": "max_followups_reached"}
+        return self._queue_issue_followup(repo, event)
+
+    def _dispatch_pull_request_opened(
+        self, repo: RepoConfig, event: NormalizedEvent, signature: dict[str, str] | None
+    ) -> dict[str, Any]:
+        if event.pr_merged is True:
+            return {"status": "ignored", "reason": "pr_merged"}
+        if event.pr_state == "closed":
+            return {"status": "ignored", "reason": "pr_not_open"}
+        if self.storage.is_terminal_pr(repo.full_name, event.number):
+            return {"status": "ignored", "reason": "pr_terminal"}
+        return self._queue_pull_request_review(repo, event, signature)
 
     def _handle_agent_event(self, event: NormalizedEvent, signature: dict[str, str]) -> dict[str, Any]:
         stage = signature.get("stage")
@@ -1752,6 +1795,38 @@ class DaniService:
             if job.status in {"queued", "launched", "completed"}:
                 return True
         return False
+
+    def _has_existing_implementation_job(self, repo_full_name: str, issue_number: int) -> bool:
+        for job in self.storage.find_jobs(
+            repo_full_name=repo_full_name, stage="implementation", issue_number=issue_number
+        ):
+            if job.status in {"queued", "launched", "running", "completed"}:
+                return True
+        return False
+
+    def _completed_followup_count(self, repo_full_name: str, issue_number: int) -> int:
+        count = 0
+        for job in self.storage.find_jobs(
+            repo_full_name=repo_full_name, stage="issue_followup", issue_number=issue_number
+        ):
+            if job.status in {"queued", "launched", "running", "completed"}:
+                count += 1
+        return count
+
+    def _is_dani_self_authored(self, event: NormalizedEvent) -> bool:
+        configured_login = self.config.bot_login
+        if configured_login:
+            return event.actor_login == configured_login
+        return event.actor_type == "Bot"
+
+    def _handle_pull_request_closed(self, repo: RepoConfig, event: NormalizedEvent) -> dict[str, Any]:
+        merged = bool(event.pr_merged)
+        self.storage.mark_terminal_pr(repo.full_name, event.number, merged=merged)
+        if merged:
+            issue_number = self._extract_issue_number(event.body)
+            if issue_number is not None:
+                self.storage.mark_terminal_issue(repo.full_name, issue_number)
+        return {"status": "marked_terminal", "pr_number": event.number, "merged": merged}
 
     def _queue_implementation(self, repo: RepoConfig, event: NormalizedEvent) -> dict[str, Any]:
         job = self._enqueue_job(

--- a/dani/storage.py
+++ b/dani/storage.py
@@ -21,6 +21,7 @@ class JsonStorage:
         self._ensure_json_file(self.config.jobs_path, {"jobs": []})
         self._ensure_json_file(self.config.sessions_path, {"sessions": []})
         self._ensure_json_file(self.config.processed_events_path, {"keys": []})
+        self._ensure_json_file(self.config.terminal_targets_path, {"prs": [], "issues": []})
         if not self.config.events_path.exists():
             self.config.events_path.write_text("", encoding="utf-8")
 
@@ -185,6 +186,42 @@ class JsonStorage:
             payload = self._read_json(self.config.processed_events_path)
             return key in payload["keys"]
 
+    def mark_terminal_pr(self, repo_full_name: str, pr_number: int, *, merged: bool) -> None:
+        with self._lock:
+            payload = self._read_json(self.config.terminal_targets_path)
+            entries = payload.setdefault("prs", [])
+            for entry in entries:
+                if entry.get("repo") == repo_full_name and entry.get("pr") == pr_number:
+                    return
+            entries.append({"repo": repo_full_name, "pr": pr_number, "merged": bool(merged)})
+            self._write_json(self.config.terminal_targets_path, payload)
+
+    def is_terminal_pr(self, repo_full_name: str, pr_number: int) -> bool:
+        with self._lock:
+            payload = self._read_json(self.config.terminal_targets_path)
+            for entry in payload.get("prs", []):
+                if entry.get("repo") == repo_full_name and entry.get("pr") == pr_number:
+                    return True
+        return False
+
+    def mark_terminal_issue(self, repo_full_name: str, issue_number: int) -> None:
+        with self._lock:
+            payload = self._read_json(self.config.terminal_targets_path)
+            entries = payload.setdefault("issues", [])
+            for entry in entries:
+                if entry.get("repo") == repo_full_name and entry.get("issue") == issue_number:
+                    return
+            entries.append({"repo": repo_full_name, "issue": issue_number})
+            self._write_json(self.config.terminal_targets_path, payload)
+
+    def is_terminal_issue(self, repo_full_name: str, issue_number: int) -> bool:
+        with self._lock:
+            payload = self._read_json(self.config.terminal_targets_path)
+            for entry in payload.get("issues", []):
+                if entry.get("repo") == repo_full_name and entry.get("issue") == issue_number:
+                    return True
+        return False
+
     def snapshot(self) -> dict[str, Any]:
         with self._lock:
             return {
@@ -192,5 +229,6 @@ class JsonStorage:
                 "jobs": self._read_json(self.config.jobs_path),
                 "sessions": self._read_json(self.config.sessions_path),
                 "processed_events": self._read_json(self.config.processed_events_path),
+                "terminal_targets": self._read_json(self.config.terminal_targets_path),
                 "events_path": str(self.config.events_path),
             }

--- a/dani/webhook.py
+++ b/dani/webhook.py
@@ -15,6 +15,158 @@ def verify_github_signature(secret: str, body: bytes, signature_header: str | No
     return hmac.compare_digest(expected, signature_header)
 
 
+def _actor_type(payload: dict[str, Any]) -> str | None:
+    sender = payload.get("sender")
+    if not isinstance(sender, dict):
+        return None
+    type_value = sender.get("type")
+    if isinstance(type_value, str) and type_value:
+        return type_value
+    return None
+
+
+def _coerce_state(value: object) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _coerce_merged(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _normalize_issue_opened(
+    payload: dict[str, Any], *, repo_full_name: str, action: str, delivery_id: str | None
+) -> NormalizedEvent:
+    issue = payload["issue"]
+    return NormalizedEvent(
+        kind="issue_opened",
+        repo_full_name=repo_full_name,
+        action=action,
+        number=issue["number"],
+        actor_login=payload["sender"]["login"],
+        payload=payload,
+        body=issue.get("body"),
+        title=issue.get("title"),
+        delivery_id=delivery_id,
+        issue_state=_coerce_state(issue.get("state")),
+        actor_type=_actor_type(payload),
+    )
+
+
+def _normalize_issue_comment(
+    payload: dict[str, Any], *, repo_full_name: str, action: str, delivery_id: str | None
+) -> NormalizedEvent:
+    issue = payload["issue"]
+    is_pr = bool(issue.get("pull_request"))
+    pr_marker = issue.get("pull_request") if is_pr else None
+    pr_merged: bool | None = None
+    if isinstance(pr_marker, dict) and pr_marker.get("merged_at") is not None:
+        pr_merged = True
+    issue_state = _coerce_state(issue.get("state"))
+    return NormalizedEvent(
+        kind="pull_request_comment" if is_pr else "issue_comment",
+        repo_full_name=repo_full_name,
+        action=action,
+        number=issue["number"],
+        actor_login=payload["sender"]["login"],
+        payload=payload,
+        body=payload["comment"].get("body"),
+        title=issue.get("title"),
+        delivery_id=delivery_id,
+        is_pull_request=is_pr,
+        issue_state=issue_state,
+        pr_state=issue_state if is_pr else None,
+        pr_merged=pr_merged,
+        actor_type=_actor_type(payload),
+    )
+
+
+def _normalize_branch_push(
+    payload: dict[str, Any], *, repo_full_name: str, delivery_id: str | None
+) -> NormalizedEvent | None:
+    ref = payload.get("ref")
+    commit_sha = payload.get("after")
+    if not ref or not commit_sha or payload.get("deleted"):
+        return None
+    return NormalizedEvent(
+        kind="branch_push",
+        repo_full_name=repo_full_name,
+        action="push",
+        number=0,
+        actor_login=payload["sender"]["login"],
+        payload=payload,
+        delivery_id=delivery_id,
+        ref=ref,
+        commit_sha=commit_sha,
+        actor_type=_actor_type(payload),
+    )
+
+
+def _normalize_pull_request(
+    payload: dict[str, Any],
+    *,
+    repo_full_name: str,
+    action: str,
+    kind: str,
+    delivery_id: str | None,
+) -> NormalizedEvent:
+    pull_request = payload["pull_request"]
+    return NormalizedEvent(
+        kind=kind,
+        repo_full_name=repo_full_name,
+        action=action,
+        number=pull_request["number"],
+        actor_login=payload["sender"]["login"],
+        payload=payload,
+        body=pull_request.get("body"),
+        title=pull_request.get("title"),
+        base_branch=pull_request["base"]["ref"],
+        head_branch=pull_request["head"]["ref"],
+        delivery_id=delivery_id,
+        commit_sha=pull_request["head"].get("sha"),
+        is_pull_request=True,
+        pr_state=_coerce_state(pull_request.get("state")),
+        pr_merged=_coerce_merged(pull_request.get("merged")),
+        actor_type=_actor_type(payload),
+    )
+
+
+def _normalize_pull_request_review_comment(
+    payload: dict[str, Any], *, repo_full_name: str, action: str, delivery_id: str | None
+) -> NormalizedEvent:
+    pull_request = payload["pull_request"]
+    return NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name=repo_full_name,
+        action=action,
+        number=pull_request["number"],
+        actor_login=payload["sender"]["login"],
+        payload=payload,
+        body=payload["comment"].get("body"),
+        title=pull_request.get("title"),
+        base_branch=pull_request["base"]["ref"],
+        head_branch=pull_request["head"]["ref"],
+        delivery_id=delivery_id,
+        commit_sha=pull_request["head"].get("sha"),
+        is_pull_request=True,
+        pr_state=_coerce_state(pull_request.get("state")),
+        pr_merged=_coerce_merged(pull_request.get("merged")),
+        actor_type=_actor_type(payload),
+    )
+
+
+_PULL_REQUEST_OPEN_ACTIONS = frozenset({
+    "opened",
+    "synchronize",
+    "reopened",
+    "ready_for_review",
+    "review_requested",
+})
+
+
 def normalize_event(
     event_name: str, payload: dict[str, Any], *, delivery_id: str | None = None
 ) -> NormalizedEvent | None:
@@ -24,93 +176,32 @@ def normalize_event(
         return None
 
     action = payload.get("action", "")
+
     if event_name == "issues" and action == "opened":
-        issue = payload["issue"]
-        return NormalizedEvent(
-            kind="issue_opened",
-            repo_full_name=repo_full_name,
-            action=action,
-            number=issue["number"],
-            actor_login=payload["sender"]["login"],
-            payload=payload,
-            body=issue.get("body"),
-            title=issue.get("title"),
-            delivery_id=delivery_id,
-        )
-
+        return _normalize_issue_opened(payload, repo_full_name=repo_full_name, action=action, delivery_id=delivery_id)
     if event_name == "issue_comment" and action == "created":
-        issue = payload["issue"]
-        is_pr = bool(issue.get("pull_request"))
-        return NormalizedEvent(
-            kind="pull_request_comment" if is_pr else "issue_comment",
-            repo_full_name=repo_full_name,
-            action=action,
-            number=issue["number"],
-            actor_login=payload["sender"]["login"],
-            payload=payload,
-            body=payload["comment"].get("body"),
-            title=issue.get("title"),
-            delivery_id=delivery_id,
-            is_pull_request=is_pr,
-        )
-
+        return _normalize_issue_comment(payload, repo_full_name=repo_full_name, action=action, delivery_id=delivery_id)
     if event_name == "push":
-        ref = payload.get("ref")
-        commit_sha = payload.get("after")
-        if not ref or not commit_sha or payload.get("deleted"):
-            return None
-        return NormalizedEvent(
-            kind="branch_push",
+        return _normalize_branch_push(payload, repo_full_name=repo_full_name, delivery_id=delivery_id)
+    if event_name == "pull_request" and action in _PULL_REQUEST_OPEN_ACTIONS:
+        return _normalize_pull_request(
+            payload,
             repo_full_name=repo_full_name,
-            action="push",
-            number=0,
-            actor_login=payload["sender"]["login"],
-            payload=payload,
-            delivery_id=delivery_id,
-            ref=ref,
-            commit_sha=commit_sha,
-        )
-
-    if event_name == "pull_request" and action in {
-        "opened",
-        "synchronize",
-        "reopened",
-        "ready_for_review",
-        "review_requested",
-    }:
-        pull_request = payload["pull_request"]
-        return NormalizedEvent(
+            action=action,
             kind="pull_request_opened",
-            repo_full_name=repo_full_name,
-            action=action,
-            number=pull_request["number"],
-            actor_login=payload["sender"]["login"],
-            payload=payload,
-            body=pull_request.get("body"),
-            title=pull_request.get("title"),
-            base_branch=pull_request["base"]["ref"],
-            head_branch=pull_request["head"]["ref"],
             delivery_id=delivery_id,
-            commit_sha=pull_request["head"].get("sha"),
-            is_pull_request=True,
         )
-
-    if event_name == "pull_request_review_comment" and action == "created":
-        pull_request = payload["pull_request"]
-        return NormalizedEvent(
-            kind="pull_request_comment",
+    if event_name == "pull_request" and action == "closed":
+        return _normalize_pull_request(
+            payload,
             repo_full_name=repo_full_name,
             action=action,
-            number=pull_request["number"],
-            actor_login=payload["sender"]["login"],
-            payload=payload,
-            body=payload["comment"].get("body"),
-            title=pull_request.get("title"),
-            base_branch=pull_request["base"]["ref"],
-            head_branch=pull_request["head"]["ref"],
+            kind="pull_request_closed",
             delivery_id=delivery_id,
-            commit_sha=pull_request["head"].get("sha"),
-            is_pull_request=True,
+        )
+    if event_name == "pull_request_review_comment" and action == "created":
+        return _normalize_pull_request_review_comment(
+            payload, repo_full_name=repo_full_name, action=action, delivery_id=delivery_id
         )
 
     return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,3 +95,68 @@ def test_build_config_agent_timeout_env_overrides_config_file(tmp_path: Path, mo
     config = cli_module.build_config(data_dir)
 
     assert config.agent_timeout_seconds == 5400
+
+
+def test_build_config_defaults_for_bot_login_and_max_issue_followups(tmp_path: Path, monkeypatch) -> None:
+    data_dir = tmp_path / ".dani"
+    data_dir.mkdir()
+    monkeypatch.delenv("DANI_BOT_LOGIN", raising=False)
+    monkeypatch.delenv("DANI_MAX_ISSUE_FOLLOWUPS", raising=False)
+
+    config = cli_module.build_config(data_dir)
+
+    assert config.bot_login is None
+    assert config.max_issue_followups == 3
+
+
+def test_build_config_reads_bot_login_from_env(tmp_path: Path, monkeypatch) -> None:
+    data_dir = tmp_path / ".dani"
+    data_dir.mkdir()
+    monkeypatch.setenv("DANI_BOT_LOGIN", "danibot[bot]")
+
+    config = cli_module.build_config(data_dir)
+
+    assert config.bot_login == "danibot[bot]"
+
+
+def test_build_config_reads_bot_login_from_config_file(tmp_path: Path, monkeypatch) -> None:
+    data_dir = tmp_path / ".dani"
+    data_dir.mkdir()
+    (data_dir / "config.json").write_text(json.dumps({"bot_login": "dani-machine"}), encoding="utf-8")
+    monkeypatch.delenv("DANI_BOT_LOGIN", raising=False)
+
+    config = cli_module.build_config(data_dir)
+
+    assert config.bot_login == "dani-machine"
+
+
+def test_build_config_bot_login_env_overrides_config_file(tmp_path: Path, monkeypatch) -> None:
+    data_dir = tmp_path / ".dani"
+    data_dir.mkdir()
+    (data_dir / "config.json").write_text(json.dumps({"bot_login": "from-file"}), encoding="utf-8")
+    monkeypatch.setenv("DANI_BOT_LOGIN", "from-env")
+
+    config = cli_module.build_config(data_dir)
+
+    assert config.bot_login == "from-env"
+
+
+def test_build_config_reads_max_issue_followups_from_env(tmp_path: Path, monkeypatch) -> None:
+    data_dir = tmp_path / ".dani"
+    data_dir.mkdir()
+    monkeypatch.setenv("DANI_MAX_ISSUE_FOLLOWUPS", "5")
+
+    config = cli_module.build_config(data_dir)
+
+    assert config.max_issue_followups == 5
+
+
+def test_build_config_reads_max_issue_followups_from_config_file(tmp_path: Path, monkeypatch) -> None:
+    data_dir = tmp_path / ".dani"
+    data_dir.mkdir()
+    (data_dir / "config.json").write_text(json.dumps({"max_issue_followups": 7}), encoding="utf-8")
+    monkeypatch.delenv("DANI_MAX_ISSUE_FOLLOWUPS", raising=False)
+
+    config = cli_module.build_config(data_dir)
+
+    assert config.max_issue_followups == 7

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3144,3 +3144,401 @@ def test_agent_timeout_config_is_passed_to_runner(tmp_path: Path) -> None:
     service.wait_for_idle()
 
     assert omx_runner.wait_calls[-1]["timeout_seconds"] == 5400
+
+
+def test_issue_opened_with_closed_state_is_ignored(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=58,
+            actor_login="human",
+            payload={},
+            body="b",
+            title="t",
+            issue_state="closed",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "issue_closed"}
+    assert omx_runner.launches == []
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_request", issue_number=58) == []
+
+
+def test_issue_opened_after_terminal_issue_flag_is_ignored(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    service.storage.mark_terminal_issue("acme/demo", 58)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=58,
+            actor_login="h",
+            payload={},
+            body="b",
+            title="t",
+            issue_state="open",
+        )
+    )
+
+    assert result == {"status": "ignored", "reason": "issue_terminal"}
+    assert omx_runner.launches == []
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_request", issue_number=58) == []
+
+
+def test_issue_reopened_action_is_no_op(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_opened",
+            repo_full_name="acme/demo",
+            action="reopened",
+            number=58,
+            actor_login="h",
+            payload={},
+            body="b",
+            title="t",
+            issue_state="open",
+        )
+    )
+
+    assert result == {"status": "ignored", "reason": "issue_reopened_no_op"}
+    assert omx_runner.launches == []
+
+
+def test_approve_on_closed_issue_does_not_queue_implementation(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=12,
+            actor_login="h",
+            payload={"issue": {"body": "x"}},
+            body="/approve",
+            title="t",
+            issue_state="closed",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "issue_closed"}
+    assert omx_runner.launches == []
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", issue_number=12) == []
+
+
+def test_approve_after_terminal_issue_flag_is_ignored(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    service.storage.mark_terminal_issue("acme/demo", 12)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=12,
+            actor_login="h",
+            payload={"issue": {"body": "x"}},
+            body="/approve",
+            title="t",
+            issue_state="open",
+        )
+    )
+
+    assert result == {"status": "ignored", "reason": "issue_terminal"}
+    assert omx_runner.launches == []
+
+
+def test_second_approve_for_same_issue_is_deduplicated(tmp_path: Path) -> None:
+    service, _, _omx_runner = make_service(tmp_path)
+    base_event = NormalizedEvent(
+        kind="issue_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=13,
+        actor_login="h",
+        payload={"issue": {"body": "x"}},
+        body="/approve",
+        title="t",
+        issue_state="open",
+    )
+
+    first = service.handle_event(base_event)
+    service.wait_for_idle()
+    second = service.handle_event(base_event)
+    service.wait_for_idle()
+
+    assert first["status"] == "queued"
+    assert first["stage"] == "implementation"
+    assert second == {"status": "ignored", "reason": "duplicate_implementation"}
+    impl_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", issue_number=13)
+    assert len(impl_jobs) == 1
+
+
+def test_followup_from_dani_bot_login_is_ignored(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    service.config.bot_login = "danibot[bot]"
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=21,
+            actor_login="danibot[bot]",
+            payload={"issue": {"body": "x"}},
+            body="dani report",
+            title="t",
+            issue_state="open",
+            actor_type="Bot",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "self_authored_comment"}
+    assert omx_runner.launches == []
+    assert omx_runner.resumes == []
+
+
+def test_followup_with_actor_type_bot_is_ignored_when_bot_login_unset(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    assert service.config.bot_login is None
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=22,
+            actor_login="some-bot",
+            payload={"issue": {"body": "x"}},
+            body="comment",
+            title="t",
+            issue_state="open",
+            actor_type="Bot",
+        )
+    )
+
+    assert result == {"status": "ignored", "reason": "self_authored_comment"}
+    assert omx_runner.launches == []
+
+
+def test_followup_short_circuits_after_max_rounds(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    for _ in range(service.config.max_issue_followups):
+        service.storage.create_job(
+            JobRecord(
+                repo_full_name=repo.full_name,
+                stage="issue_followup",
+                issue_number=23,
+                status="completed",
+            )
+        )
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=23,
+            actor_login="human",
+            payload={"issue": {"body": "x"}},
+            body="more?",
+            title="t",
+            issue_state="open",
+            actor_type="User",
+        )
+    )
+
+    assert result == {"status": "ignored", "reason": "max_followups_reached"}
+    assert omx_runner.launches == []
+    assert omx_runner.resumes == []
+
+
+def test_followup_on_closed_issue_is_ignored(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=24,
+            actor_login="human",
+            payload={"issue": {"body": "x"}},
+            body="hello",
+            title="t",
+            issue_state="closed",
+            actor_type="User",
+        )
+    )
+
+    assert result == {"status": "ignored", "reason": "issue_closed"}
+    assert omx_runner.launches == []
+
+
+def test_followup_after_terminal_issue_flag_is_ignored(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    service.storage.mark_terminal_issue("acme/demo", 25)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=25,
+            actor_login="human",
+            payload={"issue": {"body": "x"}},
+            body="hello",
+            title="t",
+            issue_state="open",
+            actor_type="User",
+        )
+    )
+
+    assert result == {"status": "ignored", "reason": "issue_terminal"}
+    assert omx_runner.launches == []
+
+
+def test_pull_request_opened_with_merged_state_is_ignored(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    event = make_pr_event(pr_number=88, action="synchronize", body="Implements #21")
+    event.pr_state = "closed"
+    event.pr_merged = True
+
+    result = service.handle_event(event)
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "pr_merged"}
+    assert omx_runner.launches == []
+
+
+def test_pull_request_opened_with_closed_state_is_ignored(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    event = make_pr_event(pr_number=89, action="synchronize", body="Implements #22")
+    event.pr_state = "closed"
+    event.pr_merged = False
+
+    result = service.handle_event(event)
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "pr_not_open"}
+    assert omx_runner.launches == []
+
+
+def test_pull_request_opened_after_terminal_pr_flag_is_ignored(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+    service.storage.mark_terminal_pr("acme/demo", 90, merged=True)
+    event = make_pr_event(pr_number=90, action="opened", body="Implements #23")
+
+    result = service.handle_event(event)
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "pr_terminal"}
+    assert omx_runner.launches == []
+
+
+def test_pull_request_closed_merged_marks_terminal_pr_and_issue(tmp_path: Path) -> None:
+    service, _, _ = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_closed",
+            repo_full_name="acme/demo",
+            action="closed",
+            number=70,
+            actor_login="danibot[bot]",
+            payload={},
+            body="Implements #58",
+            title="Feature/#70",
+            base_branch="dev",
+            head_branch="feature/#70",
+            commit_sha="x",
+            is_pull_request=True,
+            pr_state="closed",
+            pr_merged=True,
+            actor_type="Bot",
+        )
+    )
+
+    assert result == {"status": "marked_terminal", "pr_number": 70, "merged": True}
+    assert service.storage.is_terminal_pr("acme/demo", 70) is True
+    assert service.storage.is_terminal_issue("acme/demo", 58) is True
+
+
+def test_pull_request_closed_unmerged_marks_only_pr(tmp_path: Path) -> None:
+    service, _, _ = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_closed",
+            repo_full_name="acme/demo",
+            action="closed",
+            number=71,
+            actor_login="h",
+            payload={},
+            body="Implements #59",
+            title="Feature/#71",
+            base_branch="dev",
+            head_branch="feature/#71",
+            is_pull_request=True,
+            pr_state="closed",
+            pr_merged=False,
+        )
+    )
+
+    assert result == {"status": "marked_terminal", "pr_number": 71, "merged": False}
+    assert service.storage.is_terminal_pr("acme/demo", 71) is True
+    assert service.storage.is_terminal_issue("acme/demo", 59) is False
+
+
+def test_followup_after_pr_merged_is_short_circuited_end_to_end(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_closed",
+            repo_full_name="acme/demo",
+            action="closed",
+            number=70,
+            actor_login="danibot[bot]",
+            payload={},
+            body="Implements #58",
+            title="Feature/#70",
+            base_branch="dev",
+            head_branch="feature/#70",
+            is_pull_request=True,
+            pr_state="closed",
+            pr_merged=True,
+            actor_type="Bot",
+        )
+    )
+
+    followup_result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=58,
+            actor_login="human",
+            payload={"issue": {"body": "x"}},
+            body="anything else?",
+            issue_state="open",
+            actor_type="User",
+        )
+    )
+
+    assert followup_result == {"status": "ignored", "reason": "issue_terminal"}
+    assert omx_runner.launches == []
+    assert omx_runner.resumes == []

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -133,3 +133,70 @@ def test_find_latest_session_can_filter_by_source_job_id(tmp_path: Path) -> None
     assert source_session is not None
     assert source_session.job_id == first_job.id
     assert source_session.omx_session_id == "omx-first"
+
+
+def test_storage_marks_and_queries_terminal_pr(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+
+    assert storage.is_terminal_pr("acme/demo", 70) is False
+
+    storage.mark_terminal_pr("acme/demo", 70, merged=True)
+
+    assert storage.is_terminal_pr("acme/demo", 70) is True
+    assert storage.is_terminal_pr("acme/other", 70) is False
+    assert storage.is_terminal_pr("acme/demo", 71) is False
+
+    storage.mark_terminal_pr("acme/demo", 70, merged=True)
+    assert storage.is_terminal_pr("acme/demo", 70) is True
+
+
+def test_storage_marks_terminal_pr_unmerged_and_queries(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+
+    storage.mark_terminal_pr("acme/demo", 71, merged=False)
+
+    assert storage.is_terminal_pr("acme/demo", 71) is True
+
+
+def test_storage_marks_and_queries_terminal_issue(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+
+    assert storage.is_terminal_issue("acme/demo", 58) is False
+
+    storage.mark_terminal_issue("acme/demo", 58)
+
+    assert storage.is_terminal_issue("acme/demo", 58) is True
+    assert storage.is_terminal_issue("acme/other", 58) is False
+    assert storage.is_terminal_issue("acme/demo", 59) is False
+
+    storage.mark_terminal_issue("acme/demo", 58)
+    assert storage.is_terminal_issue("acme/demo", 58) is True
+
+
+def test_storage_terminal_targets_persist_across_instances(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    storage.mark_terminal_pr("acme/demo", 70, merged=True)
+    storage.mark_terminal_issue("acme/demo", 58)
+
+    reloaded = JsonStorage(config)
+
+    assert reloaded.is_terminal_pr("acme/demo", 70) is True
+    assert reloaded.is_terminal_issue("acme/demo", 58) is True
+
+
+def test_storage_terminal_targets_snapshot_includes_payload(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    storage.mark_terminal_pr("acme/demo", 70, merged=True)
+    storage.mark_terminal_issue("acme/demo", 58)
+
+    snapshot = storage.snapshot()
+
+    assert snapshot["terminal_targets"] == {
+        "prs": [{"repo": "acme/demo", "pr": 70, "merged": True}],
+        "issues": [{"repo": "acme/demo", "issue": 58}],
+    }

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -54,3 +54,165 @@ def test_normalize_pull_request_review_requested_event() -> None:
     assert event.head_branch == "feature/#21"
     assert event.commit_sha == "def456"
     assert event.is_pull_request is True
+
+
+def test_normalized_event_state_fields_default_to_none() -> None:
+    from dani.models import NormalizedEvent
+
+    event = NormalizedEvent(
+        kind="issue_opened",
+        repo_full_name="acme/demo",
+        action="opened",
+        number=1,
+        actor_login="human",
+        payload={},
+    )
+
+    assert event.issue_state is None
+    assert event.pr_state is None
+    assert event.pr_merged is None
+    assert event.actor_type is None
+
+
+def test_normalize_issue_opened_propagates_issue_state_and_actor_type() -> None:
+    event = normalize_event(
+        "issues",
+        {
+            "action": "opened",
+            "repository": {"full_name": "acme/demo"},
+            "sender": {"login": "human", "type": "User"},
+            "issue": {"number": 42, "title": "t", "body": "b", "state": "open"},
+        },
+    )
+
+    assert event is not None
+    assert event.kind == "issue_opened"
+    assert event.issue_state == "open"
+    assert event.actor_type == "User"
+    assert event.pr_state is None
+    assert event.pr_merged is None
+
+
+def test_normalize_issue_comment_propagates_issue_state_closed_and_actor_type() -> None:
+    event = normalize_event(
+        "issue_comment",
+        {
+            "action": "created",
+            "repository": {"full_name": "acme/demo"},
+            "sender": {"login": "danibot", "type": "Bot"},
+            "issue": {"number": 11, "state": "closed", "title": "t"},
+            "comment": {"body": "still here?"},
+        },
+    )
+
+    assert event is not None
+    assert event.kind == "issue_comment"
+    assert event.issue_state == "closed"
+    assert event.actor_type == "Bot"
+
+
+def test_normalize_pull_request_opened_propagates_pr_state_and_merged_false() -> None:
+    event = normalize_event(
+        "pull_request",
+        {
+            "action": "opened",
+            "repository": {"full_name": "acme/demo"},
+            "sender": {"login": "human", "type": "User"},
+            "pull_request": {
+                "number": 21,
+                "title": "x",
+                "body": "y",
+                "state": "open",
+                "merged": False,
+                "base": {"ref": "dev"},
+                "head": {"ref": "f/#21", "sha": "abc"},
+            },
+        },
+    )
+
+    assert event is not None
+    assert event.pr_state == "open"
+    assert event.pr_merged is False
+    assert event.actor_type == "User"
+
+
+def test_normalize_pull_request_review_comment_propagates_pr_state() -> None:
+    event = normalize_event(
+        "pull_request_review_comment",
+        {
+            "action": "created",
+            "repository": {"full_name": "acme/demo"},
+            "sender": {"login": "human", "type": "User"},
+            "pull_request": {
+                "number": 30,
+                "title": "x",
+                "body": "y",
+                "state": "open",
+                "merged": False,
+                "base": {"ref": "dev"},
+                "head": {"ref": "f/#30", "sha": "deadbeef"},
+            },
+            "comment": {"body": "looks good"},
+        },
+    )
+
+    assert event is not None
+    assert event.kind == "pull_request_comment"
+    assert event.pr_state == "open"
+    assert event.pr_merged is False
+    assert event.actor_type == "User"
+
+
+def test_normalize_pull_request_closed_merged_event() -> None:
+    event = normalize_event(
+        "pull_request",
+        {
+            "action": "closed",
+            "repository": {"full_name": "acme/demo"},
+            "sender": {"login": "danibot", "type": "Bot"},
+            "pull_request": {
+                "number": 70,
+                "title": "Feature/#70",
+                "body": "Implements #58",
+                "state": "closed",
+                "merged": True,
+                "base": {"ref": "dev"},
+                "head": {"ref": "feature/#70", "sha": "deadbeef"},
+            },
+        },
+        delivery_id="d-70",
+    )
+
+    assert event is not None
+    assert event.kind == "pull_request_closed"
+    assert event.action == "closed"
+    assert event.pr_state == "closed"
+    assert event.pr_merged is True
+    assert event.actor_type == "Bot"
+    assert event.commit_sha == "deadbeef"
+    assert event.is_pull_request is True
+
+
+def test_normalize_pull_request_closed_unmerged_event() -> None:
+    event = normalize_event(
+        "pull_request",
+        {
+            "action": "closed",
+            "repository": {"full_name": "acme/demo"},
+            "sender": {"login": "human", "type": "User"},
+            "pull_request": {
+                "number": 71,
+                "title": "Feature/#71",
+                "body": "Implements #59",
+                "state": "closed",
+                "merged": False,
+                "base": {"ref": "dev"},
+                "head": {"ref": "feature/#71", "sha": "x"},
+            },
+        },
+    )
+
+    assert event is not None
+    assert event.kind == "pull_request_closed"
+    assert event.pr_state == "closed"
+    assert event.pr_merged is False


### PR DESCRIPTION
## Summary

PR #19 added `_is_pr_open` guards to dani's *signed* agent-event handlers in
`DaniService._handle_agent_event`, but the infinite PR-creation loop seen in
[`open-clone/openclone`](https://github.com/open-clone/openclone) (PRs #58–#70,
all closed by jeffrey on 2026-05-07) flowed through the *unsigned* branches in
`handle_event` (`dani/service.py` L207–L222), which still treated every
webhook for an already-closed issue or merged PR as live.

This PR closes the remaining gaps so an externally-closed issue or
GitHub-merged PR can no longer trigger another `implementation`,
`review_round`, or `issue_followup` job. The end-to-end regression
`test_followup_after_pr_merged_is_short_circuited_end_to_end` reproduces the
openclone scenario and proves the loop is broken.

## Why this happened (post-mortem)

1. PR `merged` → GitHub sends `push` to `main` → `_queue_dev_sync` ran fine.
2. dani's own bot left a comment on the source issue.
3. That comment came back as `issue_comment` → `_queue_issue_followup` had **no**
   actor filter, **no** closed-issue check, **no** max-rounds counter, so it
   spawned another agent that posted another comment, repeating ad infinitum.
4. Externally `/approve` on the same issue had **no** dedup, so the implementation
   job was queued every time.
5. `pull_request closed` was not even in the webhook whitelist, so dani had no
   way to learn 'this PR is finished' from GitHub at all.

## What this changes

### `dani/models.py`
- `NormalizedEvent` gains `issue_state`, `pr_state`, `pr_merged`, `actor_type`
  (all optional, defaulting to `None` — backward compatible).
- `DaniConfig` gains `bot_login` (env: `DANI_BOT_LOGIN`) and
  `max_issue_followups` (env: `DANI_MAX_ISSUE_FOLLOWUPS`, default `3`),
  plus a `terminal_targets_path` property.

### `dani/webhook.py`
- `normalize_event` now extracts `issue.state`, `pr.state`, `pr.merged`,
  `sender.type` on every supported event. Helpers split per event-kind to
  keep cyclomatic complexity within ruff `C901`.
- `pull_request action == "closed"` is now whitelisted as a new
  `pull_request_closed` event kind (distinct from `pull_request_opened`).
  This lets `handle_event` record terminal flags rather than enqueue review
  jobs.

### `dani/storage.py`
- `JsonStorage` gains `mark_terminal_pr` / `is_terminal_pr` /
  `mark_terminal_issue` / `is_terminal_issue`, persisted in a new
  `terminal-targets.json` file under the data dir
  (schema: `{prs: [{repo, pr, merged}], issues: [{repo, issue}]}`).
  Created lazily by `_ensure_layout`; existing data dirs upgrade in place.
- `snapshot()` includes the new file alongside `processed_events`.

### `dani/service.py`
- `handle_event` dispatches the four unsigned branches into per-kind helpers
  (`_dispatch_issue_opened`, `_dispatch_approve_comment`,
  `_dispatch_issue_followup_comment`, `_dispatch_pull_request_opened`) that
  short-circuit when:
  - `issue_state == "closed"` → `issue_closed`
  - `storage.is_terminal_issue` → `issue_terminal`
  - `issue_opened action == "reopened"` → `issue_reopened_no_op`
  - `/approve` already produced an implementation job → `duplicate_implementation`
    (via new `_has_existing_implementation_job`)
  - `issue_comment` author matches `DANI_BOT_LOGIN`, or `actor_type == "Bot"`
    when `bot_login` is unset → `self_authored_comment`
    (via new `_is_dani_self_authored`)
  - completed/queued `issue_followup` count >= `max_issue_followups` →
    `max_followups_reached` (via new `_completed_followup_count`)
  - `pr_merged is True` → `pr_merged`
  - `pr_state == "closed"` → `pr_not_open`
  - `storage.is_terminal_pr` → `pr_terminal`
- New `_handle_pull_request_closed` records terminal-PR flag and (when merged)
  terminal-issue flag using `_extract_issue_number(event.body)`.

### `dani/cli.py`
- `build_config` reads `DANI_BOT_LOGIN`, `DANI_MAX_ISSUE_FOLLOWUPS`
  (with `config.json` fallbacks) and forwards them to `DaniConfig`.

## Test plan

35 new tests, TDD-first:

- `tests/test_webhook.py` — 6 new tests for state propagation and the new
  `pull_request_closed` kind (closed+merged, closed+unmerged).
- `tests/test_storage.py` — 5 new tests for the terminal-target API
  (mark/query, idempotency, persistence across instances, snapshot payload).
- `tests/test_cli.py` — 6 new tests for env/config wiring of `bot_login` and
  `max_issue_followups`.
- `tests/test_service.py` — 17 new tests covering all four unsigned-branch
  guards plus the **end-to-end regression**
  `test_followup_after_pr_merged_is_short_circuited_end_to_end` that
  reproduces the openclone loop: a `pull_request_closed` with `merged=true`
  blocks subsequent `issue_followup` events on the source issue.

## Verification (run locally on this branch tip)

| Check | Result |
|---|---|
| `uv run pytest -q` | **270 passed**, 2 skipped (was 235 + 2 on `origin/main`) |
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 40 files already formatted |
| `uv run ty check` | All checks passed |
| `uv run python -m pytest --doctest-modules` | 270 passed, 2 skipped |
| `uv lock --locked` | Resolved 60 packages, no drift |
| `uv run deptry .` | No dependency issues |

### Manual QA

A scripted end-to-end QA replays the openclone scenario through fake webhook
payloads. With this branch checked out, all five steps short-circuit and the
`FakeOmxRunner` records **zero** launches/resumes:

1. `pull_request closed merged` → `{status: marked_terminal, pr_number: 70, merged: True}`
2. `issue_comment` on source issue → `{status: ignored, reason: issue_terminal}`
3. `/approve` on a closed issue → `{status: ignored, reason: issue_closed}`
4. bot self-authored `issue_comment` → `{status: ignored, reason: self_authored_comment}`
5. `pull_request_opened` on a terminal PR → `{status: ignored, reason: pr_terminal}`

## Backward compatibility

- All new `NormalizedEvent` fields default to `None`; existing tests that
  build events without them continue to pass unchanged (the existing
  signed-agent-event tests still cover the same rows untouched).
- `bot_login` defaults to `None`, with fallback to `actor_type == "Bot"` for
  GitHub-App-installed bots.
- `terminal-targets.json` is created lazily; existing data dirs upgrade on
  next start.

## Configuration

| Setting | Source | Default |
|---|---|---|
| `bot_login` | `DANI_BOT_LOGIN` env (preferred) or `~/.dani/config.json` `bot_login` | `None` |
| `max_issue_followups` | `DANI_MAX_ISSUE_FOLLOWUPS` env or `~/.dani/config.json` `max_issue_followups` | `3` |

## Out of scope

- Signed agent-event handlers from PR #19 already have `_is_pr_open` —
  those unchanged.
- `_queue_dev_sync` already has dedup via `_has_existing_dev_sync_job` —
  unchanged.
- The agent prompt that made dani's own bot post repeated comments
  (`prompts.py issue_followup`) is not edited here; that's a separate UX/QA
  improvement. Once `bot_login` is set, those bot comments are filtered
  before they ever reach `_queue_issue_followup`.