### PR TITLE
fix: prune duplicate signed comments and harden anti-duplicate prompt

### DIFF
--- a/dani/github.py
+++ b/dani/github.py
@@ -121,6 +121,32 @@ class GitHubCLI:
         pull_request = self._repo(repo_full_name).get_pull(pr_number)
         return pull_request.create_issue_comment(body).raw_data
 
+    def delete_issue_comment(self, repo_full_name: str, comment_id: int) -> bool:
+        """Delete a single issue/PR comment by id.
+
+        Returns True on successful deletion, False if the comment no longer exists.
+        Other GithubException values propagate so callers can decide whether to
+        treat the failure as fatal.
+        """
+        repo = self._repo(repo_full_name)
+        try:
+            comment = repo.get_issue_comment(comment_id)
+        except UnknownObjectException:
+            return False
+        except GithubException as exc:
+            if exc.status == 404:
+                return False
+            raise
+        try:
+            comment.delete()
+        except UnknownObjectException:
+            return False
+        except GithubException as exc:
+            if exc.status == 404:
+                return False
+            raise
+        return True
+
     def close_pull_request(self, repo_full_name: str, pr_number: int) -> None:
         pull_request = self._repo(repo_full_name).get_pull(pr_number)
         pull_request.edit(state="closed")

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -68,6 +68,14 @@ For the "Evidence-based implementation plan" section, report:
 Use this exact signature somewhere in the comment:
 $signature
 
+POST EXACTLY ONCE. Strict anti-duplicate contract:
+- Before calling `gh issue comment`, run:
+  gh issue view $issue_number --repo $repo --json comments --jq '.comments[].body' | grep -F '$signature' || true
+  If that command prints anything non-empty, a comment with this exact signature already exists. DO NOT post again. Exit immediately.
+- Call `gh issue comment` at most ONE time in this session.
+- After `gh issue comment` returns successfully, do not run it again under any circumstance — not for retries, not for self-review, not for "double-checking". Exit.
+- If `gh issue comment` appears to fail, re-run the `gh issue view ... | grep` check before retrying. If the signature is already present, the post succeeded; do not retry; exit.
+
 Post it with gh (write the comment to a file first, then send it):
 gh issue comment $issue_number --repo $repo --body-file <comment-file.md>
 
@@ -101,6 +109,14 @@ Write exactly one GitHub issue comment that addresses the new follow-up. The com
 - Remind the human that implementation starts only after a comment containing "/approve".
 - Include this exact signature on its own line:
 $signature
+
+POST EXACTLY ONCE. Strict anti-duplicate contract:
+- Before calling `gh issue comment`, run:
+  gh issue view $issue_number --repo $repo --json comments --jq '.comments[].body' | grep -F '$signature' || true
+  If that command prints anything non-empty, a comment with this exact signature already exists. DO NOT post again. Exit immediately.
+- Call `gh issue comment` at most ONE time in this session.
+- After `gh issue comment` returns successfully, do not run it again under any circumstance — not for retries, not for self-review, not for "double-checking". Exit.
+- If `gh issue comment` appears to fail, re-run the `gh issue view ... | grep` check before retrying. If the signature is already present, the post succeeded; do not retry; exit.
 
 Post it with gh (write the comment to a file first, then send it):
 gh issue comment $issue_number --repo $repo --body-file <followup-comment.md>

--- a/dani/service.py
+++ b/dani/service.py
@@ -1657,6 +1657,17 @@ class DaniService:
             f"Original job id: {source_job_id}\n"
             f"Original stage: {original_stage}\n"
             f"Required exact Dani signature:\n{expected_signature}\n\n"
+            "POST EXACTLY ONCE. Strict anti-duplicate contract:\n"
+            "- Before calling `gh issue comment`, run:\n"
+            f"  gh issue view {issue_number} --repo {repo.full_name} --json comments --jq '.comments[].body' "
+            f"| grep -F '{expected_signature}' || true\n"
+            "  If that command prints anything non-empty, the recovery comment already exists. DO NOT post again. "
+            "Exit immediately.\n"
+            "- Call `gh issue comment` at most ONE time in this session.\n"
+            "- After `gh issue comment` returns successfully, do not run it again — not for retries, not for "
+            "self-review, not for 'double-checking'. Exit.\n"
+            "- If `gh issue comment` appears to fail, re-run the `gh issue view ... | grep` check before retrying. "
+            "If the signature is already present, the post succeeded; do not retry; exit.\n\n"
             "Post it with gh (write the comment to a file first, then send it):\n"
             f"gh issue comment {issue_number} --repo {repo.full_name} --body-file <recovery-comment.md>\n\n"
             "After posting the comment, exit."
