### PR TITLE
feat: owner-only /approve gate + single-round triage for untracked external PRs

### DIFF
--- a/dani/github.py
+++ b/dani/github.py
@@ -158,6 +158,27 @@ class GitHubCLI:
             return pull_request.raw_data
         return repo.create_pull(title=title, body=body, base=base, head=head).raw_data
 
+    def is_org_member(self, org: str, username: str) -> bool:
+        if not org or not username:
+            return False
+        client = self._client_for_request()
+        try:
+            organization = client.get_organization(org)
+            user = client.get_user(username)
+        except UnknownObjectException:
+            return False
+        try:
+            return bool(organization.has_in_members(user))
+        except UnknownObjectException:
+            return False
+
+    def add_issue_comment_reaction(
+        self, repo_full_name: str, issue_number: int, comment_id: int, reaction: str
+    ) -> None:
+        issue = self._repo(repo_full_name).get_issue(issue_number)
+        comment = issue.get_comment(comment_id)
+        comment.create_reaction(reaction)
+
     def merge_pull_request(self, repo_full_name: str, pr_number: int) -> None:
         pull_request = self._repo(repo_full_name).get_pull(pr_number)
         try:

--- a/dani/service.py
+++ b/dani/service.py
@@ -238,9 +238,60 @@ class DaniService:
             return {"status": "ignored", "reason": "issue_closed"}
         if self.storage.is_terminal_issue(repo.full_name, event.number):
             return {"status": "ignored", "reason": "issue_terminal"}
+        if not self._is_authorized_approver(repo, event):
+            self._react_unauthorized_approve(repo, event)
+            return {"status": "ignored", "reason": "approver_not_authorized"}
         if self._has_existing_implementation_job(repo.full_name, event.number):
             return {"status": "ignored", "reason": "duplicate_implementation"}
         return self._queue_implementation(repo, event)
+
+    _TRUSTED_APPROVE_AUTHOR_ASSOCIATIONS = frozenset({"OWNER", "MEMBER"})
+
+    def _is_authorized_approver(self, repo: RepoConfig, event: NormalizedEvent) -> bool:
+        owner_login = repo.full_name.split("/", 1)[0]
+        actor = event.actor_login or ""
+        if not actor:
+            return False
+        if actor.casefold() == owner_login.casefold():
+            return True
+        comment = event.payload.get("comment") if isinstance(event.payload, dict) else None
+        author_association = ""
+        if isinstance(comment, dict):
+            author_association = str(comment.get("author_association") or "").upper()
+        if author_association in self._TRUSTED_APPROVE_AUTHOR_ASSOCIATIONS:
+            return True
+        try:
+            return bool(self.github.is_org_member(owner_login, actor))
+        except Exception:
+            logger.warning(
+                "approve_owner_check_failed",
+                extra={
+                    "repo_full_name": repo.full_name,
+                    "owner_login": owner_login,
+                    "actor_login": actor,
+                },
+                exc_info=True,
+            )
+            return False
+
+    def _react_unauthorized_approve(self, repo: RepoConfig, event: NormalizedEvent) -> None:
+        comment = event.payload.get("comment") if isinstance(event.payload, dict) else None
+        comment_id = comment.get("id") if isinstance(comment, dict) else None
+        if not isinstance(comment_id, int):
+            return
+        try:
+            self.github.add_issue_comment_reaction(repo.full_name, event.number, comment_id, "-1")
+        except Exception:
+            logger.warning(
+                "approve_unauthorized_reaction_failed",
+                extra={
+                    "repo_full_name": repo.full_name,
+                    "issue_number": event.number,
+                    "actor_login": event.actor_login,
+                    "comment_id": comment_id,
+                },
+                exc_info=True,
+            )
 
     def _dispatch_issue_followup_comment(self, repo: RepoConfig, event: NormalizedEvent) -> dict[str, Any]:
         if event.issue_state == "closed":
@@ -1973,11 +2024,7 @@ class DaniService:
         review_round_cap = 1 if untracked else self.config.review_rounds
 
         if len(consumed_review_rounds) >= review_round_cap:
