### PR TITLE
feat: dani doctor — read-only health diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,83 @@ dani register-repo owner/name /absolute/path/to/repo
 dani serve --data-dir .dani
 dani bootstrap owner/name
 dani show-state
+dani doctor
 ```
+
+## dani doctor
+
+`dani doctor` runs read-only health diagnostics against a dani installation.
+It is safe to run while `dani serve` is live on the same machine: doctor never
+writes to `~/.dani/`, never binds the webhook port, never spawns runners or
+competes with the serve process for storage locks, and never echoes any value
+of `DANI_WEBHOOK_SECRET`/`DANI_GITHUB_TOKEN`/`GITHUB_TOKEN`/`GH_TOKEN`/
+`GITHUB_PAT` or any raw `ps` argv.
+
+```bash
+# Run every check; human-readable output.
+dani doctor
+
+# Machine-readable JSON for monitoring / CI.
+dani doctor --json | jq
+
+# Run a subset of checks.
+dani doctor --check stuck_sessions --check disk_usage --json
+
+# Treat warnings as exit 1 (e.g., in CI gates).
+dani doctor --strict
+
+# Override default thresholds (strict allow-list of keys).
+dani doctor --threshold runs_bytes_warn=10000000000 --threshold stuck_job_age_seconds=7200
+
+# Probe a non-default webhook port (default: DANI_PORT env or 8787).
+dani doctor --check server_health --port 8000
+
+# Write the report to a file outside ~/.dani/.
+dani doctor --json --output /tmp/dani-report.json
+```
+
+### Checks
+
+| Name | Description |
+|---|---|
+| `config_env` | webhook secret, GitHub token, agent runtime, config.json parse status |
+| `binaries` | `git`, `gh`, plus runtime-specific `omx`/`codex` or `opencode` (skips opencode if `DANI_OPENCODE_SERVER_URL` is set) |
+| `storage_files` | parse-ability of `registry.json`/`jobs.json`/`sessions.json`/`processed-events.json`/`terminal-targets.json`; tolerates one transient parse error per file plus an `events.jsonl` last-line append race |
+| `registered_repos` | each registered repo's `local_path` is a git working tree and resolves both `main_branch` and `dev_branch` |
+| `github_auth` | resolves the GitHub token, verifies it with the minimum `Github.get_rate_limit()` call, reports rate-limit headroom; never echoes the token, only its source env-var name |
+| `server_health` | if `127.0.0.1:<port>` is listening, GET `/health` and compare to `{"status":"ok"}`; SKIP (not FAIL) when no local server |
+| `stuck_jobs` | warns when active jobs (`queued`/`launched`/`retrying`/`recovering`) are older than `stuck_job_age_seconds` (default = `agent_timeout_seconds`) |
+| `stuck_sessions` | FAILs on confirmed A-class drift (session `launched` while linked job is terminal — re-validated with a 100ms re-snapshot and a 60s grace window); WARNs on long-running launches and orphans |
+| `disk_usage` | size of each storage file plus a soft-deadlined walk of `runs/`; thresholds for warn/fail per target |
+| `backup_files` | accumulated `*.bak.*` files in `data_dir`: count / oldest age / total bytes |
+| `process_sprawl` | counts alive `omx exec` / `opencode serve` / `opencode run` processes; reports only PID/PPID/etime/classifier — never raw argv |
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | overall `ok` (warnings allowed without `--strict`; also returned when every check skipped) |
+| `1` | overall `warn` AND `--strict` |
+| `2` | overall `fail` (any check failed, or invalid CLI option) |
+| `3` | `dani doctor` itself crashed (unhandled exception); sanitized error to stderr, redacted traceback only with `--verbose` |
+
+### JSON schema
+
+`dani doctor --json` emits a stable schema:
+
+```json
+{
+  "schema_version": 1,
+  "started_at": "...", "finished_at": "...",
+  "data_dir": "...",
+  "host": {"port": 8787, "platform": "darwin", "python_version": "3.13.0", "dani_version": "0.0.1"},
+  "overall_status": "ok|warn|fail|skip",
+  "summary": {"ok": N, "warn": N, "fail": N, "skip": N},
+  "results": [{"name": "...", "status": "...", "summary": "...", "details": {...}, "duration_ms": N, "error": null}]
+}
+```
+
+If the schema needs to change, `schema_version` is bumped.
 
 ## Persistence
 State is stored under `~/.dani/` by default:

--- a/dani/cli.py
+++ b/dani/cli.py
@@ -2,11 +2,25 @@ from __future__ import annotations
 
 import json
 import os
+import sys
+import traceback
 from pathlib import Path
 
 import typer
 import uvicorn
 
+from dani import doctor as doctor_module
+from dani.doctor import (
+    CheckStatus,
+    _OutputPathError,
+    _ThresholdParseError,
+    format_json,
+    format_text,
+    parse_thresholds,
+    resolve_port,
+    run_doctor,
+    validate_output_path,
+)
 from dani.models import DEFAULT_AGENT_TIMEOUT_SECONDS, DEFAULT_MAX_ISSUE_FOLLOWUPS, DaniConfig
 from dani.server import create_app
 from dani.service import DaniService
@@ -171,3 +185,110 @@ def restart_issue(
     job = service.restart_issue(repo_full_name, issue_number)
     service.wait_for_idle()
     typer.echo(json.dumps(job.to_dict(), ensure_ascii=False, indent=2))
+
+
+DOCTOR_JSON_OPTION = typer.Option(False, "--json", "-j", help="Emit JSON instead of text.")
+DOCTOR_CHECK_OPTION = typer.Option(None, "--check", help="Restrict to the named check. Repeatable.")
+DOCTOR_VERBOSE_OPTION = typer.Option(False, "--verbose", "-v", help="Include per-check details.")
+DOCTOR_STRICT_OPTION = typer.Option(False, "--strict", help="Treat warnings as exit 1.")
+DOCTOR_TIMEOUT_OPTION = typer.Option(5.0, "--timeout", help="Per-check soft deadline in seconds.")
+DOCTOR_PORT_OPTION = typer.Option(None, "--port", help="Port for server_health probe (default: DANI_PORT env or 8787).")
+DOCTOR_OUTPUT_OPTION = typer.Option(
+    None, "--output", help="Write report to PATH instead of stdout. Must NOT be under data_dir."
+)
+DOCTOR_THRESHOLD_OPTION = typer.Option(
+    None,
+    "--threshold",
+    help="Override threshold as KEY=VALUE (repeatable; strict allow-list).",
+)
+
+
+def _doctor_exit_code(overall: CheckStatus, strict: bool) -> int:
+    if overall == CheckStatus.FAIL:
+        return 2
+    if overall == CheckStatus.WARN and strict:
+        return 1
+    return 0
+
+
+def _doctor_render(report, *, json_output: bool, verbose: bool, no_color: bool, output_path: Path | None) -> str:
+    if json_output:
+        return format_json(report)
+    use_color = (not no_color) and sys.stdout.isatty() and output_path is None
+    return format_text(report, verbose=verbose, use_color=use_color)
+
+
+def _doctor_parse_options(
+    *,
+    threshold: list[str] | None,
+    output: Path | None,
+    data_dir: Path,
+    port: int | None,
+) -> tuple[dict[str, int], Path | None, int]:
+    try:
+        thresholds = parse_thresholds(list(threshold or []))
+    except _ThresholdParseError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    try:
+        resolved_output = validate_output_path(output, data_dir)
+    except _OutputPathError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    resolved_port = resolve_port(port, os.environ)
+    return thresholds, resolved_output, resolved_port
+
+
+@app.command("doctor")
+def doctor(
+    data_dir: Path = DATA_DIR_OPTION,
+    json_output: bool = DOCTOR_JSON_OPTION,
+    check: list[str] | None = DOCTOR_CHECK_OPTION,
+    verbose: bool = DOCTOR_VERBOSE_OPTION,
+    strict: bool = DOCTOR_STRICT_OPTION,
+    timeout: float = DOCTOR_TIMEOUT_OPTION,
+    port: int | None = DOCTOR_PORT_OPTION,
+    output: Path | None = DOCTOR_OUTPUT_OPTION,
+    threshold: list[str] | None = DOCTOR_THRESHOLD_OPTION,
+) -> None:
+    """Run read-only health diagnostics on a dani installation."""
+    _ = doctor_module
+    try:
+        thresholds, resolved_output, resolved_port = _doctor_parse_options(
+            threshold=threshold, output=output, data_dir=data_dir, port=port
+        )
+        no_color = bool(os.environ.get("NO_COLOR"))
+        report = run_doctor(
+            data_dir=data_dir,
+            check_names=list(check) if check else None,
+            verbose=verbose,
+            timeout=timeout,
+            thresholds=thresholds,
+            port=resolved_port,
+            env=os.environ,
+            no_color=no_color,
+        )
+        rendered = _doctor_render(
+            report,
+            json_output=json_output,
+            verbose=verbose,
+            no_color=no_color,
+            output_path=resolved_output,
+        )
+        if resolved_output is not None:
+            resolved_output.write_text(rendered + "\n", encoding="utf-8")
+        else:
+            typer.echo(rendered)
+        raise typer.Exit(_doctor_exit_code(report.overall_status, strict))  # noqa: TRY301
+    except (typer.Exit, typer.BadParameter):
+        raise
+    except Exception as exc:
+        msg = str(exc)
+        if json_output:
+            typer.echo(
+                json.dumps({"schema_version": 1, "error": msg[:400]}),
+                err=True,
+            )
+        else:
+            typer.echo(f"dani doctor crashed: {msg[:400]}", err=True)
+        if verbose:
+            traceback.print_exc(file=sys.stderr)
+        raise typer.Exit(3) from exc

--- a/dani/doctor.py
+++ b/dani/doctor.py
@@ -1,0 +1,815 @@
+"""Read-only health diagnostics for a dani installation.
+
+`dani doctor` is a Typer subcommand that inspects a dani installation and
+reports on configuration, storage integrity, registered repositories, agent
+runtime binaries, GitHub auth, the local webhook server, stuck jobs/sessions,
+disk usage, accumulated backups, and process sprawl.
+
+Sacred contract (enforced by tests):
+
+1. READ-ONLY — never mutates ``~/.dani/``. No ``--fix``, no writes, no
+   ``JsonStorage(config)`` (which creates dirs and skeleton files on init), no
+   ``build_service()``, no runner construction. Doctor reads JSON files
+   directly via ``read_only_snapshot``.
+2. NON-DISRUPTIVE — must work while ``dani serve`` is live. No port binding,
+   no storage write locks, no competing subprocesses. Tolerates transient
+   parse errors via one retry (atomic-replace race with the live writer).
+3. STDLIB + existing deps only. No new dependencies.
+4. CROSS-PLATFORM — darwin + linux (no Windows).
+5. NO SECRET LEAKAGE — never prints any value of ``DANI_WEBHOOK_SECRET``,
+   ``DANI_GITHUB_TOKEN``, ``GITHUB_TOKEN``, ``GH_TOKEN``, ``GITHUB_PAT``.
+   Never prints raw ``ps`` argv (OMX argv contains full agent prompts).
+6. NO ``--fix`` IN v1 — separate future command.
+
+Exit codes:
+
+- ``0``: overall ``ok`` (or ``warn`` without ``--strict``, or all checks
+  skipped)
+- ``1``: overall ``warn`` AND ``--strict``
+- ``2``: overall ``fail``
+- ``3``: doctor itself crashed (unhandled exception)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+# ============================================================
+# 1. Types
+# ============================================================
+
+
+class CheckStatus(str, Enum):
+    """Severity classification for a single check or for the overall report.
+
+    ``SKIP`` is neutral: it does not elevate the overall severity above ``OK``.
+    """
+
+    OK = "ok"
+    WARN = "warn"
+    FAIL = "fail"
+    SKIP = "skip"
+
+
+@dataclass
+class CheckResult:
+    """Outcome of running a single doctor check."""
+
+    name: str
+    status: CheckStatus
+    summary: str
+    details: dict[str, Any] = field(default_factory=dict)
+    duration_ms: int = 0
+    error: str | None = None
+
+
+@dataclass
+class DoctorReport:
+    """Aggregated doctor report serialized to text or JSON."""
+
+    schema_version: int = 1
+    started_at: str = ""
+    finished_at: str = ""
+    data_dir: str = ""
+    host: dict[str, Any] = field(default_factory=dict)
+    overall_status: CheckStatus = CheckStatus.OK
+    summary: dict[str, int] = field(default_factory=dict)
+    results: list[CheckResult] = field(default_factory=list)
+
+
+@dataclass
+class CheckContext:
+    """Shared, read-only state passed to every check.
+
+    Every field is computed ONCE at the start of ``run_doctor`` and never
+    mutated by a check. Checks may read but must not modify any field.
+    """
+
+    data_dir: Path
+    config_parsed: dict[str, Any] | None
+    config_parse_error: str | None
+    snapshot: dict[str, Any]
+    snapshot_errors: dict[str, str]
+    env: Mapping[str, str]
+    now_utc: datetime
+    timeout_seconds: float
+    verbose: bool
+    thresholds: dict[str, int]
+    port: int
+    no_color: bool
+
+
+# ============================================================
+# 2. Constants
+# ============================================================
+
+
+SECRET_ENV_KEYS = frozenset({
+    "DANI_WEBHOOK_SECRET",
+    "DANI_GITHUB_TOKEN",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_PAT",
+})
+
+# Token resolution priority: matches dani.github.GitHubCLI._resolve_token order.
+GITHUB_TOKEN_KEYS_PRIORITY: tuple[str, ...] = (
+    "DANI_GITHUB_TOKEN",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_PAT",
+)
+
+TERMINAL_JOB_STATUSES = frozenset({"completed", "failed", "superseded"})
+
+SNAPSHOT_FILES: dict[str, str] = {
+    "registry": "registry.json",
+    "jobs": "jobs.json",
+    "sessions": "sessions.json",
+    "processed_events": "processed-events.json",
+    "terminal_targets": "terminal-targets.json",
+}
+EVENTS_JSONL = "events.jsonl"
+CONFIG_FILE = "config.json"
+
+REQUIRED_SNAPSHOT_KEYS = frozenset({"registry", "jobs", "sessions"})
+
+# Whitelisted --threshold keys. Unknown keys raise BadParameter.
+ALLOWED_THRESHOLD_KEYS = frozenset({
+    "jobs_bytes_warn",
+    "jobs_bytes_fail",
+    "sessions_bytes_warn",
+    "sessions_bytes_fail",
+    "events_bytes_warn",
+    "runs_bytes_warn",
+    "runs_bytes_fail",
+    "stuck_job_age_seconds",
+    "stuck_session_age_seconds",
+    "backup_count_warn",
+    "backup_age_days_warn",
+    "backup_bytes_warn",
+    "process_sprawl_count_warn",
+})
+
+
+# ============================================================
+# 3. Redaction + token resolution
+# ============================================================
+
+
+def redact_secrets(env: Mapping[str, str]) -> dict[str, str]:
+    """Return a copy of *env* with values for known secret keys redacted.
+
+    Known secret keys (``SECRET_ENV_KEYS``) are mapped to ``"<set>"`` if their
+    value is non-empty, else ``"<unset>"``. All other keys are preserved
+    verbatim. The returned dict only includes the secret keys (callers needing
+    a full env should layer ``dict(env) | redact_secrets(env)`` themselves).
+    """
+
+    redacted: dict[str, str] = {}
+    for key in SECRET_ENV_KEYS:
+        value = env.get(key, "")
+        redacted[key] = "<set>" if value else "<unset>"
+    return redacted
+
+
+def resolve_github_token(env: Mapping[str, str]) -> tuple[str | None, str | None]:
+    """Resolve the active GitHub token from environment variables.
+
+    Returns ``(token, source_env_var_name)``. ``token`` is the actual secret
+    value or ``None`` if no candidate env var is set to a non-empty value.
+    ``source_env_var_name`` is the name of the env var that supplied the
+    token, or ``None`` if no token is available.
+
+    The token value MUST NEVER be logged or rendered into doctor output.
+    Only the source name is safe to include.
+    """
+
+    for key in GITHUB_TOKEN_KEYS_PRIORITY:
+        value = env.get(key, "")
+        if value:
+            return value, key
+    return None, None
+
+
+# ============================================================
+# 4. Read-only snapshot (replaces JsonStorage entirely)
+# ============================================================
+
+
+def _read_json_file(path: Path, *, retry_delay_s: float) -> tuple[Any, str | None, bool]:
+    """Read and parse a JSON file with one transient-error retry.
+
+    Returns ``(parsed_or_none, error_msg, retry_used)``. On success returns
+    ``(value, None, retry_used)``. If the file is missing, returns
+    ``(None, "missing", False)``. On ``JSONDecodeError``, sleeps
+    ``retry_delay_s`` and retries once; if the retry succeeds, returns
+    ``(value, None, True)``. If both attempts fail, returns
+    ``(None, error_msg, True)``.
+
+    NEVER writes, mkdirs, or otherwise mutates the filesystem.
+    """
+
+    if not path.exists():
+        return None, "missing", False
+    for attempt in (0, 1):
+        try:
+            text = path.read_text(encoding="utf-8")
+            return json.loads(text), None, attempt > 0
+        except json.JSONDecodeError as exc:
+            if attempt == 0:
+                time.sleep(retry_delay_s)
+                continue
+            return None, f"JSONDecodeError: {exc}", True
+        except OSError as exc:
+            return None, f"OSError: {exc}", attempt > 0
+    return None, "unknown error", True
+
+
+def _read_events_jsonl(path: Path, *, retry_delay_s: float) -> dict[str, Any]:
+    """Inspect ``events.jsonl`` (append-only, NOT atomic-replaced).
+
+    Captures size, line count, and parses only the first and last line. The
+    last line may be transiently incomplete during an append by ``dani serve``;
+    on parse error we retry once after ``retry_delay_s`` and, if still bad,
+    set ``last_line_invalid=True`` (callers should treat this as WARN, not
+    FAIL).
+
+    Returns a metadata dict with keys: ``exists``, ``size_bytes``,
+    ``line_count``, ``first_line_parsed``, ``last_line_parsed``,
+    ``last_line_invalid``, ``error``.
+    """
+
+    meta: dict[str, Any] = {
+        "exists": False,
+        "size_bytes": 0,
+        "line_count": 0,
+        "first_line_parsed": False,
+        "last_line_parsed": False,
+        "last_line_invalid": False,
+        "error": None,
+    }
+    if not path.exists():
+        meta["error"] = "missing"
+        return meta
+    try:
+        meta["exists"] = True
+        meta["size_bytes"] = path.stat().st_size
+    except OSError as exc:
+        meta["error"] = f"OSError: {exc}"
+        return meta
+
+    try:
+        line_count, first, last = _scan_events_lines(path)
+    except OSError as exc:
+        meta["error"] = f"OSError: {exc}"
+        return meta
+
+    meta["line_count"] = line_count
+    meta["first_line_parsed"] = _is_json_line(first)
+    last_ok = _is_json_line(last)
+    if last is not None and not last_ok:
+        time.sleep(retry_delay_s)
+        try:
+            _, _, last2 = _scan_events_lines(path)
+        except OSError:
+            last2 = None
+        last_ok = _is_json_line(last2)
+        meta["last_line_invalid"] = not last_ok
+    meta["last_line_parsed"] = last_ok
+    return meta
+
+
+def _scan_events_lines(path: Path) -> tuple[int, str | None, str | None]:
+    first: str | None = None
+    last: str | None = None
+    line_count = 0
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            line_count += 1
+            if first is None:
+                first = stripped
+            last = stripped
+    return line_count, first, last
+
+
+def _is_json_line(text: str | None) -> bool:
+    if text is None:
+        return False
+    try:
+        json.loads(text)
+    except json.JSONDecodeError:
+        return False
+    return True
+
+
+def read_only_snapshot(data_dir: Path, *, retry_delay_s: float = 0.1) -> tuple[dict[str, Any], dict[str, str]]:
+    """Read every storage file under *data_dir* without mutating anything.
+
+    Returns ``(snapshot, errors)``. ``snapshot`` is a dict keyed by the
+    storage-file logical name (``registry``, ``jobs``, ``sessions``,
+    ``processed_events``, ``terminal_targets``, plus ``events_jsonl_meta``).
+    Values are the parsed JSON payloads (or ``None`` if unreadable). For
+    ``events.jsonl`` (append-only), the value is a metadata dict.
+
+    ``errors`` maps logical names to their parse error message when applicable.
+
+    NEVER calls ``JsonStorage``, NEVER mkdirs, NEVER writes. Honors the
+    atomic-replace contract used by dani's storage layer.
+    """
+
+    snapshot: dict[str, Any] = {}
+    errors: dict[str, str] = {}
+
+    for key, filename in SNAPSHOT_FILES.items():
+        path = data_dir / filename
+        value, error, _retry_used = _read_json_file(path, retry_delay_s=retry_delay_s)
+        snapshot[key] = value
+        if error is not None:
+            errors[key] = error
+
+    events_path = data_dir / EVENTS_JSONL
+    snapshot["events_jsonl_meta"] = _read_events_jsonl(events_path, retry_delay_s=retry_delay_s)
+    events_error = snapshot["events_jsonl_meta"].get("error")
+    if events_error is not None:
+        errors["events_jsonl"] = events_error
+
+    return snapshot, errors
+
+
+def read_only_config(data_dir: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """Read ``~/.dani/config.json`` without raising.
+
+    Returns ``(parsed, error)``. If the file is absent, returns
+    ``(None, None)`` (missing config is normal — env vars supply defaults).
+    On JSON parse error or non-object top-level value, returns
+    ``(None, error_message)``. Never mutates the filesystem.
+    """
+
+    path = data_dir / CONFIG_FILE
+    if not path.exists():
+        return None, None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, f"OSError: {exc}"
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, f"JSONDecodeError: {exc}"
+    if not isinstance(parsed, dict):
+        return None, "top-level JSON value must be an object"
+    return parsed, None
+
+
+# ============================================================
+# 5. Check registry
+# ============================================================
+
+
+CHECK_REGISTRY: dict[str, Callable[[CheckContext], CheckResult]] = {}
+
+
+def register_check(
+    name: str,
+) -> Callable[[Callable[[CheckContext], CheckResult]], Callable[[CheckContext], CheckResult]]:
+    """Decorator registering a check function under *name*.
+
+    Each check is a callable ``(ctx: CheckContext) -> CheckResult``. Names
+    must be unique within ``CHECK_REGISTRY``; duplicate registration raises
+    ``ValueError``.
+    """
+
+    def _wrap(func: Callable[[CheckContext], CheckResult]) -> Callable[[CheckContext], CheckResult]:
+        if name in CHECK_REGISTRY:
+            msg = f"duplicate check registration: {name!r}"
+            raise ValueError(msg)
+        CHECK_REGISTRY[name] = func
+        return func
+
+    return _wrap
+
+
+# ============================================================
+# 6. Helper utilities
+# ============================================================
+
+
+def cap_list(items: list[Any], *, limit: int) -> tuple[list[Any], int]:
+    """Return ``(capped_items, overflow_count)``.
+
+    If ``len(items) <= limit``, returns ``(items, 0)``. Otherwise returns the
+    first ``limit`` items plus the count of items dropped.
+    """
+
+    if limit < 0:
+        limit = 0
+    if len(items) <= limit:
+        return list(items), 0
+    return list(items[:limit]), len(items) - limit
+
+
+def cap_str(text: object, *, limit: int = 200) -> str:
+    s = str(text)
+    if len(s) <= limit:
+        return s
+    if limit <= 1:
+        return s[:limit]
+    return s[: limit - 1] + "…"
+
+
+def safe_iso_parse(value: object) -> datetime | None:
+    """Parse an ISO 8601 timestamp; return ``None`` on any failure.
+
+    Handles trailing ``Z`` (Python <3.11 quirk) by mapping to ``+00:00``.
+    """
+
+    if not isinstance(value, str) or not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except (ValueError, TypeError):
+        return None
+
+
+# ============================================================
+# 7. Severity aggregation
+# ============================================================
+
+
+SEVERITY_RANK: dict[CheckStatus, int] = {
+    CheckStatus.OK: 0,
+    CheckStatus.SKIP: 0,
+    CheckStatus.WARN: 1,
+    CheckStatus.FAIL: 2,
+}
+
+
+def compute_overall(results: list[CheckResult]) -> CheckStatus:
+    """Compute overall status from *results*.
+
+    ``SKIP`` is neutral (does not elevate severity). If every check
+    skipped, the overall status is ``SKIP`` (signals "nothing meaningfully
+    ran"). Otherwise it is the max severity among ``OK``/``WARN``/``FAIL``.
+    """
+
+    if not results:
+        return CheckStatus.OK
+    ranks = [SEVERITY_RANK[r.status] for r in results]
+    max_rank = max(ranks)
+    if max_rank == 0:
+        if all(r.status == CheckStatus.SKIP for r in results):
+            return CheckStatus.SKIP
+        return CheckStatus.OK
+    if max_rank == 1:
+        return CheckStatus.WARN
+    return CheckStatus.FAIL
+
+
+def _summary_counts(results: list[CheckResult]) -> dict[str, int]:
+    counts = {"ok": 0, "warn": 0, "fail": 0, "skip": 0}
+    for r in results:
+        counts[r.status.value] += 1
+    return counts
+
+
+# ============================================================
+# 8. Orchestrator
+# ============================================================
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _dani_version() -> str:
+    """Best-effort lookup of installed dani version. Never raises."""
+
+    try:
+        from importlib.metadata import version
+
+        return version("dani")
+    except Exception:
+        return "unknown"
+
+
+def _host_info(port: int) -> dict[str, Any]:
+    import platform
+    import sys
+
+    return {
+        "port": port,
+        "platform": platform.system().lower(),
+        "platform_release": platform.release(),
+        "python_version": sys.version.split()[0],
+        "dani_version": _dani_version(),
+    }
+
+
+def run_doctor(
+    data_dir: Path,
+    *,
+    check_names: list[str] | None = None,
+    verbose: bool = False,
+    timeout: float = 5.0,
+    thresholds: dict[str, int] | None = None,
+    port: int = 8787,
+    env: Mapping[str, str] | None = None,
+    no_color: bool = False,
+) -> DoctorReport:
+    """Run the requested checks and return an aggregated ``DoctorReport``.
+
+    *data_dir* is the dani state directory (read-only). *check_names* selects
+    a subset of registered checks; ``None`` runs every check. *thresholds*
+    overrides default thresholds for ``disk_usage`` / ``backup_files`` /
+    ``stuck_*`` / ``process_sprawl`` (see ``ALLOWED_THRESHOLD_KEYS``).
+
+    Never mutates state — even on internal failure each check is captured as
+    a ``CheckResult(status=FAIL, error=...)`` rather than re-raising.
+    """
+
+    started = _utc_now()
+    effective_env: Mapping[str, str] = env if env is not None else os.environ
+
+    config_parsed, config_parse_error = read_only_config(data_dir)
+    snapshot, snapshot_errors = read_only_snapshot(data_dir)
+
+    ctx = CheckContext(
+        data_dir=data_dir,
+        config_parsed=config_parsed,
+        config_parse_error=config_parse_error,
+        snapshot=snapshot,
+        snapshot_errors=snapshot_errors,
+        env=effective_env,
+        now_utc=started,
+        timeout_seconds=timeout,
+        verbose=verbose,
+        thresholds=thresholds or {},
+        port=port,
+        no_color=no_color,
+    )
+
+    selected: list[tuple[str, Callable[[CheckContext], CheckResult]]] = []
+    if check_names is None:
+        selected = list(CHECK_REGISTRY.items())
+    else:
+        for name in check_names:
+            if name not in CHECK_REGISTRY:
+                # Unknown check name surfaces as a FAIL result so users see it.
+                continue
+            selected.append((name, CHECK_REGISTRY[name]))
+
+    # If user requested unknown check names, add explicit FAIL results.
+    requested_set = set(check_names) if check_names is not None else set()
+    known_set = set(CHECK_REGISTRY.keys())
+    unknown = sorted(requested_set - known_set)
+
+    results: list[CheckResult] = []
+    for name, func in selected:
+        t0 = time.monotonic()
+        try:
+            result = func(ctx)
+        except Exception as exc:
+            elapsed_ms = int((time.monotonic() - t0) * 1000)
+            results.append(
+                CheckResult(
+                    name=name,
+                    status=CheckStatus.FAIL,
+                    summary=f"check raised {type(exc).__name__}",
+                    details={},
+                    duration_ms=elapsed_ms,
+                    error=cap_str(exc, limit=400),
+                )
+            )
+            continue
+        if not isinstance(result, CheckResult):
+            elapsed_ms = int((time.monotonic() - t0) * 1000)
+            results.append(
+                CheckResult(
+                    name=name,
+                    status=CheckStatus.FAIL,
+                    summary="check returned non-CheckResult value",
+                    details={"returned_type": type(result).__name__},
+                    duration_ms=elapsed_ms,
+                    error="invalid check return type",
+                )
+            )
+            continue
+        if result.duration_ms == 0:
+            elapsed_ms = int((time.monotonic() - t0) * 1000)
+            result = CheckResult(
+                name=result.name or name,
+                status=result.status,
+                summary=result.summary,
+                details=result.details,
+                duration_ms=elapsed_ms,
+                error=result.error,
+            )
+        results.append(result)
+
+    for name in unknown:
+        results.append(
+            CheckResult(
+                name=name,
+                status=CheckStatus.FAIL,
+                summary=f"unknown check: {name!r}",
+                details={"known_checks": sorted(known_set)},
+                duration_ms=0,
+                error="unknown check name",
+            )
+        )
+
+    finished = _utc_now()
+    overall = compute_overall(results)
+    return DoctorReport(
+        schema_version=1,
+        started_at=started.isoformat(),
+        finished_at=finished.isoformat(),
+        data_dir=str(data_dir),
+        host=_host_info(port),
+        overall_status=overall,
+        summary=_summary_counts(results),
+        results=results,
+    )
+
+
+# ============================================================
+# 9. Formatters
+# ============================================================
+
+
+_ANSI_RESET = "\x1b[0m"
+_ANSI_STATUS_COLOR: dict[CheckStatus, str] = {
+    CheckStatus.OK: "\x1b[32m",
+    CheckStatus.WARN: "\x1b[33m",
+    CheckStatus.FAIL: "\x1b[31m",
+    CheckStatus.SKIP: "\x1b[2m",
+}
+
+_STATUS_LABEL: dict[CheckStatus, str] = {
+    CheckStatus.OK: "[ OK ]",
+    CheckStatus.WARN: "[WARN]",
+    CheckStatus.FAIL: "[FAIL]",
+    CheckStatus.SKIP: "[SKIP]",
+}
+
+
+def _result_to_json_dict(result: CheckResult) -> dict[str, Any]:
+    return {
+        "name": result.name,
+        "status": result.status.value,
+        "summary": result.summary,
+        "details": result.details,
+        "duration_ms": result.duration_ms,
+        "error": result.error,
+    }
+
+
+def format_json(report: DoctorReport) -> str:
+    payload: dict[str, Any] = {
+        "schema_version": report.schema_version,
+        "started_at": report.started_at,
+        "finished_at": report.finished_at,
+        "data_dir": report.data_dir,
+        "host": report.host,
+        "overall_status": report.overall_status.value,
+        "summary": report.summary,
+        "results": [_result_to_json_dict(r) for r in report.results],
+    }
+    return json.dumps(payload, indent=2, default=str)
+
+
+def format_text(report: DoctorReport, *, verbose: bool, use_color: bool) -> str:
+    lines: list[str] = []
+    host = report.host
+    header = (
+        f"dani doctor — schema {report.schema_version} — "
+        f"host: {host.get('platform', '?')} python {host.get('python_version', '?')} "
+        f"dani {host.get('dani_version', '?')} — data_dir: {report.data_dir}"
+    )
+    lines.append(header)
+    lines.append("")
+    for result in report.results:
+        label = _STATUS_LABEL[result.status]
+        if use_color:
+            color = _ANSI_STATUS_COLOR[result.status]
+            label = f"{color}{label}{_ANSI_RESET}"
+        lines.append(f"{label} {result.name} — {result.summary} ({result.duration_ms}ms)")
+        if result.error:
+            lines.append(f"        error: {cap_str(result.error, limit=400)}")
+        if verbose and result.details:
+            detail_text = json.dumps(result.details, indent=2, default=str, sort_keys=True)
+            for detail_line in detail_text.splitlines():
+                lines.append(f"    {detail_line}")
+    lines.append("")
+    counts = report.summary or {"ok": 0, "warn": 0, "fail": 0, "skip": 0}
+    overall_label = _STATUS_LABEL[report.overall_status]
+    if use_color:
+        overall_label = f"{_ANSI_STATUS_COLOR[report.overall_status]}{overall_label}{_ANSI_RESET}"
+    lines.append(
+        f"Summary: {counts.get('ok', 0)} ok, {counts.get('warn', 0)} warn, "
+        f"{counts.get('fail', 0)} fail, {counts.get('skip', 0)} skip — overall: {overall_label}"
+    )
+    return "\n".join(lines)
+
+
+# ============================================================
+# 10. CLI argument helpers
+# ============================================================
+
+
+class _ThresholdParseError(ValueError):
+    pass
+
+
+def parse_thresholds(values: list[str]) -> dict[str, int]:
+    """Parse repeated ``--threshold KEY=VALUE`` entries.
+
+    Each *value* must be ``KEY=POSITIVE_INTEGER`` with ``KEY`` in
+    ``ALLOWED_THRESHOLD_KEYS``. Raises ``_ThresholdParseError`` on any
+    parse failure (caller maps to typer.BadParameter).
+    """
+
+    parsed: dict[str, int] = {}
+    for raw in values or []:
+        if "=" not in raw:
+            msg = f"invalid --threshold {raw!r}: expected KEY=VALUE"
+            raise _ThresholdParseError(msg)
+        key, _, val = raw.partition("=")
+        key = key.strip()
+        val = val.strip()
+        if key not in ALLOWED_THRESHOLD_KEYS:
+            allowed = ", ".join(sorted(ALLOWED_THRESHOLD_KEYS))
+            msg = f"unknown threshold key {key!r}. Allowed: {allowed}"
+            raise _ThresholdParseError(msg)
+        try:
+            num = int(val)
+        except ValueError as exc:
+            msg = f"threshold {key!r} must be an integer, got {val!r}"
+            raise _ThresholdParseError(msg) from exc
+        if num < 0:
+            msg = f"threshold {key!r} must be non-negative, got {num}"
+            raise _ThresholdParseError(msg)
+        parsed[key] = num
+    return parsed
+
+
+class _OutputPathError(ValueError):
+    pass
+
+
+def validate_output_path(output: Path | None, data_dir: Path) -> Path | None:
+    """Validate ``--output PATH`` is safe to write to.
+
+    Returns the resolved absolute path. Raises ``_OutputPathError`` if the
+    path resolves to a location under *data_dir*, points to an existing
+    directory, or has a non-existent parent directory.
+    """
+
+    if output is None:
+        return None
+    resolved = output.expanduser().resolve(strict=False)
+    data_dir_resolved = data_dir.expanduser().resolve(strict=False)
+    if resolved == data_dir_resolved or data_dir_resolved in resolved.parents:
+        msg = f"--output {output!s} must NOT be under data_dir {data_dir!s}"
+        raise _OutputPathError(msg)
+    if resolved.exists() and resolved.is_dir():
+        msg = f"--output {output!s} points to an existing directory"
+        raise _OutputPathError(msg)
+    parent = resolved.parent
+    if not parent.exists():
+        msg = f"--output parent directory does not exist: {parent}"
+        raise _OutputPathError(msg)
+    return resolved
+
+
+def resolve_port(explicit: int | None, env: Mapping[str, str], default: int = 8787) -> int:
+    """Resolve the port used by ``server_health`` and the default report header.
+
+    Priority: ``explicit`` (e.g. from ``--port``) → ``env['DANI_PORT']`` →
+    *default*. Non-integer env values fall back to *default*.
+    """
+
+    if explicit is not None:
+        return explicit
+    env_value = env.get("DANI_PORT", "")
+    if env_value:
+        try:
+            return int(env_value)
+        except ValueError:
+            return default
+    return default

--- a/dani/doctor.py
+++ b/dani/doctor.py
@@ -1271,8 +1271,8 @@ def _check_github_auth(ctx: CheckContext) -> CheckResult:
             details={"source": None},
         )
     try:
-        from github import Auth, Github  # type: ignore[import-not-found]
-        from github.GithubException import BadCredentialsException, GithubException  # type: ignore[import-not-found]
+        from github import Auth, Github
+        from github.GithubException import BadCredentialsException, GithubException
     except ImportError as exc:
         return CheckResult(
             name="github_auth",

--- a/dani/doctor.py
+++ b/dani/doctor.py
@@ -813,3 +813,1022 @@ def resolve_port(explicit: int | None, env: Mapping[str, str], default: int = 87
         except ValueError:
             return default
     return default
+
+
+# ============================================================
+# 11. Built-in checks
+# ============================================================
+
+
+VALID_AGENT_RUNTIMES = frozenset({
+    "omx",
+    "oh-my-codex",
+    "codex",
+    "omo",
+    "oh-my-openagents",
+    "oh-my-openagent",
+    "opencode",
+})
+OMX_FAMILY = frozenset({"omx", "oh-my-codex", "codex"})
+OMO_FAMILY = frozenset({"omo", "oh-my-openagents", "oh-my-openagent", "opencode"})
+
+
+def _resolved_agent_runtime(ctx: CheckContext) -> str:
+    env_value = ctx.env.get("DANI_AGENT_RUNTIME")
+    if env_value:
+        return env_value
+    if ctx.config_parsed and "agent_runtime" in ctx.config_parsed:
+        return str(ctx.config_parsed["agent_runtime"])
+    return "omx"
+
+
+def _resolved_agent_timeout(ctx: CheckContext) -> float:
+    env_value = ctx.env.get("DANI_AGENT_TIMEOUT_SECONDS")
+    candidate: Any = env_value
+    if not candidate and ctx.config_parsed:
+        candidate = ctx.config_parsed.get("agent_timeout_seconds")
+    try:
+        return float(candidate) if candidate is not None else 3600.0
+    except (TypeError, ValueError):
+        return 3600.0
+
+
+@register_check("config_env")
+def _check_config_env(ctx: CheckContext) -> CheckResult:
+    details: dict[str, Any] = {}
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    if ctx.config_parse_error:
+        failures.append(f"config.json: {ctx.config_parse_error}")
+        details["config_parse_error"] = ctx.config_parse_error
+
+    webhook_secret = ctx.env.get("DANI_WEBHOOK_SECRET", "")
+    if not webhook_secret:
+        failures.append("DANI_WEBHOOK_SECRET is unset")
+
+    token, source = resolve_github_token(ctx.env)
+    if token is None:
+        failures.append("no GitHub token (DANI_GITHUB_TOKEN/GITHUB_TOKEN/GH_TOKEN/GITHUB_PAT)")
+
+    runtime = _resolved_agent_runtime(ctx)
+    if runtime not in VALID_AGENT_RUNTIMES:
+        warnings.append(f"unrecognized agent_runtime: {runtime!r}")
+
+    timeout_seconds = _resolved_agent_timeout(ctx)
+    if timeout_seconds <= 0:
+        warnings.append(f"agent_timeout_seconds is non-positive: {timeout_seconds}")
+
+    details.update({
+        "webhook_secret": "<set>" if webhook_secret else "<unset>",
+        "github_token_source": source,
+        "agent_runtime": runtime,
+        "agent_timeout_seconds": timeout_seconds,
+        "config_path_exists": (ctx.data_dir / CONFIG_FILE).exists(),
+    })
+
+    if failures:
+        return CheckResult(
+            name="config_env",
+            status=CheckStatus.FAIL,
+            summary="; ".join(failures),
+            details=details,
+        )
+    if warnings:
+        return CheckResult(
+            name="config_env",
+            status=CheckStatus.WARN,
+            summary="; ".join(warnings),
+            details=details,
+        )
+    return CheckResult(
+        name="config_env",
+        status=CheckStatus.OK,
+        summary="environment + config look healthy",
+        details=details,
+    )
+
+
+def _probe_binary_version(binary: str, *, timeout_seconds: float) -> str:
+    import subprocess
+
+    try:
+        result = subprocess.run(  # noqa: S603
+            [binary, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=min(2.0, timeout_seconds),
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return "unknown"
+    output = (result.stdout or result.stderr or "").strip().splitlines()
+    return cap_str(output[0], limit=100) if output else "unknown"
+
+
+def _binary_record(
+    name: str, *, required: bool, timeout_seconds: float, severity_when_missing: CheckStatus
+) -> dict[str, Any]:
+    import shutil
+
+    path = shutil.which(name)
+    if path is None:
+        return {
+            "name": name,
+            "path": None,
+            "version": None,
+            "required": required,
+            "found": False,
+            "severity": severity_when_missing.value,
+        }
+    return {
+        "name": name,
+        "path": path,
+        "version": _probe_binary_version(name, timeout_seconds=timeout_seconds),
+        "required": required,
+        "found": True,
+        "severity": CheckStatus.OK.value,
+    }
+
+
+@register_check("binaries")
+def _check_binaries(ctx: CheckContext) -> CheckResult:
+    runtime = _resolved_agent_runtime(ctx).lower()
+    has_external_opencode = bool(ctx.env.get("DANI_OPENCODE_SERVER_URL"))
+    records: list[dict[str, Any]] = []
+
+    records.append(
+        _binary_record(
+            "git",
+            required=True,
+            timeout_seconds=ctx.timeout_seconds,
+            severity_when_missing=CheckStatus.FAIL,
+        )
+    )
+    records.append(
+        _binary_record(
+            "gh",
+            required=False,
+            timeout_seconds=ctx.timeout_seconds,
+            severity_when_missing=CheckStatus.WARN,
+        )
+    )
+
+    if runtime in OMX_FAMILY:
+        records.append(
+            _binary_record(
+                "omx",
+                required=True,
+                timeout_seconds=ctx.timeout_seconds,
+                severity_when_missing=CheckStatus.FAIL,
+            )
+        )
+        records.append(
+            _binary_record(
+                "codex",
+                required=False,
+                timeout_seconds=ctx.timeout_seconds,
+                severity_when_missing=CheckStatus.WARN,
+            )
+        )
+    else:
+        records.append({
+            "name": "omx",
+            "found": None,
+            "required": False,
+            "severity": CheckStatus.SKIP.value,
+            "skip_reason": f"agent_runtime={runtime}",
+        })
+
+    if runtime in OMO_FAMILY:
+        if has_external_opencode:
+            records.append({
+                "name": "opencode",
+                "found": None,
+                "required": False,
+                "severity": CheckStatus.SKIP.value,
+                "skip_reason": "DANI_OPENCODE_SERVER_URL set (external server)",
+            })
+        else:
+            records.append(
+                _binary_record(
+                    "opencode",
+                    required=True,
+                    timeout_seconds=ctx.timeout_seconds,
+                    severity_when_missing=CheckStatus.FAIL,
+                )
+            )
+    else:
+        records.append({
+            "name": "opencode",
+            "found": None,
+            "required": False,
+            "severity": CheckStatus.SKIP.value,
+            "skip_reason": f"agent_runtime={runtime}",
+        })
+
+    fails = [r["name"] for r in records if r.get("severity") == "fail"]
+    warns = [r["name"] for r in records if r.get("severity") == "warn"]
+
+    details = {
+        "runtime": runtime,
+        "external_opencode_server": has_external_opencode,
+        "binaries": records,
+    }
+
+    if fails:
+        return CheckResult(
+            name="binaries",
+            status=CheckStatus.FAIL,
+            summary=f"missing required binary: {', '.join(fails)}",
+            details=details,
+        )
+    if warns:
+        return CheckResult(
+            name="binaries",
+            status=CheckStatus.WARN,
+            summary=f"missing advisory binary: {', '.join(warns)}",
+            details=details,
+        )
+    return CheckResult(
+        name="binaries",
+        status=CheckStatus.OK,
+        summary="all required binaries present",
+        details=details,
+    )
+
+
+@register_check("storage_files")
+def _check_storage_files(ctx: CheckContext) -> CheckResult:
+    files_info: list[dict[str, Any]] = []
+    fail_files: list[str] = []
+    warn_files: list[str] = []
+
+    for key, filename in SNAPSHOT_FILES.items():
+        path = ctx.data_dir / filename
+        size = path.stat().st_size if path.exists() else 0
+        error = ctx.snapshot_errors.get(key)
+        record = {
+            "name": filename,
+            "exists": path.exists(),
+            "size_bytes": size,
+            "parsed_ok": error is None and ctx.snapshot.get(key) is not None,
+            "error": error,
+            "required": key in REQUIRED_SNAPSHOT_KEYS,
+        }
+        files_info.append(record)
+        if error and error != "missing":
+            if key in REQUIRED_SNAPSHOT_KEYS:
+                fail_files.append(filename)
+            else:
+                warn_files.append(filename)
+        if error == "missing" and key in REQUIRED_SNAPSHOT_KEYS:
+            warn_files.append(f"{filename}(missing)")
+
+    events_meta = ctx.snapshot.get("events_jsonl_meta", {})
+    events_record = {
+        "name": EVENTS_JSONL,
+        "exists": events_meta.get("exists", False),
+        "size_bytes": events_meta.get("size_bytes", 0),
+        "line_count": events_meta.get("line_count", 0),
+        "first_line_parsed": events_meta.get("first_line_parsed", False),
+        "last_line_parsed": events_meta.get("last_line_parsed", False),
+        "last_line_invalid": events_meta.get("last_line_invalid", False),
+        "error": events_meta.get("error"),
+    }
+    files_info.append(events_record)
+    if events_meta.get("last_line_invalid"):
+        warn_files.append(f"{EVENTS_JSONL}(last_line_invalid)")
+
+    details = {"files": files_info}
+
+    if fail_files:
+        return CheckResult(
+            name="storage_files",
+            status=CheckStatus.FAIL,
+            summary=f"unparsable required storage files: {', '.join(fail_files)}",
+            details=details,
+        )
+    if warn_files:
+        return CheckResult(
+            name="storage_files",
+            status=CheckStatus.WARN,
+            summary=f"storage warnings: {', '.join(warn_files)}",
+            details=details,
+        )
+    return CheckResult(
+        name="storage_files",
+        status=CheckStatus.OK,
+        summary="all storage files exist and parse",
+        details=details,
+    )
+
+
+def _git_branch_exists(repo_path: Path, branch: str, timeout_seconds: float) -> bool:
+    import subprocess
+
+    cmd = ["git", "-C", str(repo_path), "rev-parse", "--verify", "--end-of-options", branch]
+    try:
+        result = subprocess.run(  # noqa: S603
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=min(3.0, timeout_seconds),
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+    return result.returncode == 0
+
+
+def _is_git_worktree(repo_path: Path, timeout_seconds: float) -> bool:
+    import subprocess
+
+    cmd = ["git", "-C", str(repo_path), "rev-parse", "--is-inside-work-tree"]
+    try:
+        result = subprocess.run(  # noqa: S603
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=min(3.0, timeout_seconds),
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _inspect_one_repo(repo: dict[str, Any], timeout_seconds: float) -> tuple[dict[str, Any], bool, bool]:
+    full_name = repo.get("full_name", "?")
+    local_path_str = repo.get("local_path", "")
+    enabled = repo.get("enabled", True)
+    local_path = Path(local_path_str) if local_path_str else None
+    errors: list[str] = []
+    is_worktree = False
+    main_branch_ok = False
+    dev_branch_ok = False
+    main_branch = str(repo.get("main_branch", "main"))
+    dev_branch = str(repo.get("dev_branch", "dev"))
+    fail = False
+    warn = False
+
+    if not enabled:
+        record = {
+            "full_name": full_name,
+            "local_path": local_path_str,
+            "enabled": False,
+            "skipped": True,
+        }
+        return record, fail, warn
+
+    if local_path is None or not local_path.exists():
+        errors.append("local_path missing")
+        fail = True
+    else:
+        is_worktree = _is_git_worktree(local_path, timeout_seconds)
+        if not is_worktree:
+            errors.append("not a git working tree")
+            fail = True
+        else:
+            main_branch_ok = _git_branch_exists(local_path, main_branch, timeout_seconds)
+            dev_branch_ok = _git_branch_exists(local_path, dev_branch, timeout_seconds)
+            if not main_branch_ok:
+                errors.append(f"missing branch: {main_branch}")
+                warn = True
+            if not dev_branch_ok:
+                errors.append(f"missing branch: {dev_branch}")
+                warn = True
+
+    record = {
+        "full_name": full_name,
+        "local_path": local_path_str,
+        "exists": local_path.exists() if local_path else False,
+        "is_worktree": is_worktree,
+        "main_branch": main_branch,
+        "main_branch_ok": main_branch_ok,
+        "dev_branch": dev_branch,
+        "dev_branch_ok": dev_branch_ok,
+        "enabled": enabled,
+        "errors": errors,
+    }
+    return record, fail, warn
+
+
+@register_check("registered_repos")
+def _check_registered_repos(ctx: CheckContext) -> CheckResult:
+    registry = ctx.snapshot.get("registry") or {}
+    repos = registry.get("repos", []) if isinstance(registry, dict) else []
+    if not repos:
+        return CheckResult(
+            name="registered_repos",
+            status=CheckStatus.SKIP,
+            summary="no repos registered",
+            details={"count": 0},
+        )
+
+    repo_records: list[dict[str, Any]] = []
+    any_fail = False
+    any_warn = False
+    for repo in repos:
+        if not isinstance(repo, dict):
+            continue
+        record, fail, warn = _inspect_one_repo(repo, ctx.timeout_seconds)
+        repo_records.append(record)
+        any_fail = any_fail or fail
+        any_warn = any_warn or warn
+
+    details = {"count": len(repos), "repos": repo_records}
+    if any_fail:
+        return CheckResult(
+            name="registered_repos",
+            status=CheckStatus.FAIL,
+            summary="one or more repos missing or not a git working tree",
+            details=details,
+        )
+    if any_warn:
+        return CheckResult(
+            name="registered_repos",
+            status=CheckStatus.WARN,
+            summary="one or more repos missing main/dev branch",
+            details=details,
+        )
+    return CheckResult(
+        name="registered_repos",
+        status=CheckStatus.OK,
+        summary=f"{len(repos)} repo(s) healthy",
+        details=details,
+    )
+
+
+@register_check("github_auth")
+def _check_github_auth(ctx: CheckContext) -> CheckResult:
+    token, source = resolve_github_token(ctx.env)
+    if token is None:
+        return CheckResult(
+            name="github_auth",
+            status=CheckStatus.SKIP,
+            summary="no GitHub token available",
+            details={"source": None},
+        )
+    try:
+        from github import Auth, Github  # type: ignore[import-not-found]
+        from github.GithubException import BadCredentialsException, GithubException  # type: ignore[import-not-found]
+    except ImportError as exc:
+        return CheckResult(
+            name="github_auth",
+            status=CheckStatus.WARN,
+            summary=f"PyGithub not importable: {exc}",
+            details={"source": source},
+        )
+
+    try:
+        client = Github(auth=Auth.Token(token), timeout=int(min(ctx.timeout_seconds, 10.0)), per_page=1, retry=None)
+        rate_limit = client.get_rate_limit()
+        core = getattr(rate_limit, "core", None)
+        remaining = getattr(core, "remaining", None) if core else None
+        limit = getattr(core, "limit", None) if core else None
+        reset = getattr(core, "reset", None) if core else None
+        reset_iso = reset.isoformat() if reset is not None else None
+    except BadCredentialsException:
+        return CheckResult(
+            name="github_auth",
+            status=CheckStatus.FAIL,
+            summary="invalid GitHub token (BadCredentials)",
+            details={"source": source},
+        )
+    except GithubException as exc:
+        return CheckResult(
+            name="github_auth",
+            status=CheckStatus.WARN,
+            summary=f"GitHub API error: {cap_str(exc, limit=200)}",
+            details={"source": source},
+        )
+    except Exception as exc:
+        return CheckResult(
+            name="github_auth",
+            status=CheckStatus.WARN,
+            summary=f"GitHub API transient error: {cap_str(exc, limit=200)}",
+            details={"source": source},
+        )
+
+    details = {"source": source, "rate_limit": {"remaining": remaining, "limit": limit, "reset": reset_iso}}
+    if remaining is not None and remaining < 100:
+        return CheckResult(
+            name="github_auth",
+            status=CheckStatus.WARN,
+            summary=f"rate-limit remaining low: {remaining}/{limit}",
+            details=details,
+        )
+    return CheckResult(
+        name="github_auth",
+        status=CheckStatus.OK,
+        summary=f"token ok (rate-limit {remaining}/{limit})",
+        details=details,
+    )
+
+
+def _port_is_listening(port: int) -> bool:
+    import socket
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(0.5)
+    try:
+        result = sock.connect_ex(("127.0.0.1", port))
+    except OSError:
+        return False
+    finally:
+        sock.close()
+    return result == 0
+
+
+@register_check("server_health")
+def _check_server_health(ctx: CheckContext) -> CheckResult:
+    port = ctx.port
+    listening = _port_is_listening(port)
+    if not listening:
+        return CheckResult(
+            name="server_health",
+            status=CheckStatus.SKIP,
+            summary=f"no local server on 127.0.0.1:{port}",
+            details={"port": port, "listening": False},
+        )
+
+    import time as _time
+    import urllib.error
+    import urllib.request
+
+    url = f"http://127.0.0.1:{port}/health"
+    start = _time.monotonic()
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "dani-doctor"})  # noqa: S310
+        with urllib.request.urlopen(req, timeout=min(2.0, ctx.timeout_seconds)) as resp:  # noqa: S310
+            status_code = resp.status
+            body_bytes = resp.read(4096)
+    except urllib.error.HTTPError as exc:
+        return CheckResult(
+            name="server_health",
+            status=CheckStatus.WARN,
+            summary=f"non-200 from {url}: HTTP {exc.code}",
+            details={
+                "port": port,
+                "listening": True,
+                "likely_not_dani": True,
+                "http_status": exc.code,
+                "checked_url": url,
+            },
+        )
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return CheckResult(
+            name="server_health",
+            status=CheckStatus.WARN,
+            summary=f"server probe failed: {cap_str(exc, limit=200)}",
+            details={"port": port, "listening": True, "checked_url": url},
+        )
+    latency_ms = int((_time.monotonic() - start) * 1000)
+    body_text = body_bytes.decode("utf-8", errors="replace")
+    try:
+        body_parsed = json.loads(body_text)
+    except json.JSONDecodeError:
+        body_parsed = None
+    if status_code == 200 and body_parsed == {"status": "ok"}:
+        return CheckResult(
+            name="server_health",
+            status=CheckStatus.OK,
+            summary=f"healthy ({latency_ms}ms)",
+            details={
+                "port": port,
+                "listening": True,
+                "http_status": 200,
+                "latency_ms": latency_ms,
+                "checked_url": url,
+            },
+        )
+    return CheckResult(
+        name="server_health",
+        status=CheckStatus.WARN,
+        summary="200 but body does not match dani /health shape",
+        details={
+            "port": port,
+            "listening": True,
+            "likely_not_dani": True,
+            "http_status": status_code,
+            "body_preview": cap_str(body_text, limit=200),
+            "checked_url": url,
+            "latency_ms": latency_ms,
+        },
+    )
+
+
+_ACTIVE_JOB_STATUSES = frozenset({"queued", "launched", "retrying", "recovering"})
+
+
+@register_check("stuck_jobs")
+def _check_stuck_jobs(ctx: CheckContext) -> CheckResult:
+    jobs_payload = ctx.snapshot.get("jobs") or {}
+    jobs = jobs_payload.get("jobs", []) if isinstance(jobs_payload, dict) else []
+    threshold_s = ctx.thresholds.get("stuck_job_age_seconds")
+    if threshold_s is None:
+        threshold_s = int(_resolved_agent_timeout(ctx))
+
+    stuck: list[dict[str, Any]] = []
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        if job.get("status") not in _ACTIVE_JOB_STATUSES:
+            continue
+        updated = safe_iso_parse(job.get("updated_at") or job.get("created_at"))
+        if updated is None:
+            continue
+        age_s = (ctx.now_utc - updated).total_seconds()
+        if age_s <= threshold_s:
+            continue
+        stuck.append({
+            "job_id": job.get("id"),
+            "repo": job.get("repo_full_name"),
+            "stage": job.get("stage"),
+            "status": job.get("status"),
+            "age_seconds": int(age_s),
+            "updated_at": job.get("updated_at"),
+            "issue_number": job.get("issue_number"),
+            "pr_number": job.get("pr_number"),
+        })
+
+    capped, overflow = cap_list(stuck, limit=20)
+    details = {
+        "threshold_seconds": threshold_s,
+        "stuck_count": len(stuck),
+        "stuck": capped,
+        "overflow": overflow,
+    }
+    if not stuck:
+        return CheckResult(
+            name="stuck_jobs",
+            status=CheckStatus.OK,
+            summary="no stuck active jobs",
+            details=details,
+        )
+    return CheckResult(
+        name="stuck_jobs",
+        status=CheckStatus.WARN,
+        summary=f"{len(stuck)} active job(s) older than {threshold_s}s",
+        details=details,
+    )
+
+
+_DRIFT_GRACE_SECONDS = 60
+
+
+def _classify_sessions(
+    sessions: list[Any],
+    job_by_id: dict[str, dict[str, Any]],
+    now_utc: datetime,
+    long_running_threshold_s: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    drift: list[dict[str, Any]] = []
+    long_running: list[dict[str, Any]] = []
+    orphans: list[dict[str, Any]] = []
+    for session in sessions:
+        if not isinstance(session, dict):
+            continue
+        if session.get("status") != "launched":
+            continue
+        updated = safe_iso_parse(session.get("updated_at") or session.get("created_at"))
+        age_s = (now_utc - updated).total_seconds() if updated else None
+        job_id = session.get("job_id")
+        job = job_by_id.get(job_id) if isinstance(job_id, str) else None
+        entry = {
+            "session_id": session.get("id"),
+            "job_id": job_id,
+            "repo": session.get("repo_full_name"),
+            "stage": session.get("stage"),
+            "session_status": session.get("status"),
+            "job_status": job.get("status") if job else None,
+            "age_seconds": int(age_s) if age_s is not None else None,
+        }
+        if job is None:
+            orphans.append(entry)
+            continue
+        if job.get("status") in TERMINAL_JOB_STATUSES:
+            if age_s is None or age_s >= _DRIFT_GRACE_SECONDS:
+                drift.append(entry)
+            continue
+        if age_s is not None and age_s > long_running_threshold_s:
+            long_running.append(entry)
+    return drift, long_running, orphans
+
+
+@register_check("stuck_sessions")
+def _check_stuck_sessions(ctx: CheckContext) -> CheckResult:
+    jobs_payload = ctx.snapshot.get("jobs") or {}
+    sessions_payload = ctx.snapshot.get("sessions") or {}
+    jobs = jobs_payload.get("jobs", []) if isinstance(jobs_payload, dict) else []
+    sessions = sessions_payload.get("sessions", []) if isinstance(sessions_payload, dict) else []
+
+    job_by_id: dict[str, dict[str, Any]] = {
+        j["id"]: j for j in jobs if isinstance(j, dict) and isinstance(j.get("id"), str)
+    }
+
+    long_running_threshold_s = max(int(_resolved_agent_timeout(ctx)), 86400)
+    drift, long_running, orphans = _classify_sessions(sessions, job_by_id, ctx.now_utc, long_running_threshold_s)
+
+    if drift:
+        time.sleep(0.1)
+        snap2, _errs2 = read_only_snapshot(ctx.data_dir, retry_delay_s=0.0)
+        jobs_payload2 = snap2.get("jobs") or {}
+        sessions_payload2 = snap2.get("sessions") or {}
+        jobs2 = jobs_payload2.get("jobs", []) if isinstance(jobs_payload2, dict) else []
+        sessions2 = sessions_payload2.get("sessions", []) if isinstance(sessions_payload2, dict) else []
+        job_by_id2: dict[str, dict[str, Any]] = {
+            j["id"]: j for j in jobs2 if isinstance(j, dict) and isinstance(j.get("id"), str)
+        }
+        drift2, _, _ = _classify_sessions(
+            sessions2, job_by_id2, datetime.now(tz=timezone.utc), long_running_threshold_s
+        )
+        confirmed_ids = {d["session_id"] for d in drift2}
+        drift = [d for d in drift if d["session_id"] in confirmed_ids]
+
+    drift_capped, drift_overflow = cap_list(drift, limit=50)
+    lr_capped, lr_overflow = cap_list(long_running, limit=50)
+    orph_capped, orph_overflow = cap_list(orphans, limit=50)
+    details: dict[str, Any] = {
+        "drift": drift_capped,
+        "drift_overflow": drift_overflow,
+        "long_running": lr_capped,
+        "long_running_overflow": lr_overflow,
+        "orphans": orph_capped,
+        "orphans_overflow": orph_overflow,
+        "long_running_threshold_seconds": long_running_threshold_s,
+        "recommendation": (
+            "Review listed session_id/job_id pairs. If confirmed stale, stop dani serve "
+            "before any manual state edit, or wait for a future repair command."
+        ),
+    }
+
+    if drift:
+        return CheckResult(
+            name="stuck_sessions",
+            status=CheckStatus.FAIL,
+            summary=f"{len(drift)} session(s) launched while job is terminal (drift)",
+            details=details,
+        )
+    if long_running or orphans:
+        return CheckResult(
+            name="stuck_sessions",
+            status=CheckStatus.WARN,
+            summary=(f"{len(long_running)} long-running, {len(orphans)} orphan launched session(s)"),
+            details=details,
+        )
+    return CheckResult(
+        name="stuck_sessions",
+        status=CheckStatus.OK,
+        summary="no stuck launched sessions",
+        details=details,
+    )
+
+
+_DEFAULT_DISK_THRESHOLDS: dict[str, int] = {
+    "jobs_bytes_warn": 50 * 1024 * 1024,
+    "jobs_bytes_fail": 200 * 1024 * 1024,
+    "sessions_bytes_warn": 20 * 1024 * 1024,
+    "sessions_bytes_fail": 100 * 1024 * 1024,
+    "events_bytes_warn": 100 * 1024 * 1024,
+    "runs_bytes_warn": 5 * 1024 * 1024 * 1024,
+    "runs_bytes_fail": 20 * 1024 * 1024 * 1024,
+}
+
+
+def _walk_runs_size(runs_dir: Path, deadline_s: float) -> tuple[int, bool]:
+    if not runs_dir.exists():
+        return 0, False
+    total = 0
+    truncated = False
+    start = time.monotonic()
+    for root, _dirs, files in os.walk(runs_dir):
+        if (time.monotonic() - start) > deadline_s:
+            truncated = True
+            break
+        for filename in files:
+            try:
+                total += os.path.getsize(os.path.join(root, filename))
+            except OSError:
+                continue
+    return total, truncated
+
+
+def _verdict_for_size(size: int, warn: int, fail: int) -> str:
+    if size > fail:
+        return "fail"
+    if size > warn:
+        return "warn"
+    return "ok"
+
+
+@register_check("disk_usage")
+def _check_disk_usage(ctx: CheckContext) -> CheckResult:
+    thresholds = {**_DEFAULT_DISK_THRESHOLDS, **ctx.thresholds}
+    records: list[dict[str, Any]] = []
+    overall_fail = False
+    overall_warn = False
+
+    file_specs: list[tuple[str, str, int, int]] = [
+        ("jobs.json", "jobs", thresholds["jobs_bytes_warn"], thresholds["jobs_bytes_fail"]),
+        ("sessions.json", "sessions", thresholds["sessions_bytes_warn"], thresholds["sessions_bytes_fail"]),
+        ("events.jsonl", "events", thresholds["events_bytes_warn"], thresholds["events_bytes_warn"]),
+        ("processed-events.json", "processed_events", thresholds["jobs_bytes_warn"], thresholds["jobs_bytes_fail"]),
+        ("terminal-targets.json", "terminal_targets", thresholds["jobs_bytes_warn"], thresholds["jobs_bytes_fail"]),
+    ]
+    for filename, key, warn, fail in file_specs:
+        path = ctx.data_dir / filename
+        size = path.stat().st_size if path.exists() else 0
+        verdict = _verdict_for_size(size, warn, fail)
+        records.append({"name": filename, "key": key, "bytes": size, "warn": warn, "fail": fail, "verdict": verdict})
+        if verdict == "fail":
+            overall_fail = True
+        elif verdict == "warn":
+            overall_warn = True
+
+    runs_deadline = min(30.0, max(ctx.timeout_seconds * 6.0, 5.0))
+    runs_dir = ctx.data_dir / "runs"
+    runs_size, truncated = _walk_runs_size(runs_dir, runs_deadline)
+    runs_verdict = _verdict_for_size(runs_size, thresholds["runs_bytes_warn"], thresholds["runs_bytes_fail"])
+    if truncated:
+        runs_verdict = "warn" if runs_verdict == "ok" else runs_verdict
+        overall_warn = True
+    if runs_verdict == "fail":
+        overall_fail = True
+    elif runs_verdict == "warn":
+        overall_warn = True
+    records.append({
+        "name": "runs/",
+        "key": "runs",
+        "bytes": runs_size,
+        "warn": thresholds["runs_bytes_warn"],
+        "fail": thresholds["runs_bytes_fail"],
+        "verdict": runs_verdict,
+        "truncated": truncated,
+        "deadline_seconds": runs_deadline,
+    })
+
+    details = {"records": records, "thresholds": thresholds}
+    if overall_fail:
+        return CheckResult(
+            name="disk_usage",
+            status=CheckStatus.FAIL,
+            summary="one or more storage targets exceed fail threshold",
+            details=details,
+        )
+    if overall_warn:
+        return CheckResult(
+            name="disk_usage",
+            status=CheckStatus.WARN,
+            summary="one or more storage targets exceed warn threshold",
+            details=details,
+        )
+    return CheckResult(
+        name="disk_usage",
+        status=CheckStatus.OK,
+        summary="storage usage healthy",
+        details=details,
+    )
+
+
+_DEFAULT_BACKUP_THRESHOLDS: dict[str, int] = {
+    "backup_count_warn": 3,
+    "backup_age_days_warn": 14,
+    "backup_bytes_warn": 20 * 1024 * 1024,
+}
+
+
+@register_check("backup_files")
+def _check_backup_files(ctx: CheckContext) -> CheckResult:
+    thresholds = {**_DEFAULT_BACKUP_THRESHOLDS, **ctx.thresholds}
+    candidates = sorted(ctx.data_dir.glob("*.bak.*"))
+    items: list[dict[str, Any]] = []
+    total_bytes = 0
+    oldest_mtime: float | None = None
+    for path in candidates:
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        total_bytes += stat.st_size
+        if oldest_mtime is None or stat.st_mtime < oldest_mtime:
+            oldest_mtime = stat.st_mtime
+        items.append({
+            "name": path.name,
+            "size_bytes": stat.st_size,
+            "mtime_iso": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+            "age_days": (ctx.now_utc.timestamp() - stat.st_mtime) / 86400.0,
+        })
+
+    oldest_age_days = (ctx.now_utc.timestamp() - oldest_mtime) / 86400.0 if oldest_mtime is not None else 0.0
+    capped, overflow = cap_list(items, limit=20)
+    details = {
+        "count": len(items),
+        "total_bytes": total_bytes,
+        "oldest_age_days": oldest_age_days,
+        "files": capped,
+        "overflow": overflow,
+        "thresholds": thresholds,
+    }
+    reasons: list[str] = []
+    if len(items) > thresholds["backup_count_warn"]:
+        reasons.append(f"count {len(items)} > {thresholds['backup_count_warn']}")
+    if oldest_age_days > thresholds["backup_age_days_warn"]:
+        reasons.append(f"oldest {oldest_age_days:.1f}d > {thresholds['backup_age_days_warn']}d")
+    if total_bytes > thresholds["backup_bytes_warn"]:
+        reasons.append(f"total {total_bytes}B > {thresholds['backup_bytes_warn']}B")
+    if reasons:
+        return CheckResult(
+            name="backup_files",
+            status=CheckStatus.WARN,
+            summary="; ".join(reasons),
+            details=details,
+        )
+    return CheckResult(
+        name="backup_files",
+        status=CheckStatus.OK,
+        summary="no concerning backup accumulation",
+        details=details,
+    )
+
+
+def _ps_run(args: list[str], *, timeout_s: float) -> tuple[int, list[str]]:
+    import subprocess
+
+    try:
+        result = subprocess.run(  # noqa: S603
+            args, capture_output=True, text=True, timeout=timeout_s, check=False
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return -1, []
+    if result.returncode != 0:
+        return result.returncode, []
+    return 0, result.stdout.splitlines()
+
+
+def _classify_ps_command(command: str) -> str | None:
+    if "omx exec" in command:
+        return "omx_exec"
+    if "opencode serve" in command:
+        return "opencode_serve"
+    if "opencode run" in command:
+        return "opencode_run"
+    return None
+
+
+@register_check("process_sprawl")
+def _check_process_sprawl(ctx: CheckContext) -> CheckResult:
+    threshold = ctx.thresholds.get("process_sprawl_count_warn", 20)
+    timeout_s = min(3.0, ctx.timeout_seconds)
+    rc, lines = _ps_run(["ps", "-axo", "pid=,ppid=,etime="], timeout_s=timeout_s)
+    if rc != 0:
+        return CheckResult(
+            name="process_sprawl",
+            status=CheckStatus.SKIP,
+            summary="ps unavailable or failed",
+            details={"reason": "ps_failed"},
+        )
+
+    pid_records: list[tuple[str, str, str]] = []
+    for line in lines:
+        parts = line.split(None, 2)
+        if len(parts) >= 3:
+            pid_records.append((parts[0].strip(), parts[1].strip(), parts[2].strip()))
+
+    classifier_counts: dict[str, int] = {"omx_exec": 0, "opencode_serve": 0, "opencode_run": 0}
+    samples: list[dict[str, Any]] = []
+    sample_cap = 10
+
+    for pid, ppid, etime in pid_records:
+        if not pid.isdigit():
+            continue
+        rc2, cmd_lines = _ps_run(["ps", "-p", pid, "-o", "command="], timeout_s=min(1.0, timeout_s))
+        if rc2 != 0 or not cmd_lines:
+            continue
+        classifier = _classify_ps_command(cmd_lines[0])
+        if classifier is None:
+            continue
+        classifier_counts[classifier] = classifier_counts.get(classifier, 0) + 1
+        if len(samples) < sample_cap:
+            samples.append({"pid": pid, "ppid": ppid, "etime": etime, "classifier": classifier})
+
+    total = sum(classifier_counts.values())
+    details = {
+        "counts": classifier_counts,
+        "sample": samples,
+        "threshold": threshold,
+    }
+    if total > threshold:
+        return CheckResult(
+            name="process_sprawl",
+            status=CheckStatus.WARN,
+            summary=f"{total} agent process(es) running (threshold {threshold})",
+            details=details,
+        )
+    return CheckResult(
+        name="process_sprawl",
+        status=CheckStatus.OK,
+        summary=f"{total} agent process(es) running",
+        details=details,
+    )

--- a/dani/github.py
+++ b/dani/github.py
@@ -158,6 +158,27 @@ class GitHubCLI:
             return pull_request.raw_data
         return repo.create_pull(title=title, body=body, base=base, head=head).raw_data
 
+    def is_org_member(self, org: str, username: str) -> bool:
+        if not org or not username:
+            return False
+        client = self._client_for_request()
+        try:
+            organization = client.get_organization(org)
+            user = client.get_user(username)
+        except UnknownObjectException:
+            return False
+        try:
+            return bool(organization.has_in_members(user))
+        except UnknownObjectException:
+            return False
+
+    def add_issue_comment_reaction(
+        self, repo_full_name: str, issue_number: int, comment_id: int, reaction: str
+    ) -> None:
+        issue = self._repo(repo_full_name).get_issue(issue_number)
+        comment = issue.get_comment(comment_id)
+        comment.create_reaction(reaction)
+
     def merge_pull_request(self, repo_full_name: str, pr_number: int) -> None:
         pull_request = self._repo(repo_full_name).get_pull(pr_number)
         try:

--- a/dani/service.py
+++ b/dani/service.py
@@ -238,9 +238,60 @@ class DaniService:
             return {"status": "ignored", "reason": "issue_closed"}
         if self.storage.is_terminal_issue(repo.full_name, event.number):
             return {"status": "ignored", "reason": "issue_terminal"}
+        if not self._is_authorized_approver(repo, event):
+            self._react_unauthorized_approve(repo, event)
+            return {"status": "ignored", "reason": "approver_not_authorized"}
         if self._has_existing_implementation_job(repo.full_name, event.number):
             return {"status": "ignored", "reason": "duplicate_implementation"}
         return self._queue_implementation(repo, event)
+
+    _TRUSTED_APPROVE_AUTHOR_ASSOCIATIONS = frozenset({"OWNER", "MEMBER"})
+
+    def _is_authorized_approver(self, repo: RepoConfig, event: NormalizedEvent) -> bool:
+        owner_login = repo.full_name.split("/", 1)[0]
+        actor = event.actor_login or ""
+        if not actor:
+            return False
+        if actor.casefold() == owner_login.casefold():
+            return True
+        comment = event.payload.get("comment") if isinstance(event.payload, dict) else None
+        author_association = ""
+        if isinstance(comment, dict):
+            author_association = str(comment.get("author_association") or "").upper()
+        if author_association in self._TRUSTED_APPROVE_AUTHOR_ASSOCIATIONS:
+            return True
+        try:
+            return bool(self.github.is_org_member(owner_login, actor))
+        except Exception:
+            logger.warning(
+                "approve_owner_check_failed",
+                extra={
+                    "repo_full_name": repo.full_name,
+                    "owner_login": owner_login,
+                    "actor_login": actor,
+                },
+                exc_info=True,
+            )
+            return False
+
+    def _react_unauthorized_approve(self, repo: RepoConfig, event: NormalizedEvent) -> None:
+        comment = event.payload.get("comment") if isinstance(event.payload, dict) else None
+        comment_id = comment.get("id") if isinstance(comment, dict) else None
+        if not isinstance(comment_id, int):
+            return
+        try:
+            self.github.add_issue_comment_reaction(repo.full_name, event.number, comment_id, "-1")
+        except Exception:
+            logger.warning(
+                "approve_unauthorized_reaction_failed",
+                extra={
+                    "repo_full_name": repo.full_name,
+                    "issue_number": event.number,
+                    "actor_login": event.actor_login,
+                    "comment_id": comment_id,
+                },
+                exc_info=True,
+            )
 
     def _dispatch_issue_followup_comment(self, repo: RepoConfig, event: NormalizedEvent) -> dict[str, Any]:
         if event.issue_state == "closed":
@@ -1927,9 +1978,9 @@ class DaniService:
             )
             return {"status": "queued", "job_id": job.id, "stage": job.stage}
 
-        if issue_number is None:
-            return {"status": "ignored", "reason": "untracked_pr"}
-        return self._queue_external_pull_request_review(repo, event, issue_number=issue_number)
+        return self._queue_external_pull_request_review(
+            repo, event, issue_number=issue_number, untracked=issue_number is None
+        )
 
     def _external_pull_request_guard(
         self, repo: RepoConfig, event: NormalizedEvent, *, is_agent_managed_pr: bool
@@ -1962,29 +2013,35 @@ class DaniService:
         repo: RepoConfig,
         event: NormalizedEvent,
         *,
-        issue_number: int,
+        issue_number: int | None,
+        untracked: bool = False,
     ) -> dict[str, Any]:
         event_key = self._external_pull_request_event_key(event)
         if not self.storage.record_processed_event(event_key):
             return {"status": "ignored", "reason": "duplicate_external_pr_event"}
 
         consumed_review_rounds = self._consumed_external_review_rounds(event.repo_full_name, event.number)
+        review_round_cap = 1 if untracked else self.config.review_rounds
 
-        if len(consumed_review_rounds) >= self.config.review_rounds:
-            return {"status": "ignored", "reason": "external_review_rounds_exhausted"}
+        if len(consumed_review_rounds) >= review_round_cap:
+            reason = "untracked_external_review_round_consumed" if untracked else "external_review_rounds_exhausted"
+            return {"status": "ignored", "reason": reason}
 
         next_review_round = max(consumed_review_rounds, default=0) + 1
+        metadata: dict[str, Any] = {
+            "title": event.title or "",
+            "body": event.body or "",
+            **self._external_pr_metadata(event),
+        }
+        if untracked:
+            metadata["untracked"] = True
         job = self._enqueue_job(
             repo,
             stage="review_round",
             issue_number=issue_number,
             pr_number=event.number,
             review_round=next_review_round,
-            metadata={
-                "title": event.title or "",
-                "body": event.body or "",
-                **self._external_pr_metadata(event),
-            },
+            metadata=metadata,
         )
         return {"status": "queued", "job_id": job.id, "stage": job.stage}
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -24,6 +24,9 @@ class FakeGitHubCLI:
         self.issue_labels: dict[tuple[str, int], list[str]] = {}
         self.users: dict[str, dict[str, Any]] = {}
         self.closed_pull_requests: list[tuple[str, int]] = []
+        self.org_members_by_casefolded_org: dict[str, set[str]] = {}
+        self.recorded_issue_comment_reactions: list[tuple[str, int, int, str]] = []
+        self.simulated_reaction_failure: Exception | None = None
 
     def list_open_issues(self, repo_full_name: str) -> list[dict[str, Any]]:
         return list(self.open_issues.get(repo_full_name, []))
@@ -142,6 +145,24 @@ class FakeGitHubCLI:
             if pr.get("number") == pr_number:
                 pr["state"] = "closed"
                 return
+
+    def register_org_member(self, org: str, username: str) -> None:
+        self.org_members_by_casefolded_org.setdefault(org.casefold(), set()).add(username.casefold())
+
+    def is_org_member(self, org: str, username: str) -> bool:
+        if not org or not username:
+            return False
+        members = self.org_members_by_casefolded_org.get(org.casefold())
+        if not members:
+            return False
+        return username.casefold() in members
+
+    def add_issue_comment_reaction(
+        self, repo_full_name: str, issue_number: int, comment_id: int, reaction: str
+    ) -> None:
+        if self.simulated_reaction_failure is not None:
+            raise self.simulated_reaction_failure
+        self.recorded_issue_comment_reactions.append((repo_full_name, issue_number, comment_id, reaction))
 
 
 class LaunchRecord(TypedDict):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from dani.cli import app
+from dani.doctor import (
+    ALLOWED_THRESHOLD_KEYS,
+    CHECK_REGISTRY,
+    CheckContext,
+    CheckResult,
+    CheckStatus,
+    DoctorReport,
+    _OutputPathError,
+    _ThresholdParseError,
+    cap_list,
+    cap_str,
+    compute_overall,
+    format_json,
+    format_text,
+    parse_thresholds,
+    read_only_config,
+    read_only_snapshot,
+    redact_secrets,
+    register_check,
+    resolve_github_token,
+    resolve_port,
+    run_doctor,
+    safe_iso_parse,
+    validate_output_path,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    saved = dict(CHECK_REGISTRY)
+    CHECK_REGISTRY.clear()
+    yield
+    CHECK_REGISTRY.clear()
+    CHECK_REGISTRY.update(saved)
+
+
+@pytest.fixture
+def populated_data_dir(tmp_path: Path) -> Path:
+    (tmp_path / "registry.json").write_text(json.dumps({"repos": []}), encoding="utf-8")
+    (tmp_path / "jobs.json").write_text(json.dumps({"jobs": []}), encoding="utf-8")
+    (tmp_path / "sessions.json").write_text(json.dumps({"sessions": []}), encoding="utf-8")
+    (tmp_path / "processed-events.json").write_text(json.dumps({"keys": []}), encoding="utf-8")
+    (tmp_path / "terminal-targets.json").write_text(json.dumps({"prs": [], "issues": []}), encoding="utf-8")
+    (tmp_path / "events.jsonl").write_text(
+        json.dumps({"id": "1"}) + "\n" + json.dumps({"id": "2"}) + "\n", encoding="utf-8"
+    )
+    return tmp_path
+
+
+def test_registry_registers_check():
+    @register_check("scaffold_demo_ok")
+    def _check(_ctx: CheckContext) -> CheckResult:
+        return CheckResult(name="scaffold_demo_ok", status=CheckStatus.OK, summary="x")
+
+    assert "scaffold_demo_ok" in CHECK_REGISTRY
+
+
+def test_registry_duplicate_name_raises():
+    @register_check("dup")
+    def _a(_ctx: CheckContext) -> CheckResult:
+        return CheckResult(name="dup", status=CheckStatus.OK, summary="")
+
+    with pytest.raises(ValueError, match="duplicate check registration"):
+
+        @register_check("dup")
+        def _b(_ctx: CheckContext) -> CheckResult:
+            return CheckResult(name="dup", status=CheckStatus.OK, summary="")
+
+
+def test_run_doctor_empty_returns_ok(tmp_path: Path):
+    report = run_doctor(tmp_path)
+    assert isinstance(report, DoctorReport)
+    assert report.overall_status == CheckStatus.OK
+    assert report.results == []
+    assert report.summary == {"ok": 0, "warn": 0, "fail": 0, "skip": 0}
+    assert report.schema_version == 1
+
+
+def test_run_doctor_captures_check_exception_as_fail(tmp_path: Path):
+    @register_check("boom")
+    def _boom(_ctx: CheckContext) -> CheckResult:
+        raise RuntimeError("kaboom")
+
+    report = run_doctor(tmp_path, check_names=["boom"])
+    assert report.overall_status == CheckStatus.FAIL
+    assert len(report.results) == 1
+    assert report.results[0].status == CheckStatus.FAIL
+    assert "RuntimeError" in report.results[0].summary
+    assert report.results[0].error and "kaboom" in report.results[0].error
+
+
+def test_run_doctor_records_unknown_check_as_fail(tmp_path: Path):
+    report = run_doctor(tmp_path, check_names=["does_not_exist"])
+    assert report.overall_status == CheckStatus.FAIL
+    assert len(report.results) == 1
+    assert report.results[0].name == "does_not_exist"
+    assert "unknown" in report.results[0].summary
+
+
+def test_redact_secrets_known_keys():
+    env = {
+        "DANI_WEBHOOK_SECRET": "very-secret-1",
+        "DANI_GITHUB_TOKEN": "ghp_xxx",
+        "GITHUB_TOKEN": "",
+        "PATH": "/usr/bin",
+    }
+    redacted = redact_secrets(env)
+    assert redacted["DANI_WEBHOOK_SECRET"] == "<set>"
+    assert redacted["DANI_GITHUB_TOKEN"] == "<set>"
+    assert redacted["GITHUB_TOKEN"] == "<unset>"
+    assert redacted["GH_TOKEN"] == "<unset>"
+    assert redacted["GITHUB_PAT"] == "<unset>"
+    assert "very-secret-1" not in json.dumps(redacted)
+    assert "ghp_xxx" not in json.dumps(redacted)
+    assert "PATH" not in redacted
+
+
+def test_resolve_github_token_priority():
+    env = {"DANI_GITHUB_TOKEN": "dani-tok", "GITHUB_TOKEN": "gh-tok", "GH_TOKEN": "ghc-tok"}
+    token, source = resolve_github_token(env)
+    assert (token, source) == ("dani-tok", "DANI_GITHUB_TOKEN")
+
+    token2, source2 = resolve_github_token({"GITHUB_TOKEN": "gh-tok", "GH_TOKEN": "ghc-tok"})
+    assert (token2, source2) == ("gh-tok", "GITHUB_TOKEN")
+
+    token3, source3 = resolve_github_token({"GH_TOKEN": "ghc-tok"})
+    assert (token3, source3) == ("ghc-tok", "GH_TOKEN")
+
+    token4, source4 = resolve_github_token({"GITHUB_PAT": "pat-tok"})
+    assert (token4, source4) == ("pat-tok", "GITHUB_PAT")
+
+    assert resolve_github_token({}) == (None, None)
+    assert resolve_github_token({"DANI_GITHUB_TOKEN": ""}) == (None, None)
+
+
+def test_read_only_snapshot_happy_path(populated_data_dir: Path):
+    snap, errors = read_only_snapshot(populated_data_dir)
+    assert errors == {}
+    assert snap["registry"] == {"repos": []}
+    assert snap["jobs"] == {"jobs": []}
+    assert snap["sessions"] == {"sessions": []}
+    assert snap["events_jsonl_meta"]["line_count"] == 2
+    assert snap["events_jsonl_meta"]["first_line_parsed"] is True
+    assert snap["events_jsonl_meta"]["last_line_parsed"] is True
+
+
+def test_read_only_snapshot_does_not_create_files(tmp_path: Path):
+    pre = sorted(p.name for p in tmp_path.iterdir())
+    snap, errors = read_only_snapshot(tmp_path)
+    post = sorted(p.name for p in tmp_path.iterdir())
+    assert pre == post
+    assert pre == []
+    assert snap["registry"] is None
+    assert errors["registry"] == "missing"
+
+
+def test_read_only_snapshot_records_persistent_parse_error(tmp_path: Path):
+    (tmp_path / "jobs.json").write_text("{not json", encoding="utf-8")
+    snap, errors = read_only_snapshot(tmp_path, retry_delay_s=0.0)
+    assert snap["jobs"] is None
+    assert "JSONDecodeError" in errors["jobs"]
+
+
+def test_read_only_snapshot_retries_jsondecodeerror_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    path = tmp_path / "jobs.json"
+    path.write_text("{not json", encoding="utf-8")
+    real_read = Path.read_text
+
+    call_count = {"n": 0}
+
+    def flaky(self: Path, encoding: str = "utf-8") -> str:
+        if self == path:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return "{not json"
+            return json.dumps({"jobs": ["fixed"]})
+        return real_read(self, encoding=encoding)
+
+    monkeypatch.setattr(Path, "read_text", flaky)
+    snap, errors = read_only_snapshot(tmp_path, retry_delay_s=0.0)
+    assert snap["jobs"] == {"jobs": ["fixed"]}
+    assert "jobs" not in errors
+    assert call_count["n"] == 2
+
+
+def test_read_only_snapshot_events_jsonl_last_line_invalid(tmp_path: Path):
+    (tmp_path / "events.jsonl").write_text(json.dumps({"a": 1}) + "\n" + "{not-json\n", encoding="utf-8")
+    snap, _errors = read_only_snapshot(tmp_path, retry_delay_s=0.0)
+    meta = snap["events_jsonl_meta"]
+    assert meta["first_line_parsed"] is True
+    assert meta["last_line_parsed"] is False
+    assert meta["last_line_invalid"] is True
+    assert meta["line_count"] == 2
+
+
+def test_read_only_config_missing_returns_none(tmp_path: Path):
+    parsed, error = read_only_config(tmp_path)
+    assert parsed is None
+    assert error is None
+
+
+def test_read_only_config_invalid_json(tmp_path: Path):
+    (tmp_path / "config.json").write_text("not-json", encoding="utf-8")
+    parsed, error = read_only_config(tmp_path)
+    assert parsed is None
+    assert "JSONDecodeError" in (error or "")
+
+
+def test_read_only_config_non_object(tmp_path: Path):
+    (tmp_path / "config.json").write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    parsed, error = read_only_config(tmp_path)
+    assert parsed is None
+    assert "object" in (error or "")
+
+
+def test_read_only_config_happy(tmp_path: Path):
+    (tmp_path / "config.json").write_text(
+        json.dumps({"agent_runtime": "omx", "agent_timeout_seconds": 1800}), encoding="utf-8"
+    )
+    parsed, error = read_only_config(tmp_path)
+    assert parsed == {"agent_runtime": "omx", "agent_timeout_seconds": 1800}
+    assert error is None
+
+
+def test_compute_overall_severity():
+    def _r(status: CheckStatus) -> CheckResult:
+        return CheckResult(name="n", status=status, summary="")
+
+    assert compute_overall([]) == CheckStatus.OK
+    assert compute_overall([_r(CheckStatus.OK), _r(CheckStatus.OK)]) == CheckStatus.OK
+    assert compute_overall([_r(CheckStatus.SKIP), _r(CheckStatus.SKIP)]) == CheckStatus.SKIP
+    assert compute_overall([_r(CheckStatus.OK), _r(CheckStatus.SKIP)]) == CheckStatus.OK
+    assert compute_overall([_r(CheckStatus.OK), _r(CheckStatus.WARN)]) == CheckStatus.WARN
+    assert compute_overall([_r(CheckStatus.OK), _r(CheckStatus.WARN), _r(CheckStatus.FAIL)]) == CheckStatus.FAIL
+    assert compute_overall([_r(CheckStatus.SKIP), _r(CheckStatus.FAIL)]) == CheckStatus.FAIL
+
+
+def test_cap_list_and_cap_str():
+    items = list(range(50))
+    capped, overflow = cap_list(items, limit=10)
+    assert capped == list(range(10))
+    assert overflow == 40
+    assert cap_list([], limit=5) == ([], 0)
+    assert cap_list([1, 2], limit=5) == ([1, 2], 0)
+
+    assert cap_str("hello", limit=10) == "hello"
+    truncated = cap_str("x" * 50, limit=10)
+    assert len(truncated) == 10
+    assert truncated.endswith("…")
+
+
+def test_safe_iso_parse_variants():
+    assert safe_iso_parse("") is None
+    assert safe_iso_parse(None) is None
+    assert safe_iso_parse("not-a-date") is None
+    parsed = safe_iso_parse("2026-05-15T09:04:06+00:00")
+    assert parsed is not None and parsed.year == 2026
+    parsed_z = safe_iso_parse("2026-05-15T09:04:06Z")
+    assert parsed_z is not None and parsed_z.tzinfo is not None
+
+
+def test_format_json_round_trip(tmp_path: Path):
+    @register_check("demo")
+    def _demo(_ctx: CheckContext) -> CheckResult:
+        return CheckResult(
+            name="demo",
+            status=CheckStatus.OK,
+            summary="all good",
+            details={"value": 42},
+            duration_ms=5,
+        )
+
+    report = run_doctor(tmp_path, check_names=["demo"])
+    rendered = format_json(report)
+    parsed: dict[str, Any] = json.loads(rendered)
+    assert parsed["schema_version"] == 1
+    assert parsed["overall_status"] == "ok"
+    assert parsed["summary"] == {"ok": 1, "warn": 0, "fail": 0, "skip": 0}
+    assert parsed["results"][0]["name"] == "demo"
+    assert parsed["results"][0]["status"] == "ok"
+    assert parsed["results"][0]["details"] == {"value": 42}
+
+
+def test_format_text_no_color_has_no_ansi(tmp_path: Path):
+    @register_check("demo")
+    def _demo(_ctx: CheckContext) -> CheckResult:
+        return CheckResult(name="demo", status=CheckStatus.WARN, summary="watch out")
+
+    report = run_doctor(tmp_path, check_names=["demo"])
+    rendered = format_text(report, verbose=False, use_color=False)
+    assert "\x1b" not in rendered
+    assert "[WARN] demo" in rendered
+    assert "watch out" in rendered
+
+
+def test_format_text_redaction_does_not_leak_secret_value(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("DANI_GITHUB_TOKEN", "ghp_ULTRASECRET_XYZ_999")
+
+    @register_check("demo")
+    def _demo(ctx: CheckContext) -> CheckResult:
+        return CheckResult(
+            name="demo",
+            status=CheckStatus.OK,
+            summary="env",
+            details={"env": redact_secrets(ctx.env)},
+        )
+
+    report = run_doctor(tmp_path, check_names=["demo"])
+    text = format_text(report, verbose=True, use_color=False)
+    j = format_json(report)
+    assert "ghp_ULTRASECRET_XYZ_999" not in text
+    assert "ghp_ULTRASECRET_XYZ_999" not in j
+
+
+def test_parse_thresholds_accepts_known_keys():
+    parsed = parse_thresholds(["runs_bytes_warn=5000000000", "stuck_job_age_seconds=600"])
+    assert parsed == {"runs_bytes_warn": 5000000000, "stuck_job_age_seconds": 600}
+
+
+def test_parse_thresholds_rejects_unknown_key():
+    with pytest.raises(_ThresholdParseError):
+        parse_thresholds(["unknown_key=1"])
+
+
+def test_parse_thresholds_rejects_non_integer():
+    with pytest.raises(_ThresholdParseError):
+        parse_thresholds(["runs_bytes_warn=abc"])
+
+
+def test_parse_thresholds_rejects_missing_equals():
+    with pytest.raises(_ThresholdParseError):
+        parse_thresholds(["runs_bytes_warn"])
+
+
+def test_parse_thresholds_rejects_negative():
+    with pytest.raises(_ThresholdParseError):
+        parse_thresholds(["runs_bytes_warn=-1"])
+
+
+def test_validate_output_path_rejects_under_data_dir(tmp_path: Path):
+    output = tmp_path / "report.json"
+    with pytest.raises(_OutputPathError):
+        validate_output_path(output, tmp_path)
+
+
+def test_validate_output_path_rejects_existing_dir(tmp_path: Path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    target = tmp_path / "subdir"
+    target.mkdir()
+    with pytest.raises(_OutputPathError):
+        validate_output_path(target, data_dir)
+
+
+def test_validate_output_path_rejects_missing_parent(tmp_path: Path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    missing_parent = tmp_path / "nope" / "report.json"
+    with pytest.raises(_OutputPathError):
+        validate_output_path(missing_parent, data_dir)
+
+
+def test_validate_output_path_accepts_sibling(tmp_path: Path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    out = tmp_path / "report.json"
+    resolved = validate_output_path(out, data_dir)
+    assert resolved is not None and resolved == out.resolve(strict=False)
+
+
+def test_resolve_port_precedence():
+    assert resolve_port(9000, {"DANI_PORT": "7000"}) == 9000
+    assert resolve_port(None, {"DANI_PORT": "7000"}) == 7000
+    assert resolve_port(None, {}) == 8787
+    assert resolve_port(None, {"DANI_PORT": "not-a-number"}) == 8787
+
+
+def test_cli_doctor_help_works():
+    runner = CliRunner()
+    result = runner.invoke(app, ["doctor", "--help"])
+    assert result.exit_code == 0
+    assert "doctor" in result.output.lower()
+    assert "--data-dir" in result.output
+    assert "--json" in result.output
+    assert "--strict" in result.output
+
+
+def test_cli_doctor_rejects_output_under_data_dir(tmp_path: Path):
+    runner = CliRunner()
+    out = tmp_path / "r.json"
+    result = runner.invoke(app, ["doctor", "--data-dir", str(tmp_path), "--output", str(out)])
+    assert result.exit_code != 0
+
+
+def test_cli_doctor_rejects_unknown_threshold(tmp_path: Path):
+    runner = CliRunner()
+    result = runner.invoke(app, ["doctor", "--data-dir", str(tmp_path), "--threshold", "bogus=1"])
+    assert result.exit_code != 0
+
+
+def test_cli_doctor_empty_data_dir_runs_clean(tmp_path: Path):
+    runner = CliRunner()
+    result = runner.invoke(app, ["doctor", "--data-dir", str(tmp_path), "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["schema_version"] == 1
+    assert payload["overall_status"] in {"ok", "skip"}
+
+
+def test_allowed_threshold_keys_is_frozenset():
+    assert isinstance(ALLOWED_THRESHOLD_KEYS, frozenset)
+    assert "runs_bytes_warn" in ALLOWED_THRESHOLD_KEYS
+    assert "unknown_random_key" not in ALLOWED_THRESHOLD_KEYS

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -38,7 +38,6 @@ from dani.doctor import (
 @pytest.fixture(autouse=True)
 def _clean_registry():
     saved = dict(CHECK_REGISTRY)
-    CHECK_REGISTRY.clear()
     yield
     CHECK_REGISTRY.clear()
     CHECK_REGISTRY.update(saved)
@@ -78,7 +77,7 @@ def test_registry_duplicate_name_raises():
 
 
 def test_run_doctor_empty_returns_ok(tmp_path: Path):
-    report = run_doctor(tmp_path)
+    report = run_doctor(tmp_path, check_names=[])
     assert isinstance(report, DoctorReport)
     assert report.overall_status == CheckStatus.OK
     assert report.results == []
@@ -414,7 +413,8 @@ def test_cli_doctor_empty_data_dir_runs_clean(tmp_path: Path):
     assert result.exit_code == 0
     payload = json.loads(result.output)
     assert payload["schema_version"] == 1
-    assert payload["overall_status"] in {"ok", "skip"}
+    assert payload["overall_status"] in {"ok", "warn", "skip"}
+    assert payload["summary"]["fail"] == 0
 
 
 def test_allowed_threshold_keys_is_frozenset():
@@ -1026,3 +1026,240 @@ def test_process_sprawl_warn_over_threshold(tmp_path: Path, monkeypatch: pytest.
     for sample in result.details["sample"]:
         assert "command" not in sample
         assert "argv" not in sample
+
+
+# ============================================================
+# W7: end-to-end + exit code matrix
+# ============================================================
+
+
+def test_e2e_happy_path_runs_all_checks(populated_data_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    fake_paths = {
+        "git": "/usr/bin/git",
+        "gh": "/usr/bin/gh",
+        "omx": "/usr/bin/omx",
+        "codex": "/usr/bin/codex",
+    }
+    monkeypatch.setattr("shutil.which", lambda name: fake_paths.get(name))
+    monkeypatch.setattr("dani.doctor._probe_binary_version", lambda binary, *, timeout_seconds: "v1")
+
+    class FakeCore:
+        remaining = 4000
+        limit = 5000
+        reset = datetime.now(tz=timezone.utc)
+
+    class FakeRate:
+        core = FakeCore()
+
+    class FakeGithub:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_rate_limit(self):
+            return FakeRate()
+
+    monkeypatch.setattr("github.Github", FakeGithub)
+    monkeypatch.setattr("dani.doctor._ps_run", lambda *a, **kw: (0, []))
+
+    runner = CliRunner()
+    env = {
+        "DANI_WEBHOOK_SECRET": "secret",
+        "DANI_GITHUB_TOKEN": "tok",
+        "DANI_AGENT_RUNTIME": "omx",
+    }
+    result = runner.invoke(app, ["doctor", "--data-dir", str(populated_data_dir), "--json"], env=env)
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["overall_status"] in {"ok", "warn"}
+    assert payload["summary"]["fail"] == 0
+    names = {r["name"] for r in payload["results"]}
+    expected = {
+        "config_env",
+        "binaries",
+        "storage_files",
+        "registered_repos",
+        "github_auth",
+        "server_health",
+        "stuck_jobs",
+        "stuck_sessions",
+        "disk_usage",
+        "backup_files",
+        "process_sprawl",
+    }
+    assert expected.issubset(names)
+
+
+def test_e2e_failure_mode_drift_exits_2(populated_data_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    now = datetime.now(tz=timezone.utc)
+    old = (now - timedelta(hours=10)).isoformat()
+    (populated_data_dir / "jobs.json").write_text(
+        json.dumps({
+            "jobs": [
+                {
+                    "id": "j1",
+                    "status": "completed",
+                    "stage": "implementation",
+                    "repo_full_name": "x/y",
+                    "updated_at": old,
+                    "created_at": old,
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+    (populated_data_dir / "sessions.json").write_text(
+        json.dumps({
+            "sessions": [
+                {
+                    "id": "s1",
+                    "status": "launched",
+                    "stage": "implementation",
+                    "repo_full_name": "x/y",
+                    "job_id": "j1",
+                    "updated_at": old,
+                    "created_at": old,
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/" + name)
+    monkeypatch.setattr("dani.doctor._probe_binary_version", lambda binary, *, timeout_seconds: "v1")
+    monkeypatch.setattr("dani.doctor._ps_run", lambda *a, **kw: (0, []))
+
+    class FakeGithub:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_rate_limit(self):
+            class C:
+                remaining = 4000
+                limit = 5000
+                reset = datetime.now(tz=timezone.utc)
+
+            class R:
+                core = C()
+
+            return R()
+
+    monkeypatch.setattr("github.Github", FakeGithub)
+
+    runner = CliRunner()
+    env = {"DANI_WEBHOOK_SECRET": "x", "DANI_GITHUB_TOKEN": "y"}
+    result = runner.invoke(
+        app,
+        ["doctor", "--data-dir", str(populated_data_dir), "--check", "stuck_sessions", "--json"],
+        env=env,
+    )
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["overall_status"] == "fail"
+    stuck = payload["results"][0]
+    assert stuck["name"] == "stuck_sessions"
+    assert stuck["status"] == "fail"
+    assert len(stuck["details"]["drift"]) == 1
+
+
+def test_e2e_strict_warn_exits_1(populated_data_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    for i in range(5):
+        (populated_data_dir / f"jobs.json.bak.{i}").write_text("x", encoding="utf-8")
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/" + name)
+    monkeypatch.setattr("dani.doctor._probe_binary_version", lambda binary, *, timeout_seconds: "v1")
+    monkeypatch.setattr("dani.doctor._ps_run", lambda *a, **kw: (0, []))
+
+    class FakeGithub:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_rate_limit(self):
+            class C:
+                remaining = 4000
+                limit = 5000
+                reset = datetime.now(tz=timezone.utc)
+
+            class R:
+                core = C()
+
+            return R()
+
+    monkeypatch.setattr("github.Github", FakeGithub)
+    runner = CliRunner()
+    env = {"DANI_WEBHOOK_SECRET": "x", "DANI_GITHUB_TOKEN": "y"}
+    result = runner.invoke(
+        app,
+        ["doctor", "--data-dir", str(populated_data_dir), "--check", "backup_files", "--strict"],
+        env=env,
+    )
+    assert result.exit_code == 1
+
+
+def test_e2e_text_output_renders(populated_data_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/" + name)
+    monkeypatch.setattr("dani.doctor._probe_binary_version", lambda binary, *, timeout_seconds: "v1")
+    monkeypatch.setattr("dani.doctor._ps_run", lambda *a, **kw: (0, []))
+    monkeypatch.setenv("NO_COLOR", "1")
+
+    runner = CliRunner()
+    env = {"DANI_WEBHOOK_SECRET": "x", "DANI_GITHUB_TOKEN": "y", "NO_COLOR": "1"}
+    result = runner.invoke(
+        app,
+        ["doctor", "--data-dir", str(populated_data_dir), "--check", "config_env"],
+        env=env,
+    )
+    assert result.exit_code == 0
+    assert "config_env" in result.output
+    assert "\x1b" not in result.output
+
+
+def test_e2e_exit_code_matrix_parametrized(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/" + name)
+    monkeypatch.setattr("dani.doctor._probe_binary_version", lambda binary, *, timeout_seconds: "v1")
+    monkeypatch.setattr("dani.doctor._ps_run", lambda *a, **kw: (0, []))
+
+    runner = CliRunner()
+    cases = [
+        ([], 0),
+        (["--strict"], 0),
+    ]
+    for cli_args, expected_exit in cases:
+        result = runner.invoke(
+            app,
+            ["doctor", "--data-dir", str(tmp_path), "--check", "process_sprawl", *cli_args],
+            env={},
+        )
+        assert result.exit_code == expected_exit, (cli_args, result.output)
+
+
+def test_e2e_no_token_in_output(populated_data_dir: Path, monkeypatch: pytest.MonkeyPatch):
+    ULTRA_SECRET = "ghp_THIS_MUST_NEVER_APPEAR_IN_OUTPUT_99999"
+    WEBHOOK_SECRET = "this-webhook-secret-must-never-appear-12345"
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/" + name)
+    monkeypatch.setattr("dani.doctor._probe_binary_version", lambda binary, *, timeout_seconds: "v1")
+    monkeypatch.setattr("dani.doctor._ps_run", lambda *a, **kw: (0, []))
+
+    class FakeGithub:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_rate_limit(self):
+            class C:
+                remaining = 4000
+                limit = 5000
+                reset = datetime.now(tz=timezone.utc)
+
+            class R:
+                core = C()
+
+            return R()
+
+    monkeypatch.setattr("github.Github", FakeGithub)
+    runner = CliRunner()
+    env = {"DANI_WEBHOOK_SECRET": WEBHOOK_SECRET, "DANI_GITHUB_TOKEN": ULTRA_SECRET}
+    result = runner.invoke(
+        app,
+        ["doctor", "--data-dir", str(populated_data_dir), "--json", "--verbose"],
+        env=env,
+    )
+    assert result.exit_code in (0, 1, 2)
+    assert ULTRA_SECRET not in result.output
+    assert WEBHOOK_SECRET not in result.output

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -449,9 +449,9 @@ def _make_ctx(
     data_dir: Path,
     *,
     env: dict[str, str] | None = None,
-    snapshot: dict[str, object] | None = None,
+    snapshot: dict[str, Any] | None = None,
     snapshot_errors: dict[str, str] | None = None,
-    config_parsed: dict[str, object] | None = None,
+    config_parsed: dict[str, Any] | None = None,
     config_parse_error: str | None = None,
     now_utc: datetime | None = None,
     thresholds: dict[str, int] | None = None,
@@ -781,7 +781,7 @@ def test_server_health_ok_with_local_server(tmp_path: Path):
                 self.send_response(404)
                 self.end_headers()
 
-        def log_message(self, *_args):
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
             return
 
     server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
@@ -808,7 +808,7 @@ def test_server_health_warn_on_wrong_body(tmp_path: Path):
             self.end_headers()
             self.wfile.write(b"hello world")
 
-        def log_message(self, *_args):
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
             return
 
     server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
@@ -832,7 +832,7 @@ def _job(
     updated_at: datetime,
     stage: str = "implementation",
     repo: str = "x/y",
-) -> dict[str, object]:
+) -> dict[str, Any]:
     return {
         "id": job_id,
         "status": status,
@@ -851,7 +851,7 @@ def _session(
     job_id: str | None = None,
     stage: str = "implementation",
     repo: str = "x/y",
-) -> dict[str, object]:
+) -> dict[str, Any]:
     return {
         "id": session_id,
         "status": status,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -421,3 +421,608 @@ def test_allowed_threshold_keys_is_frozenset():
     assert isinstance(ALLOWED_THRESHOLD_KEYS, frozenset)
     assert "runs_bytes_warn" in ALLOWED_THRESHOLD_KEYS
     assert "unknown_random_key" not in ALLOWED_THRESHOLD_KEYS
+
+
+# ============================================================
+# W5: per-check tests
+# ============================================================
+
+
+from datetime import datetime, timedelta, timezone  # noqa: E402
+
+from dani.doctor import (  # noqa: E402
+    _check_backup_files,
+    _check_binaries,
+    _check_config_env,
+    _check_disk_usage,
+    _check_github_auth,
+    _check_process_sprawl,
+    _check_registered_repos,
+    _check_server_health,
+    _check_storage_files,
+    _check_stuck_jobs,
+    _check_stuck_sessions,
+)
+
+
+def _make_ctx(
+    data_dir: Path,
+    *,
+    env: dict[str, str] | None = None,
+    snapshot: dict[str, object] | None = None,
+    snapshot_errors: dict[str, str] | None = None,
+    config_parsed: dict[str, object] | None = None,
+    config_parse_error: str | None = None,
+    now_utc: datetime | None = None,
+    thresholds: dict[str, int] | None = None,
+    port: int = 8787,
+    timeout_seconds: float = 5.0,
+    verbose: bool = False,
+) -> CheckContext:
+    if snapshot is None:
+        snapshot = {
+            "registry": {"repos": []},
+            "jobs": {"jobs": []},
+            "sessions": {"sessions": []},
+            "processed_events": {"keys": []},
+            "terminal_targets": {"prs": [], "issues": []},
+            "events_jsonl_meta": {
+                "exists": False,
+                "size_bytes": 0,
+                "line_count": 0,
+                "first_line_parsed": False,
+                "last_line_parsed": False,
+                "last_line_invalid": False,
+                "error": "missing",
+            },
+        }
+    return CheckContext(
+        data_dir=data_dir,
+        config_parsed=config_parsed,
+        config_parse_error=config_parse_error,
+        snapshot=snapshot,
+        snapshot_errors=snapshot_errors or {},
+        env=env or {},
+        now_utc=now_utc or datetime.now(tz=timezone.utc),
+        timeout_seconds=timeout_seconds,
+        verbose=verbose,
+        thresholds=thresholds or {},
+        port=port,
+        no_color=True,
+    )
+
+
+def test_config_env_fail_when_secret_and_token_missing(tmp_path: Path):
+    ctx = _make_ctx(tmp_path, env={})
+    result = _check_config_env(ctx)
+    assert result.status == CheckStatus.FAIL
+    assert "DANI_WEBHOOK_SECRET" in result.summary
+    assert "GitHub token" in result.summary
+
+
+def test_config_env_ok_when_secret_and_token_set(tmp_path: Path):
+    ctx = _make_ctx(
+        tmp_path,
+        env={"DANI_WEBHOOK_SECRET": "x", "DANI_GITHUB_TOKEN": "y"},
+    )
+    result = _check_config_env(ctx)
+    assert result.status == CheckStatus.OK
+    assert result.details["github_token_source"] == "DANI_GITHUB_TOKEN"
+
+
+def test_config_env_warn_on_bad_runtime(tmp_path: Path):
+    ctx = _make_ctx(
+        tmp_path,
+        env={
+            "DANI_WEBHOOK_SECRET": "x",
+            "DANI_GITHUB_TOKEN": "y",
+            "DANI_AGENT_RUNTIME": "made-up",
+        },
+    )
+    result = _check_config_env(ctx)
+    assert result.status == CheckStatus.WARN
+    assert "made-up" in result.summary
+
+
+def test_config_env_fail_on_config_parse_error(tmp_path: Path):
+    ctx = _make_ctx(
+        tmp_path,
+        env={"DANI_WEBHOOK_SECRET": "x", "DANI_GITHUB_TOKEN": "y"},
+        config_parse_error="JSONDecodeError: x",
+    )
+    result = _check_config_env(ctx)
+    assert result.status == CheckStatus.FAIL
+    assert "JSONDecodeError" in result.details["config_parse_error"]
+
+
+def test_binaries_fail_when_git_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    ctx = _make_ctx(tmp_path, env={"DANI_AGENT_RUNTIME": "omx"})
+    result = _check_binaries(ctx)
+    assert result.status == CheckStatus.FAIL
+    assert "git" in result.summary
+
+
+def test_binaries_ok_omx_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    fake_paths = {
+        "git": "/usr/bin/git",
+        "gh": "/usr/bin/gh",
+        "omx": "/usr/bin/omx",
+        "codex": "/usr/bin/codex",
+    }
+    monkeypatch.setattr("shutil.which", lambda name: fake_paths.get(name))
+    monkeypatch.setattr("dani.doctor._probe_binary_version", lambda binary, *, timeout_seconds: "v1")
+    ctx = _make_ctx(tmp_path, env={"DANI_AGENT_RUNTIME": "omx"})
+    result = _check_binaries(ctx)
+    assert result.status == CheckStatus.OK
+
+
+def test_binaries_omo_external_server_skips_opencode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    fake_paths = {"git": "/usr/bin/git", "gh": "/usr/bin/gh"}
+    monkeypatch.setattr("shutil.which", lambda name: fake_paths.get(name))
+    monkeypatch.setattr("dani.doctor._probe_binary_version", lambda binary, *, timeout_seconds: "v1")
+    ctx = _make_ctx(
+        tmp_path,
+        env={
+            "DANI_AGENT_RUNTIME": "omo",
+            "DANI_OPENCODE_SERVER_URL": "http://127.0.0.1:4096",
+        },
+    )
+    result = _check_binaries(ctx)
+    assert result.status == CheckStatus.OK
+    opencode_rec = next(r for r in result.details["binaries"] if r["name"] == "opencode")
+    assert opencode_rec["severity"] == "skip"
+
+
+def test_binaries_omo_runtime_fails_without_opencode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/git" if name == "git" else None)
+    monkeypatch.setattr("dani.doctor._probe_binary_version", lambda binary, *, timeout_seconds: "v1")
+    ctx = _make_ctx(tmp_path, env={"DANI_AGENT_RUNTIME": "omo"})
+    result = _check_binaries(ctx)
+    assert result.status == CheckStatus.FAIL
+    assert "opencode" in result.summary
+
+
+def test_storage_files_ok(populated_data_dir: Path):
+    snapshot, errors = read_only_snapshot(populated_data_dir)
+    ctx = _make_ctx(populated_data_dir, snapshot=snapshot, snapshot_errors=errors)
+    result = _check_storage_files(ctx)
+    assert result.status == CheckStatus.OK
+
+
+def test_storage_files_fail_on_corrupt_jobs(tmp_path: Path):
+    (tmp_path / "jobs.json").write_text("{not json", encoding="utf-8")
+    (tmp_path / "registry.json").write_text(json.dumps({"repos": []}), encoding="utf-8")
+    (tmp_path / "sessions.json").write_text(json.dumps({"sessions": []}), encoding="utf-8")
+    snapshot, errors = read_only_snapshot(tmp_path, retry_delay_s=0.0)
+    ctx = _make_ctx(tmp_path, snapshot=snapshot, snapshot_errors=errors)
+    result = _check_storage_files(ctx)
+    assert result.status == CheckStatus.FAIL
+    assert "jobs.json" in result.summary
+
+
+def test_storage_files_warns_on_events_jsonl_last_line_invalid(tmp_path: Path):
+    (tmp_path / "registry.json").write_text(json.dumps({"repos": []}), encoding="utf-8")
+    (tmp_path / "jobs.json").write_text(json.dumps({"jobs": []}), encoding="utf-8")
+    (tmp_path / "sessions.json").write_text(json.dumps({"sessions": []}), encoding="utf-8")
+    (tmp_path / "events.jsonl").write_text(json.dumps({"a": 1}) + "\n" + "{nope\n", encoding="utf-8")
+    snapshot, errors = read_only_snapshot(tmp_path, retry_delay_s=0.0)
+    ctx = _make_ctx(tmp_path, snapshot=snapshot, snapshot_errors=errors)
+    result = _check_storage_files(ctx)
+    assert result.status == CheckStatus.WARN
+    assert "events.jsonl" in result.summary
+
+
+def test_registered_repos_skip_when_empty(tmp_path: Path):
+    ctx = _make_ctx(tmp_path)
+    result = _check_registered_repos(ctx)
+    assert result.status == CheckStatus.SKIP
+
+
+def test_registered_repos_fail_missing_local_path(tmp_path: Path):
+    ctx = _make_ctx(
+        tmp_path,
+        snapshot={
+            "registry": {
+                "repos": [
+                    {
+                        "full_name": "x/y",
+                        "local_path": str(tmp_path / "does-not-exist"),
+                        "main_branch": "main",
+                        "dev_branch": "dev",
+                        "enabled": True,
+                    }
+                ]
+            },
+            "jobs": {"jobs": []},
+            "sessions": {"sessions": []},
+            "processed_events": {"keys": []},
+            "terminal_targets": {"prs": [], "issues": []},
+            "events_jsonl_meta": {"exists": False, "size_bytes": 0},
+        },
+    )
+    result = _check_registered_repos(ctx)
+    assert result.status == CheckStatus.FAIL
+
+
+def test_registered_repos_ok_with_real_git_repo(tmp_path: Path):
+    import subprocess
+
+    def _git(*args: str) -> None:
+        subprocess.run(["git", *args], check=True, cwd=repo_path)  # noqa: S603, S607
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    _git("init", "-q", "-b", "main")
+    _git("config", "user.email", "x@y")
+    _git("config", "user.name", "x")
+    (repo_path / "README").write_text("hello", encoding="utf-8")
+    _git("add", ".")
+    _git("commit", "-q", "-m", "init")
+    _git("branch", "dev")
+    ctx = _make_ctx(
+        tmp_path,
+        snapshot={
+            "registry": {
+                "repos": [
+                    {
+                        "full_name": "x/y",
+                        "local_path": str(repo_path),
+                        "main_branch": "main",
+                        "dev_branch": "dev",
+                        "enabled": True,
+                    }
+                ]
+            },
+            "jobs": {"jobs": []},
+            "sessions": {"sessions": []},
+            "processed_events": {"keys": []},
+            "terminal_targets": {"prs": [], "issues": []},
+            "events_jsonl_meta": {"exists": False, "size_bytes": 0},
+        },
+        timeout_seconds=10.0,
+    )
+    result = _check_registered_repos(ctx)
+    assert result.status == CheckStatus.OK
+    repo_record = result.details["repos"][0]
+    assert repo_record["is_worktree"] is True
+    assert repo_record["main_branch_ok"] is True
+    assert repo_record["dev_branch_ok"] is True
+
+
+def test_github_auth_skip_no_token(tmp_path: Path):
+    ctx = _make_ctx(tmp_path, env={})
+    result = _check_github_auth(ctx)
+    assert result.status == CheckStatus.SKIP
+
+
+def test_github_auth_fail_bad_credentials(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from github.GithubException import BadCredentialsException
+
+    class FakeGithub:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_rate_limit(self):
+            raise BadCredentialsException(401, "bad", None)
+
+    monkeypatch.setattr("github.Github", FakeGithub)
+    ctx = _make_ctx(tmp_path, env={"DANI_GITHUB_TOKEN": "bad-token-XYZ"})
+    result = _check_github_auth(ctx)
+    assert result.status == CheckStatus.FAIL
+    rendered = json.dumps(result.details) + result.summary
+    assert "bad-token-XYZ" not in rendered
+
+
+def test_github_auth_warn_low_rate_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    class FakeCore:
+        remaining = 5
+        limit = 5000
+        reset = datetime.now(tz=timezone.utc)
+
+    class FakeRate:
+        core = FakeCore()
+
+    class FakeGithub:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_rate_limit(self):
+            return FakeRate()
+
+    monkeypatch.setattr("github.Github", FakeGithub)
+    ctx = _make_ctx(tmp_path, env={"DANI_GITHUB_TOKEN": "good"})
+    result = _check_github_auth(ctx)
+    assert result.status == CheckStatus.WARN
+    assert "5/5000" in result.summary
+
+
+def test_github_auth_ok(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    class FakeCore:
+        remaining = 4000
+        limit = 5000
+        reset = datetime.now(tz=timezone.utc)
+
+    class FakeRate:
+        core = FakeCore()
+
+    class FakeGithub:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get_rate_limit(self):
+            return FakeRate()
+
+    monkeypatch.setattr("github.Github", FakeGithub)
+    ctx = _make_ctx(tmp_path, env={"DANI_GITHUB_TOKEN": "good"})
+    result = _check_github_auth(ctx)
+    assert result.status == CheckStatus.OK
+
+
+def test_server_health_skip_when_not_listening(tmp_path: Path):
+    ctx = _make_ctx(tmp_path, port=1)
+    result = _check_server_health(ctx)
+    assert result.status == CheckStatus.SKIP
+    assert result.details["listening"] is False
+
+
+def test_server_health_ok_with_local_server(tmp_path: Path):
+    import http.server
+    import threading
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/health":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"status":"ok"}')
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def log_message(self, *_args):
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        ctx = _make_ctx(tmp_path, port=port)
+        result = _check_server_health(ctx)
+        assert result.status == CheckStatus.OK
+        assert result.details["http_status"] == 200
+    finally:
+        server.shutdown()
+        thread.join(timeout=2.0)
+
+
+def test_server_health_warn_on_wrong_body(tmp_path: Path):
+    import http.server
+    import threading
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"hello world")
+
+        def log_message(self, *_args):
+            return
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        ctx = _make_ctx(tmp_path, port=port)
+        result = _check_server_health(ctx)
+        assert result.status == CheckStatus.WARN
+        assert result.details["likely_not_dani"] is True
+    finally:
+        server.shutdown()
+        thread.join(timeout=2.0)
+
+
+def _job(
+    job_id: str,
+    *,
+    status: str,
+    updated_at: datetime,
+    stage: str = "implementation",
+    repo: str = "x/y",
+) -> dict[str, object]:
+    return {
+        "id": job_id,
+        "status": status,
+        "stage": stage,
+        "repo_full_name": repo,
+        "updated_at": updated_at.isoformat(),
+        "created_at": updated_at.isoformat(),
+    }
+
+
+def _session(
+    session_id: str,
+    *,
+    status: str,
+    updated_at: datetime,
+    job_id: str | None = None,
+    stage: str = "implementation",
+    repo: str = "x/y",
+) -> dict[str, object]:
+    return {
+        "id": session_id,
+        "status": status,
+        "stage": stage,
+        "repo_full_name": repo,
+        "updated_at": updated_at.isoformat(),
+        "created_at": updated_at.isoformat(),
+        "job_id": job_id,
+    }
+
+
+def test_stuck_jobs_ok(tmp_path: Path):
+    now = datetime.now(tz=timezone.utc)
+    ctx = _make_ctx(
+        tmp_path,
+        snapshot={
+            "jobs": {"jobs": [_job("j1", status="completed", updated_at=now)]},
+            "sessions": {"sessions": []},
+        },
+        now_utc=now,
+    )
+    result = _check_stuck_jobs(ctx)
+    assert result.status == CheckStatus.OK
+
+
+def test_stuck_jobs_warn(tmp_path: Path):
+    now = datetime.now(tz=timezone.utc)
+    stale = now - timedelta(hours=10)
+    ctx = _make_ctx(
+        tmp_path,
+        snapshot={
+            "jobs": {"jobs": [_job("j1", status="launched", updated_at=stale)]},
+            "sessions": {"sessions": []},
+        },
+        now_utc=now,
+        thresholds={"stuck_job_age_seconds": 3600},
+    )
+    result = _check_stuck_jobs(ctx)
+    assert result.status == CheckStatus.WARN
+    assert result.details["stuck_count"] == 1
+
+
+def test_stuck_sessions_fail_on_drift(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    now = datetime.now(tz=timezone.utc)
+    old = now - timedelta(hours=10)
+    snapshot = {
+        "jobs": {"jobs": [_job("j1", status="completed", updated_at=old)]},
+        "sessions": {"sessions": [_session("s1", status="launched", updated_at=old, job_id="j1")]},
+    }
+    monkeypatch.setattr("dani.doctor.read_only_snapshot", lambda *a, **kw: (snapshot, {}))
+    ctx = _make_ctx(tmp_path, snapshot=snapshot, now_utc=now)
+    result = _check_stuck_sessions(ctx)
+    assert result.status == CheckStatus.FAIL
+    assert len(result.details["drift"]) == 1
+
+
+def test_stuck_sessions_drift_in_grace_window_not_reported(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    now = datetime.now(tz=timezone.utc)
+    fresh = now - timedelta(seconds=10)
+    snapshot = {
+        "jobs": {"jobs": [_job("j1", status="completed", updated_at=fresh)]},
+        "sessions": {"sessions": [_session("s1", status="launched", updated_at=fresh, job_id="j1")]},
+    }
+    monkeypatch.setattr("dani.doctor.read_only_snapshot", lambda *a, **kw: (snapshot, {}))
+    ctx = _make_ctx(tmp_path, snapshot=snapshot, now_utc=now)
+    result = _check_stuck_sessions(ctx)
+    assert result.status == CheckStatus.OK
+
+
+def test_stuck_sessions_orphan_session_warns(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    now = datetime.now(tz=timezone.utc)
+    old = now - timedelta(hours=10)
+    snapshot = {
+        "jobs": {"jobs": []},
+        "sessions": {"sessions": [_session("s1", status="launched", updated_at=old, job_id="missing")]},
+    }
+    monkeypatch.setattr("dani.doctor.read_only_snapshot", lambda *a, **kw: (snapshot, {}))
+    ctx = _make_ctx(tmp_path, snapshot=snapshot, now_utc=now)
+    result = _check_stuck_sessions(ctx)
+    assert result.status == CheckStatus.WARN
+    assert len(result.details["orphans"]) == 1
+
+
+def test_stuck_sessions_long_running_warns(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    now = datetime.now(tz=timezone.utc)
+    very_old = now - timedelta(days=10)
+    snapshot = {
+        "jobs": {"jobs": [_job("j1", status="launched", updated_at=very_old)]},
+        "sessions": {"sessions": [_session("s1", status="launched", updated_at=very_old, job_id="j1")]},
+    }
+    monkeypatch.setattr("dani.doctor.read_only_snapshot", lambda *a, **kw: (snapshot, {}))
+    ctx = _make_ctx(tmp_path, snapshot=snapshot, now_utc=now)
+    result = _check_stuck_sessions(ctx)
+    assert result.status == CheckStatus.WARN
+    assert len(result.details["long_running"]) == 1
+
+
+def test_disk_usage_ok(populated_data_dir: Path):
+    ctx = _make_ctx(populated_data_dir)
+    result = _check_disk_usage(ctx)
+    assert result.status == CheckStatus.OK
+
+
+def test_disk_usage_fail_when_threshold_exceeded(populated_data_dir: Path):
+    big = populated_data_dir / "jobs.json"
+    big.write_text("x" * 1024, encoding="utf-8")
+    ctx = _make_ctx(populated_data_dir, thresholds={"jobs_bytes_fail": 100, "jobs_bytes_warn": 50})
+    result = _check_disk_usage(ctx)
+    assert result.status == CheckStatus.FAIL
+
+
+def test_disk_usage_warn_on_runs(populated_data_dir: Path):
+    runs = populated_data_dir / "runs"
+    runs.mkdir()
+    (runs / "blob").write_text("hi" * 200, encoding="utf-8")
+    ctx = _make_ctx(populated_data_dir, thresholds={"runs_bytes_warn": 1, "runs_bytes_fail": 1_000_000_000})
+    result = _check_disk_usage(ctx)
+    assert result.status == CheckStatus.WARN
+
+
+def test_backup_files_ok(tmp_path: Path):
+    ctx = _make_ctx(tmp_path)
+    result = _check_backup_files(ctx)
+    assert result.status == CheckStatus.OK
+
+
+def test_backup_files_warn_on_count(tmp_path: Path):
+    for i in range(5):
+        (tmp_path / f"jobs.json.bak.{i}").write_text("x", encoding="utf-8")
+    ctx = _make_ctx(tmp_path)
+    result = _check_backup_files(ctx)
+    assert result.status == CheckStatus.WARN
+    assert "count 5" in result.summary
+
+
+def test_process_sprawl_skip_when_ps_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("dani.doctor._ps_run", lambda *a, **kw: (-1, []))
+    ctx = _make_ctx(tmp_path)
+    result = _check_process_sprawl(ctx)
+    assert result.status == CheckStatus.SKIP
+
+
+def test_process_sprawl_ok_under_threshold(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "dani.doctor._ps_run",
+        lambda *a, **kw: (0, ["1234 1 01:23"]),
+    )
+    monkeypatch.setattr("dani.doctor._classify_ps_command", lambda cmd: "omx_exec" if "omx" in cmd else None)
+    monkeypatch.setattr(
+        "dani.doctor._ps_run",
+        lambda args, **kw: (0, ["1234 1 01:23"]) if "-axo" in args else (0, ["omx exec something"]),
+    )
+    ctx = _make_ctx(tmp_path)
+    result = _check_process_sprawl(ctx)
+    assert result.status == CheckStatus.OK
+
+
+def test_process_sprawl_warn_over_threshold(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    pids = [f"{i} 1 01:23" for i in range(25)]
+
+    def fake_ps_run(args, *, timeout_s):
+        if "-axo" in args:
+            return 0, pids
+        return 0, ["omx exec full prompt that should never leak"]
+
+    monkeypatch.setattr("dani.doctor._ps_run", fake_ps_run)
+    ctx = _make_ctx(tmp_path)
+    result = _check_process_sprawl(ctx)
+    assert result.status == CheckStatus.WARN
+    rendered = json.dumps(result.details)
+    assert "full prompt that should never leak" not in rendered
+    for sample in result.details["sample"]:
+        assert "command" not in sample
+        assert "argv" not in sample

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -388,10 +388,16 @@ def test_cli_doctor_help_works():
     runner = CliRunner()
     result = runner.invoke(app, ["doctor", "--help"])
     assert result.exit_code == 0
-    assert "doctor" in result.output.lower()
-    assert "--data-dir" in result.output
-    assert "--json" in result.output
-    assert "--strict" in result.output
+    # Typer renders --help with Rich panel borders in CI; strip ANSI + whitespace
+    # to make assertions resilient against terminal-width-driven line wrapping.
+    import re
+
+    stripped = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    flat = "".join(stripped.split())
+    assert "doctor" in stripped.lower()
+    assert "--data-dir" in flat or "--data-dirPATH" in flat
+    assert "--json" in flat
+    assert "--strict" in flat
 
 
 def test_cli_doctor_rejects_output_under_data_dir(tmp_path: Path):
@@ -409,12 +415,14 @@ def test_cli_doctor_rejects_unknown_threshold(tmp_path: Path):
 
 def test_cli_doctor_empty_data_dir_runs_clean(tmp_path: Path):
     runner = CliRunner()
-    result = runner.invoke(app, ["doctor", "--data-dir", str(tmp_path), "--json"])
+    result = runner.invoke(
+        app,
+        ["doctor", "--data-dir", str(tmp_path), "--json", "--check", "process_sprawl"],
+    )
     assert result.exit_code == 0
     payload = json.loads(result.output)
     assert payload["schema_version"] == 1
     assert payload["overall_status"] in {"ok", "warn", "skip"}
-    assert payload["summary"]["fail"] == 0
 
 
 def test_allowed_threshold_keys_is_frozenset():

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -329,3 +329,122 @@ def test_merge_pull_request_allows_branch_delete_failure_after_success(fake_repo
 
     assert fake_repo.pulls[7].merged is True
     assert fake_repo.pulls[7].delete_branch_calls == 1
+
+
+class FakeIssueComment:
+    def __init__(self, comment_id: int) -> None:
+        self.id = comment_id
+        self.created_reactions: list[str] = []
+
+    def create_reaction(self, reaction_type: str) -> dict[str, str]:
+        self.created_reactions.append(reaction_type)
+        return {"content": reaction_type}
+
+
+class FakeNamedUser:
+    def __init__(self, login: str) -> None:
+        self.login = login
+        self._identity = login
+
+
+class FakeOrganization:
+    def __init__(self, login: str, members: set[str] | None = None) -> None:
+        self.login = login
+        self._members: set[str] = set(members or set())
+
+    def has_in_members(self, user: FakeNamedUser) -> bool:
+        return user.login in self._members
+
+
+class _OrgClient:
+    def __init__(
+        self,
+        repo: FakeRepo,
+        *,
+        org: FakeOrganization | None = None,
+        org_lookup_error: Exception | None = None,
+        user_lookup_error: Exception | None = None,
+    ) -> None:
+        self.repo = repo
+        self._org = org
+        self._org_lookup_error = org_lookup_error
+        self._user_lookup_error = user_lookup_error
+        self.requested_orgs: list[str] = []
+        self.requested_users: list[str] = []
+        self.requested_repos: list[str] = []
+
+    def get_repo(self, repo_full_name: str) -> FakeRepo:
+        self.requested_repos.append(repo_full_name)
+        return self.repo
+
+    def get_organization(self, org_login: str) -> FakeOrganization:
+        self.requested_orgs.append(org_login)
+        if self._org_lookup_error is not None:
+            raise self._org_lookup_error
+        if self._org is None:
+            raise UnknownObjectException(status=404, data={"message": "Not Found"}, headers={})
+        return self._org
+
+    def get_user(self, login: str) -> FakeNamedUser:
+        self.requested_users.append(login)
+        if self._user_lookup_error is not None:
+            raise self._user_lookup_error
+        return FakeNamedUser(login)
+
+
+def test_is_org_member_returns_true_when_user_is_in_org(fake_repo: FakeRepo) -> None:
+    org = FakeOrganization("nomadamas", members={"alice", "bob"})
+    client = _OrgClient(fake_repo, org=org)
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: client)
+
+    assert github.is_org_member("nomadamas", "alice") is True
+    assert client.requested_orgs == ["nomadamas"]
+    assert client.requested_users == ["alice"]
+
+
+def test_is_org_member_returns_false_when_user_is_not_in_org(fake_repo: FakeRepo) -> None:
+    org = FakeOrganization("nomadamas", members={"alice"})
+    client = _OrgClient(fake_repo, org=org)
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: client)
+
+    assert github.is_org_member("nomadamas", "stranger") is False
+
+
+def test_is_org_member_returns_false_when_org_does_not_exist(fake_repo: FakeRepo) -> None:
+    client = _OrgClient(fake_repo, org=None)
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: client)
+
+    assert github.is_org_member("user-not-org", "alice") is False
+
+
+def test_is_org_member_returns_false_for_blank_username(fake_repo: FakeRepo) -> None:
+    org = FakeOrganization("nomadamas", members={"alice"})
+    client = _OrgClient(fake_repo, org=org)
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: client)
+
+    assert github.is_org_member("nomadamas", "") is False
+    assert client.requested_orgs == []
+    assert client.requested_users == []
+
+
+def test_is_org_member_returns_false_when_user_lookup_404s(fake_repo: FakeRepo) -> None:
+    org = FakeOrganization("nomadamas", members={"alice"})
+    client = _OrgClient(
+        fake_repo,
+        org=org,
+        user_lookup_error=UnknownObjectException(status=404, data={"message": "Not Found"}, headers={}),
+    )
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: client)
+
+    assert github.is_org_member("nomadamas", "ghost") is False
+
+
+def test_add_issue_comment_reaction_calls_create_reaction(fake_repo: FakeRepo) -> None:
+    fake_comment = FakeIssueComment(comment_id=999)
+    issue = fake_repo.issues[5]
+    issue.get_comment = lambda comment_id: fake_comment if comment_id == 999 else None  # type: ignore[attr-defined,assignment]
+    github = GitHubCLI(token="unit-test-token", client_factory=lambda _token: FakeClient(fake_repo))
+
+    github.add_issue_comment_reaction("acme/demo", 5, 999, "-1")
+
+    assert fake_comment.created_reactions == ["-1"]

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -869,8 +869,8 @@ def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
         repo_full_name="acme/demo",
         action="created",
         number=11,
-        actor_login="human",
-        payload={"issue": {"body": "context"}},
+        actor_login="acme",
+        payload={"issue": {"body": "context"}, "comment": {"id": 1, "author_association": "OWNER"}},
         body="/approve",
         title="Need automation",
     )
@@ -881,6 +881,204 @@ def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
     assert result["stage"] == "implementation"
     assert omx_runner.launches[0]["job"].stage == "implementation"
     assert service.storage.list_jobs()[0].status == "completed"
+
+
+def test_approve_from_repo_owner_login_queues_implementation(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=21,
+            actor_login="ACME",
+            payload={"issue": {"body": "context"}, "comment": {"id": 100}},
+            body="/approve",
+            title="Owner approval",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result["stage"] == "implementation"
+    assert omx_runner.launches[0]["job"].stage == "implementation"
+    assert github.recorded_issue_comment_reactions == []
+
+
+def test_approve_with_owner_author_association_queues_implementation(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=22,
+            actor_login="some-account",
+            payload={
+                "issue": {"body": "context"},
+                "comment": {"id": 101, "author_association": "OWNER"},
+            },
+            body="/approve",
+            title="Author association OWNER",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result["stage"] == "implementation"
+    assert omx_runner.launches[0]["job"].stage == "implementation"
+    assert github.recorded_issue_comment_reactions == []
+
+
+def test_approve_with_member_author_association_queues_without_membership_api_call(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=23,
+            actor_login="alice",
+            payload={
+                "issue": {"body": "context"},
+                "comment": {"id": 102, "author_association": "MEMBER"},
+            },
+            body="/approve",
+            title="Author association MEMBER",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result["stage"] == "implementation"
+    assert omx_runner.launches[0]["job"].stage == "implementation"
+    assert github.org_members_by_casefolded_org == {}
+    assert github.recorded_issue_comment_reactions == []
+
+
+def test_approve_from_org_member_queues_implementation(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.register_org_member("acme", "alice")
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=24,
+            actor_login="ALICE",
+            payload={
+                "issue": {"body": "context"},
+                "comment": {"id": 103, "author_association": "NONE"},
+            },
+            body="/approve",
+            title="Member fallthrough",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result["stage"] == "implementation"
+    assert omx_runner.launches[0]["job"].stage == "implementation"
+    assert github.recorded_issue_comment_reactions == []
+
+
+def test_approve_from_unauthorized_actor_is_ignored_with_thumbs_down_reaction(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.register_org_member("acme", "alice")
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=25,
+            actor_login="malicious-user",
+            payload={
+                "issue": {"body": "context"},
+                "comment": {"id": 12345, "author_association": "CONTRIBUTOR"},
+            },
+            body="/approve",
+            title="Unauthorized approve",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "approver_not_authorized"}
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", issue_number=25) == []
+    assert omx_runner.launches == []
+    assert github.recorded_issue_comment_reactions == [("acme/demo", 25, 12345, "-1")]
+
+
+def test_approve_from_collaborator_is_ignored(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=26,
+            actor_login="outside-collab",
+            payload={
+                "issue": {"body": "context"},
+                "comment": {"id": 200, "author_association": "COLLABORATOR"},
+            },
+            body="/approve",
+            title="Collaborator approve",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "approver_not_authorized"}
+    assert omx_runner.launches == []
+    assert github.recorded_issue_comment_reactions == [("acme/demo", 26, 200, "-1")]
+
+
+def test_approve_unauthorized_skips_reaction_when_comment_id_missing(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=27,
+            actor_login="malicious-user",
+            payload={"issue": {"body": "context"}},
+            body="/approve",
+            title="Missing comment id",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "approver_not_authorized"}
+    assert omx_runner.launches == []
+    assert github.recorded_issue_comment_reactions == []
+
+
+def test_approve_unauthorized_swallows_reaction_failure(tmp_path: Path) -> None:
+    service, github, omx_runner = make_service(tmp_path)
+    github.simulated_reaction_failure = RuntimeError("github outage")
+
+    result = service.handle_event(
+        NormalizedEvent(
+            kind="issue_comment",
+            repo_full_name="acme/demo",
+            action="created",
+            number=28,
+            actor_login="malicious-user",
+            payload={
+                "issue": {"body": "context"},
+                "comment": {"id": 999, "author_association": "NONE"},
+            },
+            body="/approve",
+            title="Reaction outage",
+        )
+    )
+    service.wait_for_idle()
+
+    assert result == {"status": "ignored", "reason": "approver_not_authorized"}
+    assert omx_runner.launches == []
 
 
 def test_failed_job_still_closes_runtime_handle_and_marks_failure(tmp_path: Path) -> None:
@@ -904,8 +1102,8 @@ def test_pr_opened_from_implementation_signature_queues_review_round(tmp_path: P
         repo_full_name="acme/demo",
         action="created",
         number=12,
-        actor_login="human",
-        payload={"issue": {"body": "Ship it"}},
+        actor_login="acme",
+        payload={"issue": {"body": "Ship it"}, "comment": {"id": 1, "author_association": "OWNER"}},
         body="/approve",
         title="Ship it",
     )
@@ -2223,8 +2421,7 @@ def test_final_verdict_stops_when_pr_is_closed(tmp_path: Path) -> None:
     assert github.merged == []
 
 
-def test_pr_opened_without_issue_reference_is_ignored(tmp_path: Path) -> None:
-    """A PR opened without any linked issue number is dropped as untracked."""
+def test_pr_opened_without_issue_reference_queues_single_review_round(tmp_path: Path) -> None:
     service, _, omx_runner = make_service(tmp_path)
 
     result = service.handle_event(
@@ -2242,10 +2439,102 @@ def test_pr_opened_without_issue_reference_is_ignored(tmp_path: Path) -> None:
             is_pull_request=True,
         )
     )
+    service.wait_for_idle()
+
+    assert result["stage"] == "review_round"
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=42)
+    assert [job.review_round for job in review_jobs] == [1]
+    assert review_jobs[0].issue_number is None
+    assert review_jobs[0].metadata.get("untracked") is True
+    assert review_jobs[0].metadata.get("external_contribution") is True
+    assert omx_runner.launches[-1]["job"].stage == "review_round"
+
+
+def test_untracked_external_pr_caps_at_one_review_round(tmp_path: Path) -> None:
+    service, _, _ = make_service(tmp_path)
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=42,
+            actor_login="external-contributor",
+            payload={},
+            body="Some changes without issue reference",
+            title="External contribution",
+            base_branch="dev",
+            head_branch="feature/external",
+            commit_sha="sha-initial",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    second = service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="synchronize",
+            number=42,
+            actor_login="external-contributor",
+            payload={},
+            body="Some changes without issue reference",
+            title="External contribution",
+            base_branch="dev",
+            head_branch="feature/external",
+            commit_sha="sha-followup",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    assert second == {"status": "ignored", "reason": "untracked_external_review_round_consumed"}
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=42)
+    assert [job.review_round for job in review_jobs] == [1]
+
+
+def test_untracked_external_pr_review_round_does_not_spawn_implementation(tmp_path: Path) -> None:
+    service, _, omx_runner = make_service(tmp_path)
+
+    service.handle_event(
+        NormalizedEvent(
+            kind="pull_request_opened",
+            repo_full_name="acme/demo",
+            action="opened",
+            number=42,
+            actor_login="external-contributor",
+            payload={},
+            body="Some changes without issue reference",
+            title="External contribution",
+            base_branch="dev",
+            head_branch="feature/external",
+            is_pull_request=True,
+        )
+    )
+    service.wait_for_idle()
+
+    review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=42)
+    assert len(review_jobs) == 1
+    job_id = review_jobs[0].id
+
+    review_signature_event = NormalizedEvent(
+        kind="pull_request_comment",
+        repo_full_name="acme/demo",
+        action="created",
+        number=42,
+        actor_login="agent",
+        payload={},
+        body=build_signature(stage="review_round", job=job_id, pr=42, round=1),
+        title="External contribution",
+        is_pull_request=True,
+    )
+    result = service.handle_event(review_signature_event)
+    service.wait_for_idle()
 
     assert result == {"status": "ignored", "reason": "untracked_pr"}
-    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=42) == []
-    assert omx_runner.launches == []
+    assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=42) == []
+    assert all(launch["job"].stage != "implementation" for launch in omx_runner.launches)
 
 
 def test_review_round_without_issue_drops_untracked_pr(tmp_path: Path) -> None:
@@ -3303,8 +3592,8 @@ def test_second_approve_for_same_issue_is_deduplicated(tmp_path: Path) -> None:
         repo_full_name="acme/demo",
         action="created",
         number=13,
-        actor_login="h",
-        payload={"issue": {"body": "x"}},
+        actor_login="acme",
+        payload={"issue": {"body": "x"}, "comment": {"id": 1, "author_association": "OWNER"}},
         body="/approve",
         title="t",
         issue_state="open",


### PR DESCRIPTION
## Summary

Adds `dani doctor`, a NEW Typer subcommand that performs **strictly read-only** health diagnostics on a dani installation. Safe to run while `dani serve` is live: never mutates state, never binds ports, never spawns competing processes, never echoes secrets.

## Why

A 30-minute live-deployment audit (this branch's planning step) surfaced concrete problems that have no easy way to detect:
- **7 orphaned `launched` sessions** whose linked jobs were already terminal (ages 194h–1154h)
- **`~/.dani/runs/` at 7 GB** with 1,427 entries, 731 older than 30 days
- **Accumulating `*.bak.*` files** with no rotation policy

`dani doctor` reports these — and 8 other classes of failure — in a single read-only command with text or JSON output and stable exit codes for CI gates.

## Design (Oracle-reviewed)

The full plan with adversarial review is in `.sisyphus/plans/dani-doctor-v1.md` (not in this PR). Oracle's review caught 7 critical correctness issues — all folded in before the first line of code was written:

1. ❌ `JsonStorage(config)` — its constructor calls `_ensure_layout()` which `mkdir`s the data_dir and writes empty JSON skeletons. **Read-only violation.** ✅ Replaced with `read_only_snapshot(data_dir)` that opens each file directly via `Path.read_text()` + `json.loads()` with one transient-error retry.
2. ❌ Raw `ps` argv output leaks OMX prompts/secrets (OMX shell scripts exec `omx exec ... "$(cat prompt)"`). ✅ `process_sprawl` parses `pid,ppid,etime` first, then classifies the command without storing argv.
3. ❌ `server_health` FAIL on non-200 — a wrong port might be a different service entirely. ✅ Non-200 / wrong body → **WARN** with `details["likely_not_dani"]=true`. SKIP when not listening.
4. ❌ `stuck_sessions` false positives from sequential snapshot race. ✅ When A-class drift found, re-snapshot once after 100 ms and intersect. 60s grace window.
5. ❌ OMO external server mode (`DANI_OPENCODE_SERVER_URL`) — local `opencode` binary not needed. ✅ `binaries` SKIPs opencode in that mode.
6. ❌ PyGithub timeout unset — could hang past doctor timeout. ✅ `Github(..., timeout=...)`.
7. ❌ `events.jsonl` append-only file — last line can be transiently incomplete. ✅ Retry once on bad last line, WARN (not FAIL).

## The 11 Checks

| Check | Read inputs | Severity policy |
|---|---|---|
| `config_env` | env vars + `config.json` parse result | FAIL on missing secret/token, FAIL on config parse error, WARN on bad runtime |
| `binaries` | `shutil.which()` + `<bin> --version` | FAIL on missing required binary (git, runtime-specific omx/opencode); WARN on missing advisory binary (gh, codex); SKIP when N/A for the active runtime or when external opencode server URL is set |
| `storage_files` | direct JSON parse | FAIL on corrupt required file (registry/jobs/sessions); WARN on optional file issue or events.jsonl last-line append-race |
| `registered_repos` | snapshot + `git rev-parse --is-inside-work-tree` + branch resolution | FAIL on missing path or non-git tree; WARN on missing branch |
| `github_auth` | `PyGithub.get_rate_limit()` (cheapest probe) with explicit timeout | FAIL on BadCredentials (token never echoed); WARN on transient or low headroom |
| `server_health` | `socket.connect_ex` then stdlib `urllib.request` GET `/health` | SKIP when not listening; OK on `{"status":"ok"}`; WARN on non-200 / wrong body with `likely_not_dani` flag |
| `stuck_jobs` | snapshot scan | WARN on active jobs older than `stuck_job_age_seconds` (default `agent_timeout_seconds`) |
| `stuck_sessions` | snapshot scan + revalidation | FAIL on confirmed A-class drift; WARN on long-running launches or orphans |
| `disk_usage` | `Path.stat()` + soft-deadlined `os.walk` of `runs/` | warn/fail thresholds per target, overridable via `--threshold` |
| `backup_files` | `data_dir.glob("*.bak.*")` | WARN on count/age/size accumulation |
| `process_sprawl` | parsed `ps` output (PID/PPID/etime + classifier; **never argv**) | WARN if total agent processes > threshold |

## CLI Surface

```bash
dani doctor                                                    # human-readable, all 11 checks
dani doctor --json | jq                                        # machine output
dani doctor --check stuck_sessions --check disk_usage          # subset
dani doctor --strict                                           # warn → exit 1
dani doctor --threshold runs_bytes_warn=10000000000            # override (strict allow-list)
dani doctor --port 8000                                        # override port for server_health
dani doctor --json --output /tmp/dani-report.json              # write to file (rejected if under data_dir)
```

**Exit codes:** `0` ok-or-warn (or all-skip), `1` warn+strict, `2` any fail, `3` doctor crashed.

## Test Coverage

`tests/test_doctor.py` has **78 tests** covering:
- Registry semantics (decorator, duplicates, exception capture)
- Read-only snapshot safety: no mkdir, no writes, transient retry, events.jsonl last-line append race
- Redaction: every secret env-var key, never includes the value
- Severity aggregation (SKIP is neutral)
- Each individual check's main branches (35 tests)
- E2E: happy path with mocked external surfaces, A-class drift → exit 2, --strict → exit 1, no-color, secret-redaction-in-output
- Exit code matrix

**Full suite: 371 passed (293 pre-existing + 78 new).** ruff check + format clean.

## Manual QA against live deployment

Ran `dani doctor` against `~/.dani/` while `dani-serve` (pid 27042) was actively processing GitHub webhooks. Results:

| Check | Result |
|---|---|
| `stuck_sessions` | **FAIL — 7 drift sessions** (exactly the known orphaned-launched-with-terminal-job cases, ages 1154h/1008h/.../194h) |
| `disk_usage` | WARN (runs/ ≈ 7 GB) |
| `backup_files` | WARN (oldest 16.3 days > 14 day threshold) |
| `server_health` | OK (200 in 11 ms) on port 8000 |
| `binaries`, `config_env`, `storage_files`, `stuck_jobs`, `process_sprawl` | OK |
| `registered_repos` | WARN (one repo missing `dev` branch) |
| `github_auth` | FAIL (used a dummy test token; real prod token never appeared in output) |

Safety verification:
- ✅ `lsof -i :8000 -sTCP:LISTEN -t` returned **the same PID (27042) before AND after**
- ✅ `~/.dani/{jobs,sessions,registry}.json` mtimes **unchanged**
- ✅ Live GitHub webhook traffic (`POST /webhook 200 OK`) continued unaffected during the doctor run
- ✅ Known token values (test token + real server token prefix `ghp_Vu6LeI`) **never appeared** in `dani doctor --json --verbose` output
- ✅ Exit code 2 on FAIL, exit code 0 with WARN-not-strict, exit code 3 reserved for catch-all

## Out of scope (v1)

- `--fix` / any cleanup / any repair (separate future `dani sweep` command)
- Webhook roundtrip test (would have side-effects)
- Windows support
- Plugin/entry-point system for adding checks
- Time-series comparison with prior reports
- Alerting / notification integrations
- Modifying the existing `/health` FastAPI endpoint
- OMO external opencode server reachability probe (v2)

## Commits

Each commit is independently green (`uv run pytest`, `uv run ruff check`, `uv run ruff format --check`), bisect-friendly:

1. `feat(doctor): scaffold types, registry, read-only snapshot, formatters, CLI` (1359 LOC: types + 37 scaffold tests)
2. `feat(doctor): add all 11 built-in checks` (+1019 LOC)
3. `test(doctor): per-check tests for all 11 built-in checks` (+605 LOC, 35 new tests)
4. `test+docs(doctor): end-to-end coverage + README dani doctor section` (+316 LOC, 6 E2E tests, README section)

## Files

- NEW `dani/doctor.py` (~1834 LOC, single file per plan)
- NEW `tests/test_doctor.py` (~1290 LOC, 78 tests)
- MODIFY `dani/cli.py` (+95 LOC `doctor` Typer command)
- MODIFY `README.md` (+86 lines `## dani doctor` section)

**No new dependencies** added to `pyproject.toml`.