@@ -1764,21 +1775,36 @@ class DaniService:
 
     def _verify_issue_request_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
         signature = build_signature(stage="issue_request", job=job.id, issue=int(job.issue_number or 0))
-        if not self._has_exact_issue_signature(repo.full_name, int(job.issue_number or 0), signature):
-            raise RuntimeError("issue-request-comment-missing")
+        self._ensure_single_issue_signature_comment(
+            repo.full_name,
+            int(job.issue_number or 0),
+            signature,
+            missing_error="issue-request-comment-missing",
+            job=job,
+        )
 
     def _verify_issue_followup_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
         signature = build_signature(stage="issue_followup", job=job.id, issue=int(job.issue_number or 0))
-        if not self._has_exact_issue_signature(repo.full_name, int(job.issue_number or 0), signature):
-            raise RuntimeError("issue-followup-comment-missing")
+        self._ensure_single_issue_signature_comment(
+            repo.full_name,
+            int(job.issue_number or 0),
+            signature,
+            missing_error="issue-followup-comment-missing",
+            job=job,
+        )
 
     def _verify_issue_comment_recovery_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
         signature = str(job.metadata.get("expected_signature") or "")
         if not signature:
             raise RuntimeError("issue-comment-recovery-missing-signature")
-        if not self._has_exact_issue_signature(repo.full_name, int(job.issue_number or 0), signature):
-            original_error = str(job.metadata.get("original_error") or "issue-comment-missing")
-            raise RuntimeError(original_error)
+        original_error = str(job.metadata.get("original_error") or "issue-comment-missing")
+        self._ensure_single_issue_signature_comment(
+            repo.full_name,
+            int(job.issue_number or 0),
+            signature,
+            missing_error=original_error,
+            job=job,
+        )
 
     def _verify_implementation_side_effect(self, repo: RepoConfig, job: JobRecord) -> None:
         signature_fields: dict[str, int | str] = {
@@ -1865,6 +1891,70 @@ class DaniService:
                 repo_full_name, issue_number, kind="issue", signature_fragment=signature
             )
         )
+
+    def _ensure_single_issue_signature_comment(
+        self,
+        repo_full_name: str,
+        issue_number: int,
+        signature: str,
+        *,
+        missing_error: str,
+        job: JobRecord | None = None,
+    ) -> None:
+        comments = self.github.find_comments_by_signature(
+            repo_full_name, issue_number, kind="issue", signature_fragment=signature
+        )
+        if not comments:
+            raise RuntimeError(missing_error)
+        if len(comments) <= 1:
+            return
+        ordered = sorted(comments, key=lambda comment: str(comment.get("created_at") or ""))
+        keeper = ordered[0]
+        duplicates = ordered[1:]
+        deleted_ids: list[int] = []
+        failed_ids: list[int] = []
+        for duplicate in duplicates:
+            comment_id = duplicate.get("id")
+            if not isinstance(comment_id, int):
+                continue
+            try:
+                if self.github.delete_issue_comment(repo_full_name, comment_id):
+                    deleted_ids.append(comment_id)
+            except Exception:
+                failed_ids.append(comment_id)
+                logger.warning(
+                    "duplicate_signature_comment_delete_failed",
+                    extra={
+                        "repo_full_name": repo_full_name,
+                        "issue_number": issue_number,
+                        "comment_id": comment_id,
+                        "signature": signature,
+                    },
+                    exc_info=True,
+                )
+        logger.warning(
+            "duplicate_signature_comments_pruned",
+            extra={
+                "repo_full_name": repo_full_name,
+                "issue_number": issue_number,
+                "signature": signature,
+                "kept_comment_id": keeper.get("id"),
+                "duplicate_count": len(duplicates),
+                "deleted_comment_ids": deleted_ids,
+                "failed_comment_ids": failed_ids,
+                "job_id": job.id if job is not None else None,
+            },
+        )
+        if job is not None:
+            note = {
+                "duplicate_count": len(duplicates),
+                "deleted_comment_ids": deleted_ids,
+                "failed_comment_ids": failed_ids,
+                "kept_comment_id": keeper.get("id"),
+            }
+            history = list(job.metadata.get("duplicate_signature_prunes") or [])
+            history.append(note)
+            job.metadata["duplicate_signature_prunes"] = history
 
     def _is_approve_comment(self, body: str | None) -> bool:
         return bool(body and "/approve" in body.lower())

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -27,6 +27,17 @@ class FakeGitHubCLI:
         self.org_members_by_casefolded_org: dict[str, set[str]] = {}
         self.recorded_issue_comment_reactions: list[tuple[str, int, int, str]] = []
         self.simulated_reaction_failure: Exception | None = None