-            reason = (
-                "untracked_external_review_round_consumed"
-                if untracked
-                else "external_review_rounds_exhausted"
-            )
+            reason = "untracked_external_review_round_consumed" if untracked else "external_review_rounds_exhausted"
             return {"status": "ignored", "reason": reason}
 
         next_review_round = max(consumed_review_rounds, default=0) + 1

--- a/dani/service.py
+++ b/dani/service.py
@@ -1927,9 +1927,9 @@ class DaniService:
             )
             return {"status": "queued", "job_id": job.id, "stage": job.stage}
 
-        if issue_number is None:
-            return {"status": "ignored", "reason": "untracked_pr"}
-        return self._queue_external_pull_request_review(repo, event, issue_number=issue_number)
+        return self._queue_external_pull_request_review(
+            repo, event, issue_number=issue_number, untracked=issue_number is None
+        )
 
     def _external_pull_request_guard(
         self, repo: RepoConfig, event: NormalizedEvent, *, is_agent_managed_pr: bool
@@ -1962,29 +1962,39 @@ class DaniService:
         repo: RepoConfig,
         event: NormalizedEvent,
         *,
-        issue_number: int,
+        issue_number: int | None,
+        untracked: bool = False,
     ) -> dict[str, Any]:
         event_key = self._external_pull_request_event_key(event)
         if not self.storage.record_processed_event(event_key):
             return {"status": "ignored", "reason": "duplicate_external_pr_event"}
 
         consumed_review_rounds = self._consumed_external_review_rounds(event.repo_full_name, event.number)
+        review_round_cap = 1 if untracked else self.config.review_rounds
 
-        if len(consumed_review_rounds) >= self.config.review_rounds:
-            return {"status": "ignored", "reason": "external_review_rounds_exhausted"}
+        if len(consumed_review_rounds) >= review_round_cap:
+            reason = (
+                "untracked_external_review_round_consumed"
+                if untracked
+                else "external_review_rounds_exhausted"
+            )
+            return {"status": "ignored", "reason": reason}
 
         next_review_round = max(consumed_review_rounds, default=0) + 1
+        metadata: dict[str, Any] = {
+            "title": event.title or "",
+            "body": event.body or "",
+            **self._external_pr_metadata(event),
+        }
+        if untracked:
+            metadata["untracked"] = True
         job = self._enqueue_job(
             repo,
             stage="review_round",
             issue_number=issue_number,
             pr_number=event.number,
             review_round=next_review_round,
-            metadata={
-                "title": event.title or "",
-                "body": event.body or "",
-                **self._external_pr_metadata(event),
-            },
+            metadata=metadata,
         )
         return {"status": "queued", "job_id": job.id, "stage": job.stage}
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -24,6 +24,9 @@ class FakeGitHubCLI:
         self.issue_labels: dict[tuple[str, int], list[str]] = {}
         self.users: dict[str, dict[str, Any]] = {}
         self.closed_pull_requests: list[tuple[str, int]] = []
+        self.org_members_by_casefolded_org: dict[str, set[str]] = {}
+        self.recorded_issue_comment_reactions: list[tuple[str, int, str]] = []
+        self.simulated_reaction_failure: Exception | None = None
 
     def list_open_issues(self, repo_full_name: str) -> list[dict[str, Any]]:
         return list(self.open_issues.get(repo_full_name, []))
@@ -142,6 +145,24 @@ class FakeGitHubCLI:
             if pr.get("number") == pr_number:
                 pr["state"] = "closed"
                 return
+
+    def register_org_member(self, org: str, username: str) -> None:
+        self.org_members_by_casefolded_org.setdefault(org.casefold(), set()).add(username.casefold())
+
+    def is_org_member(self, org: str, username: str) -> bool:
+        if not org or not username:
+            return False
+        members = self.org_members_by_casefolded_org.get(org.casefold())
+        if not members:
+            return False
+        return username.casefold() in members
+
+    def add_issue_comment_reaction(
+        self, repo_full_name: str, issue_number: int, comment_id: int, reaction: str
+    ) -> None:
+        if self.simulated_reaction_failure is not None:
+            raise self.simulated_reaction_failure
+        self.recorded_issue_comment_reactions.append((repo_full_name, issue_number, comment_id, reaction))
 
 
 class LaunchRecord(TypedDict):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -25,7 +25,7 @@ class FakeGitHubCLI:
         self.users: dict[str, dict[str, Any]] = {}
         self.closed_pull_requests: list[tuple[str, int]] = []
         self.org_members_by_casefolded_org: dict[str, set[str]] = {}