+        self.deleted_issue_comment_ids: list[tuple[str, int]] = []
+        self._next_comment_id: int = 1
+        self._next_comment_created_at: int = 0
+
+    def _allocate_comment(self, body: str) -> dict[str, Any]:
+        comment_id = self._next_comment_id
+        self._next_comment_id += 1
+        created_seq = self._next_comment_created_at
+        self._next_comment_created_at += 1
+        created_at = f"2026-01-01T00:00:{created_seq:02d}Z"
+        return {"id": comment_id, "body": body, "created_at": created_at}
 
     def list_open_issues(self, repo_full_name: str) -> list[dict[str, Any]]:
         return list(self.open_issues.get(repo_full_name, []))
@@ -101,20 +112,31 @@ class FakeGitHubCLI:
             labels.append(label)
 
     def add_issue_signature(self, repo_full_name: str, issue_number: int, signature: str) -> None:
-        self.issue_comment_map.setdefault((repo_full_name, issue_number), []).append({"body": signature})
+        self.issue_comment_map.setdefault((repo_full_name, issue_number), []).append(self._allocate_comment(signature))
 
     def add_pr_signature(self, repo_full_name: str, pr_number: int, signature: str) -> None:
-        self.pr_comment_map.setdefault((repo_full_name, pr_number), []).append({"body": signature})
+        self.pr_comment_map.setdefault((repo_full_name, pr_number), []).append(self._allocate_comment(signature))
 
     def create_issue_comment(self, repo_full_name: str, issue_number: int, body: str) -> dict[str, Any]:
-        comment = {"body": body}
+        comment = self._allocate_comment(body)
         self.issue_comment_map.setdefault((repo_full_name, issue_number), []).append(comment)
         return comment
 
     def create_pr_comment(self, repo_full_name: str, pr_number: int, body: str) -> dict[str, Any]:
-        comment = {"body": body}
+        comment = self._allocate_comment(body)
         self.pr_comment_map.setdefault((repo_full_name, pr_number), []).append(comment)
         return comment