-        self.recorded_issue_comment_reactions: list[tuple[str, int, str]] = []
+        self.recorded_issue_comment_reactions: list[tuple[str, int, int, str]] = []
         self.simulated_reaction_failure: Exception | None = None
 
     def list_open_issues(self, repo_full_name: str) -> list[dict[str, Any]]:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -329,3 +329,122 @@ def test_merge_pull_request_allows_branch_delete_failure_after_success(fake_repo
 
     assert fake_repo.pulls[7].merged is True
     assert fake_repo.pulls[7].delete_branch_calls == 1
+
+
+class FakeIssueComment:
+    def __init__(self, comment_id: int) -> None:
+        self.id = comment_id
+        self.created_reactions: list[str] = []
+
+    def create_reaction(self, reaction_type: str) -> dict[str, str]:
+        self.created_reactions.append(reaction_type)
+        return {"content": reaction_type}
+
+
+class FakeNamedUser:
+    def __init__(self, login: str) -> None:
+        self.login = login
+        self._identity = login
+
+
+class FakeOrganization:
+    def __init__(self, login: str, members: set[str] | None = None) -> None:
+        self.login = login
+        self._members: set[str] = set(members or set())
+
+    def has_in_members(self, user: FakeNamedUser) -> bool:
+        return user.login in self._members
+
+
+class _OrgClient:
+    def __init__(
+        self,
+        repo: FakeRepo,
+        *,
+        org: FakeOrganization | None = None,
+        org_lookup_error: Exception | None = None,
+        user_lookup_error: Exception | None = None,
+    ) -> None:
+        self.repo = repo
+        self._org = org
+        self._org_lookup_error = org_lookup_error
+        self._user_lookup_error = user_lookup_error
+        self.requested_orgs: list[str] = []
+        self.requested_users: list[str] = []
+        self.requested_repos: list[str] = []
+
+    def get_repo(self, repo_full_name: str) -> FakeRepo:
+        self.requested_repos.append(repo_full_name)
+        return self.repo
+
+    def get_organization(self, org_login: str) -> FakeOrganization:
+        self.requested_orgs.append(org_login)
+        if self._org_lookup_error is not None:
+            raise self._org_lookup_error
+        if self._org is None:
+            raise UnknownObjectException(status=404, data={"message": "Not Found"}, headers={})
+        return self._org
+
+    def get_user(self, login: str) -> FakeNamedUser:
+        self.requested_users.append(login)
+        if self._user_lookup_error is not None:
+            raise self._user_lookup_error
+        return FakeNamedUser(login)
+
+
+def test_is_org_member_returns_true_when_user_is_in_org(fake_repo: FakeRepo) -> None:
+    org = FakeOrganization("nomadamas", members={"alice", "bob"})
+    client = _OrgClient(fake_repo, org=org)
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: client)
+
+    assert github.is_org_member("nomadamas", "alice") is True
+    assert client.requested_orgs == ["nomadamas"]
+    assert client.requested_users == ["alice"]
+
+
+def test_is_org_member_returns_false_when_user_is_not_in_org(fake_repo: FakeRepo) -> None:
+    org = FakeOrganization("nomadamas", members={"alice"})
+    client = _OrgClient(fake_repo, org=org)
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: client)
+
+    assert github.is_org_member("nomadamas", "stranger") is False
+
+
+def test_is_org_member_returns_false_when_org_does_not_exist(fake_repo: FakeRepo) -> None:
+    client = _OrgClient(fake_repo, org=None)
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: client)
+
+    assert github.is_org_member("user-not-org", "alice") is False
+
+
+def test_is_org_member_returns_false_for_blank_username(fake_repo: FakeRepo) -> None:
+    org = FakeOrganization("nomadamas", members={"alice"})
+    client = _OrgClient(fake_repo, org=org)
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: client)
+
+    assert github.is_org_member("nomadamas", "") is False
+    assert client.requested_orgs == []
+    assert client.requested_users == []
+
+
+def test_is_org_member_returns_false_when_user_lookup_404s(fake_repo: FakeRepo) -> None:
+    org = FakeOrganization("nomadamas", members={"alice"})
+    client = _OrgClient(
+        fake_repo,
+        org=org,
+        user_lookup_error=UnknownObjectException(status=404, data={"message": "Not Found"}, headers={}),
+    )
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: client)
+
+    assert github.is_org_member("nomadamas", "ghost") is False
+
+
+def test_add_issue_comment_reaction_calls_create_reaction(fake_repo: FakeRepo) -> None:
+    fake_comment = FakeIssueComment(comment_id=999)
+    issue = fake_repo.issues[5]
+    issue.get_comment = lambda comment_id: fake_comment if comment_id == 999 else None  # type: ignore[attr-defined,assignment]
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    github.add_issue_comment_reaction("acme/demo", 5, 999, "-1")
+
+    assert fake_comment.created_reactions == ["-1"]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -869,8 +869,8 @@ def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
         repo_full_name="acme/demo",
         action="created",
         number=11,