+
+    def delete_issue_comment(self, repo_full_name: str, comment_id: int) -> bool:
+        for (key_repo, _issue_number), comments in self.issue_comment_map.items():
+            if key_repo != repo_full_name:
+                continue
+            for index, comment in enumerate(comments):
+                if comment.get("id") == comment_id:
+                    del comments[index]
+                    self.deleted_issue_comment_ids.append((repo_full_name, comment_id))
+                    return True
+        return False
 
     def add_pull_request(
         self,

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -133,6 +133,48 @@ def test_issue_request_prompt_uses_gh_instructions() -> None:
     assert "PyGithub helper" not in prompt
 
 
+def test_issue_request_prompt_enforces_anti_duplicate_pre_check() -> None:
+    signature = "<!-- dani:stage=issue_request;job=abc;issue=7 -->"
+    prompt = render_prompt(
+        "issue_request",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "discussion": "",
+            "signature": signature,
+        },
+    )
+
+    assert "POST EXACTLY ONCE" in prompt
+    assert "gh issue view 7 --repo acme/demo --json comments" in prompt
+    assert f"grep -F '{signature}'" in prompt
+    assert "at most ONE time" in prompt
+
+
+def test_issue_followup_prompt_enforces_anti_duplicate_pre_check() -> None:
+    signature = "<!-- dani:stage=issue_followup;job=xyz;issue=7 -->"
+    prompt = render_prompt(
+        "issue_followup",
+        {
+            "repo": "acme/demo",
+            "local_path": "workspace/demo",
+            "issue_number": 7,
+            "issue_title": "Need a bot",
+            "issue_body": "Implement it",
+            "comment_body": "any chance you can build it?",
+            "signature": signature,
+        },
+    )
+
+    assert "POST EXACTLY ONCE" in prompt
+    assert "gh issue view 7 --repo acme/demo --json comments" in prompt
+    assert f"grep -F '{signature}'" in prompt
+    assert "at most ONE time" in prompt
+
+
 def test_issue_request_prompt_requires_ai_summary_and_expected_outcome() -> None:
     prompt = render_prompt(
         "issue_request",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -584,6 +584,87 @@ def test_issue_followup_verification_rejects_stale_signature(tmp_path: Path) -> 
         service._verify_side_effect(repo, job)
 
 
+def test_issue_followup_verification_prunes_duplicate_signatures(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_followup", issue_number=267)
+    signature = build_signature(stage="issue_followup", job=job.id, issue=267)
+    for _ in range(5):
+        github.add_issue_signature("acme/demo", 267, signature)
+    initial_comments = github.issue_comments("acme/demo", 267)
+    assert len(initial_comments) == 5
+    earliest_id = initial_comments[0]["id"]
+    duplicate_ids = [comment["id"] for comment in initial_comments[1:]]
+
+    service._verify_side_effect(repo, job)
+
+    remaining = github.issue_comments("acme/demo", 267)
+    assert len(remaining) == 1
+    assert remaining[0]["id"] == earliest_id
+    assert sorted(comment_id for _repo, comment_id in github.deleted_issue_comment_ids) == sorted(duplicate_ids)
+    prunes = job.metadata.get("duplicate_signature_prunes")
+    assert prunes and prunes[-1]["duplicate_count"] == 4
+    assert prunes[-1]["kept_comment_id"] == earliest_id
+
+
+def test_issue_request_verification_prunes_duplicate_signatures(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_request", issue_number=42)
+    signature = build_signature(stage="issue_request", job=job.id, issue=42)
+    for _ in range(3):
+        github.add_issue_signature("acme/demo", 42, signature)
+    earliest_id = github.issue_comments("acme/demo", 42)[0]["id"]
+
+    service._verify_side_effect(repo, job)
+
+    remaining = github.issue_comments("acme/demo", 42)
+    assert len(remaining) == 1
+    assert remaining[0]["id"] == earliest_id
+
+
+def test_issue_followup_verification_keeps_single_signature_untouched(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    job = JobRecord(repo_full_name=repo.full_name, stage="issue_followup", issue_number=99)
+    signature = build_signature(stage="issue_followup", job=job.id, issue=99)
+    github.add_issue_signature("acme/demo", 99, signature)
+
+    service._verify_side_effect(repo, job)
+
+    assert len(github.issue_comments("acme/demo", 99)) == 1
+    assert github.deleted_issue_comment_ids == []
+    assert "duplicate_signature_prunes" not in job.metadata
+
+
+def test_issue_comment_recovery_verification_prunes_duplicate_recovery_comments(tmp_path: Path) -> None:
+    service, github, _ = make_service(tmp_path)
+    repo = service.storage.get_repo("acme/demo")
+    assert repo is not None
+    expected_signature = build_signature(stage="issue_followup", job="source-job-id", issue=55)
+    job = JobRecord(
+        repo_full_name=repo.full_name,
+        stage="issue_followup_recovery",
+        issue_number=55,
+        metadata={
+            "expected_signature": expected_signature,
+            "original_error": "issue-followup-comment-missing",
+        },
+    )
+    for _ in range(4):
+        github.add_issue_signature("acme/demo", 55, expected_signature)
+    earliest_id = github.issue_comments("acme/demo", 55)[0]["id"]
+
+    service._verify_side_effect(repo, job)
+
+    remaining = github.issue_comments("acme/demo", 55)
+    assert len(remaining) == 1
+    assert remaining[0]["id"] == earliest_id
+
+
 def test_issue_followup_rollout_missing_marks_job_failed_and_posts_restart_warning(tmp_path: Path) -> None:
     service, github, omx_runner = make_service(tmp_path)
     service.handle_event(


### PR DESCRIPTION
## Problem

Issue [NomaDamas/k-skill#267](https://github.com/NomaDamas/k-skill/issues/267) received **5 follow-up comments from a single dani job** within 16 seconds (04:35:52Z → 04:36:08Z). All 5 comments share the **identical signature**:

```
<!-- dani:stage=issue_followup;job=e68c21b2e0dc4b4cb95d6183767a6d53;issue=267 -->
```

So this is not 5 racing jobs — it is **one job whose resumed agent process posted the same logical comment 5 times**.

## Root cause analysis

1. **Not dani's retry loop.** `RETRY_BACKOFF_SECONDS = [60, 180, 600]` (`dani/service.py:59`) has a minimum 60 s backoff. The 2–6 s gaps between the 5 comments rule out hypothesis B.
2. **Not OMO HTTP re-submission.** `OmoHttpRunner.resume()` sends exactly one `prompt_async` request (`dani/omo_http_runner.py:130-139`).
3. **Most likely source.** The single resumed agent turn re-invoked `gh issue comment` 5 times inside its own loop (self-review / ultrawork-style re-execution). Because the dani signature is deterministic on `job.id`, every retry inside the agent reuses the same signature.
4. **Why dani did not catch it.** `_verify_issue_followup_side_effect` (`dani/service.py:1770-1773`) only asked "does at least one comment with this signature exist?" — 5 matching comments still counted as success, so dani happily marked the job completed.
5. The prompt was advisory ("write exactly one comment") but did not give the agent a concrete pre-check command or a hard "after the gh call returns, never call it again" rule.

## Fix

The durable boundary is comment creation. The fix has three layers:

### 1. Verifier prunes duplicates instead of accepting them

`dani/service.py`: new private helper `_ensure_single_issue_signature_comment(repo, issue, signature, missing_error, job)` replaces the old "exists?" check. It:

- raises `missing_error` if zero matches (unchanged behaviour for the missing-comment path),
- returns silently if exactly one match,
- otherwise keeps the earliest-by-`created_at` comment, deletes the rest via the new GitHub helper, logs a `duplicate_signature_comments_pruned` warning, and records the prune on `job.metadata['duplicate_signature_prunes']` for postmortems.

Applied to `_verify_issue_request_side_effect`, `_verify_issue_followup_side_effect`, and `_verify_issue_comment_recovery_side_effect`.

### 2. New GitHub deletion helper

`dani/github.py`: `delete_issue_comment(repo_full_name, comment_id) -> bool`. 404 → False; other GithubException values propagate so the verifier can keep going even if one delete fails.

### 3. Prompt-level anti-duplicate contract

`dani/prompts.py` (`issue_request`, `issue_followup`) and the recovery prompt in `dani/service.py` now embed an explicit \"POST EXACTLY ONCE\" contract:

- Before calling \`gh issue comment\`, run \`gh issue view <n> --repo <r> --json comments --jq '.comments[].body' | grep -F '<signature>' || true\` and abort if it prints anything.
- Call \`gh issue comment\` at most ONE time per session.
- After the gh call returns, never re-run it — not for retries, not for self-review.
- On apparent failure, re-run the pre-check before retrying.

## Tests

- \`FakeGitHubCLI\` now allocates comment ids and \`created_at\` timestamps, and exposes \`delete_issue_comment\`, so dedup ordering is fully testable.
- 4 new service tests:
  - 5-duplicate followup → 1 remaining + 4 deletions + metadata recorded
  - 3-duplicate issue_request → 1 remaining
  - Single-comment no-op path
  - Recovery stage prunes duplicates with \`expected_signature\`
- 2 new prompt tests assert the new POST EXACTLY ONCE contract text on both \`issue_request\` and \`issue_followup\` templates.

## Verification

- \`uv run pytest\` → 381 passed, 2 skipped (pre-existing). 0 failures.
- \`uv run ruff check\` → all checks passed.
- \`uv run ruff format\` → clean.
- Manual end-to-end QA: seeded 5 duplicate signed comments for k-skill#267, ran \`service._verify_side_effect\` against a real \`DaniService\` instance, confirmed 5 → 1, earliest kept, 4 ids deleted, prune metadata recorded, warning logged.

## Limitations / follow-ups

- The fix prunes duplicates *after* they reach GitHub. Users on the issue may briefly see 5 comments before dani's next verifier run cleans them up. The prompt-level pre-check is the upstream mitigation; the verifier-level prune is the safety net.
- Webhook-level \`X-GitHub-Delivery\` deduplication is intentionally *not* part of this PR because the issue at hand is not webhook redelivery (same job id rules that out). That can be filed as a separate hardening PR.