-        actor_login="human",
-        payload={"issue": {"body": "context"}},
+        actor_login="acme",
+        payload={"issue": {"body": "context"}, "comment": {"id": 1, "author_association": "OWNER"}},
         body="/approve",
         title="Need automation",
     )
@@ -881,6 +881,204 @@ def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
     assert result["stage"] == "implementation"
     assert omx_runner.launches[0]["job"].stage == "implementation"
     assert service.storage.list_jobs()[0].status == "completed"
+
+
+def test_approve_from_repo_owner_login_queues_implementation(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=21,
+            actor_login="ACME",
+            payload={"issue": {"body": "context"}, "comment": {"id": 100}},
+            body="/approve",
+            title="Owner approval",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result["stage"] == "implementation"
+    assert omx_runner.launches[0]["job"].stage == "implementation"
+    assert github.recorded_issue_comment_reactions == []
+
+
+def test_approve_with_owner_author_association_queues_implementation(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=22,
+            actor_login="some-account",
+            payload={
+                "issue": {"body": "context"},
+                "comment": {"id": 101, "author_association": "OWNER"},
+            },
+            body="/approve",
+            title="Author association OWNER",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result["stage"] == "implementation"
+    assert omx_runner.launches[0]["job"].stage == "implementation"
+    assert github.recorded_issue_comment_reactions == []
+
+
+def test_approve_with_member_author_association_queues_without_membership_api_call(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=23,
+            actor_login="alice",
+            payload={
+                "issue": {"body": "context"},
+                "comment": {"id": 102, "author_association": "MEMBER"},
+            },
+            body="/approve",
+            title="Author association MEMBER",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result["stage"] == "implementation"
+    assert omx_runner.launches[0]["job"].stage == "implementation"
+    assert github.org_members_by_casefolded_org == {}
+    assert github.recorded_issue_comment_reactions == []
+
+
+def test_approve_from_org_member_queues_implementation(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.register_org_member("acme", "alice")
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=24,
+            actor_login="ALICE",
+            payload={
+                "issue": {"body": "context"},
+                "comment": {"id": 103, "author_association": "NONE"},
+            },
+            body="/approve",
+            title="Member fallthrough",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result["stage"] == "implementation"
+    assert omx_runner.launches[0]["job"].stage == "implementation"
+    assert github.recorded_issue_comment_reactions == []
+
+
+def test_approve_from_unauthorized_actor_is_ignored_with_thumbs_down_reaction(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.register_org_member("acme", "alice")
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=25,
+            actor_login="malicious-user",
+            payload={
+                "issue": {"body": "context"},
+                "comment": {"id": 12345, "author_association": "CONTRIBUTOR"},
+            },
+            body="/approve",
+            title="Unauthorized approve",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "approver_not_authorized"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", issue_number=25) == []
+    assert omx_runner.launches == []
+    assert github.recorded_issue_comment_reactions == [("acme/demo", 25, 12345, "-1")]
+
+
+def test_approve_from_collaborator_is_ignored(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=26,
+            actor_login="outside-collab",
+            payload={
+                "issue": {"body": "context"},
+                "comment": {"id": 200, "author_association": "COLLABORATOR"},
+            },
+            body="/approve",
+            title="Collaborator approve",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "approver_not_authorized"}
+    assert omx_runner.launches == []
+    assert github.recorded_issue_comment_reactions == [("acme/demo", 26, 200, "-1")]
+
+
+def test_approve_unauthorized_skips_reaction_when_comment_id_missing(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=27,
+            actor_login="malicious-user",
+            payload={"issue": {"body": "context"}},
+            body="/approve",
+            title="Missing comment id",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "approver_not_authorized"}
+    assert omx_runner.launches == []
+    assert github.recorded_issue_comment_reactions == []
+
+
+def test_approve_unauthorized_swallows_reaction_failure(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.simulated_reaction_failure = RuntimeError("github outage")
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=28,
+            actor_login="malicious-user",
+            payload={
+                "issue": {"body": "context"},
+                "comment": {"id": 999, "author_association": "NONE"},
+            },
+            body="/approve",
+            title="Reaction outage",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "approver_not_authorized"}
+    assert omx_runner.launches == []
 
 
 def test_failed_job_still_closes_runtime_handle_and_marks_failure(tmp_path: Path) -> None:
@@ -904,8 +1102,8 @@ def test_pr_opened_from_implementation_signature_queues_review_round(tmp_path: P
         repo_full_name="acme/demo",
         action="created",
         number=12,
-        actor_login="human",
-        payload={"issue": {"body": "Ship it"}},
+        actor_login="acme",
+        payload={"issue": {"body": "Ship it"}, "comment": {"id": 1, "author_association": "OWNER"}},
         body="/approve",
         title="Ship it",
     )
@@ -3394,8 +3592,8 @@ def test_second_approve_for_same_issue_is_deduplicated(tmp_path: Path) -> None:
         repo_full_name="acme/demo",
         action="created",
         number=13,
-        actor_login="h",
-        payload={"issue": {"body": "x"}},
+        actor_login="acme",
+        payload={"issue": {"body": "x"}, "comment": {"id": 1, "author_association": "OWNER"}},
         body="/approve",
         title="t",
         issue_state="open",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2223,8 +2223,7 @@ def test_final_verdict_stops_when_pr_is_closed(tmp_path: Path) -> None:
     assert github.merged == []
 
 
-def test_pr_opened_without_issue_reference_is_ignored(tmp_path: Path) -> None:
-    """A PR opened without any linked issue number is dropped as untracked."""
+def test_pr_opened_without_issue_reference_queues_single_review_round(tmp_path: Path) -> None:
     service, _, omx_runner = make_service(tmp_path)
 
     result = service.handle_event(
@@ -2242,10 +2241,102 @@ def test_pr_opened_without_issue_reference_is_ignored(tmp_path: Path) -> None:
             is_pull_request=True,
         )
     )
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=42)
+    assert [job.review_round for job in review_jobs] == [1]
+    assert review_jobs[0].issue_number is None
+    assert review_jobs[0].metadata.get("untracked") is True
+    assert review_jobs[0].metadata.get("external_contribution") is True
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_untracked_external_pr_caps_at_one_review_round(tmp_path: Path) -> None:
+    service, _, _ = make_service(tmp_path)
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=42,
+            actor_login="external-contributor",
+            payload={},
+            body="Some changes without issue reference",
+            title="External contribution",
+            base_branch="dev",
+            head_branch="feature/external",
+            commit_sha="sha-initial",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    second = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="synchronize",
+            number=42,
+            actor_login="external-contributor",
+            payload={},
+            body="Some changes without issue reference",
+            title="External contribution",
+            base_branch="dev",
+            head_branch="feature/external",
+            commit_sha="sha-followup",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    assert second == {"status": "ignored", "reason": "untracked_external_review_round_consumed"}
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=42)
+    assert [job.review_round for job in review_jobs] == [1]
+
+
+def test_untracked_external_pr_review_round_does_not_spawn_implementation(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=42,
+            actor_login="external-contributor",
+            payload={},
+            body="Some changes without issue reference",
+            title="External contribution",
+            base_branch="dev",
+            head_branch="feature/external",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=42)
+    assert len(review_jobs) == 1
+    job_id = review_jobs[0].id
+
+    review_signature_event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=42,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="review_round", job=job_id, pr=42, round=1),
+        title="External contribution",
+        is_pull_request=True,
+    )
+    result = service.handle_event(review_signature_event)
+    service.wait_for_idle()
 
     assert result == {"status": "ignored", "reason": "untracked_pr"}
-    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=42) == []
-    assert omx_runner.launches == []
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=42) == []
+    assert all(launch["job"].stage != "implementation" for launch in omx_runner.launches)
 
 
 def test_review_round_without_issue_drops_untracked_pr(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Two related improvements to event handling, in two reviewable commits:

1. **\`feat: queue single review round for untracked external PRs\`** (\`dc97afb\`)
   External PRs without an issue reference were dropped at intake with reason \`untracked_pr\`. They now get exactly one review round so the agent can post triage feedback, then stop. Implementation never spawns (review-round signature events still bail with \`untracked_pr\`), and any subsequent push/synchronize is rejected with the new \`untracked_external_review_round_consumed\` reason. Job metadata gains \`untracked: true\` so downstream prompts/metrics can distinguish best-effort review jobs.

2. **\`feat: gate /approve to repo owner and owner-org members\`** (\`1835c3e\`)
   Until now, any GitHub user could trigger the implementation pipeline by posting \`/approve\` on an issue. The trigger is now restricted to the literal repository owner login OR members of the repository's owning organization.

## Owner-only /approve auth model

Layered, fail-closed:

1. \`actor_login\` casefold-matches the owner segment of \`repo.full_name\` (covers user-owned repos and the case where an org owner login matches).
2. \`comment.author_association\` is \`OWNER\` or \`MEMBER\` on the webhook payload — trusted because it comes from the verified-signature webhook.
3. PyGithub \`Organization.has_in_members()\` lookup against the owner-org. Returns False on \`UnknownObjectException\` so user-owned repos and missing accounts both fail closed.

Unauthorized \`/approve\` comments leave a single 👎 reaction on the comment and return \`{'status': 'ignored', 'reason': 'approver_not_authorized'}\`. Reaction failures are logged and swallowed (reactions are UX feedback, not part of the security contract). Comments without a numeric \`comment.id\` skip the reaction gracefully.

The auth check is placed:
- **after** \`issue_closed\` / \`issue_terminal\` guards so the existing 'do not touch closed/terminal issues' contract holds
- **before** the duplicate-implementation guard so an unauthorized actor cannot probe queue state via the response

## Why no \`COLLABORATOR\` allowance

The user requirement was 'repo owner or org members'. \`COLLABORATOR\` would let outside collaborators (added repo-by-repo, no org membership) trigger \`/approve\`. Excluded by design. Add a config field if a future requirement needs it.

## Why no new \`RepoConfig\` field

The owner segment of \`repo.full_name\` is enough to enforce the rule. No \`approver_org\` / \`approve_allowlist\` field added — keep config surface minimal until a real override case appears.

## Test changes

| Suite | Added | Modified |
|---|---|---|
| \`tests/test_github.py\` | 6 (org-membership variants + reaction call) | 0 |
| \`tests/test_service.py\` | 7 (gating end-to-end) + 3 (untracked PR feature) | 3 (\`actor_login\` updated to authorized values) |

\`FakeGitHubCLI\` gained explicit \`register_org_member()\` (no default-allow) and a \`recorded_issue_comment_reactions\` recorder.

## Verification

\`\`\`
$ uv run pytest -q
293 passed, 2 skipped in 3.17s

$ ruff check dani tests
All checks passed!

$ ruff format --check dani tests
39 files already formatted
\`\`\`

Manual end-to-end QA (FakeGitHubCLI, repo \`NomaDamas/dani\`):
- owner literal match → queued
- \`OWNER\` association → queued
- \`MEMBER\` association → queued (no API call)
- org member via API fallback → queued
- non-member with thumbs-down → ignored, 👎 recorded
- COLLABORATOR → ignored, 👎 recorded
- missing comment id → ignored, no reaction (graceful)
- closed issue → still short-circuits before auth check
- reaction failure → logged and swallowed, status still ignored

## Notes for reviewer

- Both commits are independently revertable. Auth gating depends only on the owner-segment of \`repo.full_name\` and standard PyGithub paths — no shared state with the untracked-PR change.
- New PyGithub paths used: \`Organization.has_in_members(NamedUser)\`, \`Repository.get_issue(n).get_comment(id).create_reaction('-1')\`. Both verified to exist on the installed PyGithub version.