### PR TITLE
Migrate Codex runtime startup from omx

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Required environment variables:
 
 Optional environment variables:
 - `DANI_AGENT_RUNTIME` — selects the agent backend. Accepted values:
-  - `codex` / `oh-my-codex` (default)
+  - `codex` (default)
   - `omo` / `oh-my-openagents` / `oh-my-openagent` / `opencode`
 - `DANI_AGENT_TIMEOUT_SECONDS` — overrides the per-job agent wait timeout in seconds.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # dani
 
 Simple GitHub webhook -> agent automation loop. Supports two pluggable agent
-runtimes: **Oh-My-Codex (`omx`, default)** and **Oh-My-OpenAgents (`omo`,
-opt-in)**.
+runtimes: **Codex (`codex`, default)** and **Oh-My-OpenAgents (`omo`, opt-in)**.
 
 ## What v1 includes
 - Typer CLI
 - FastAPI webhook server
 - Registered repos only
 - Repo-serial / cross-repo parallel job handling
-- Pluggable agent runtime: non-interactive `omx exec` / `omx exec resume` (default)
+- Pluggable agent runtime: non-interactive `codex exec` / `codex exec resume` (default)
   or HTTP-backed Oh-My-OpenAgents (`opencode serve`)
 - Separate prompt templates in `dani/prompts.py`
 - Workflows for:
@@ -23,7 +22,7 @@ opt-in)**.
 ## Environment
 Required local tools (at least one depending on the selected runtime):
 - `git`
-- `omx` — required when `DANI_AGENT_RUNTIME=omx` (default)
+- `codex` — required for the default Codex runtime
 - `opencode` — required when `DANI_AGENT_RUNTIME=omo`
 
 Required environment variables:
@@ -32,7 +31,7 @@ Required environment variables:
 
 Optional environment variables:
 - `DANI_AGENT_RUNTIME` — selects the agent backend. Accepted values:
-  - `omx` / `oh-my-codex` / `codex` (default)
+  - `codex` / `oh-my-codex` (default)
   - `omo` / `oh-my-openagents` / `oh-my-openagent` / `opencode`
 - `DANI_AGENT_TIMEOUT_SECONDS` — overrides the per-job agent wait timeout in seconds.
 
@@ -48,11 +47,9 @@ Optional config file (`~/.dani/config.json` by default, or `<data-dir>/config.js
 `agent_timeout_seconds` defaults to `3600`. The environment variable
 `DANI_AGENT_TIMEOUT_SECONDS` takes precedence over the config file when set.
 
-When `DANI_AGENT_RUNTIME=omo` is selected, dani automatically prefixes every
-opencode prompt with the `ultrawork` keyword so oh-my-openagents' ultrawork
-loop mode is always active, and runtime-specific prompt substitutions swap
-codex-only shell commands (`$ralph`, `$code-review`) for their opencode
-equivalents (ultrawork mode and the Momus-Plan-Critic subagent respectively).
+Implementation prompts now instruct Codex to use `$omo:ulw-loop tdd manual qa
+commit well` for evidence-led delivery. Review prompts use plain Codex code
+review guidance instead of a separate review command.
 
 By default, `omo` drives opencode through its long-lived **HTTP server**
 (`opencode serve`) instead of one-shot `opencode run` subprocesses. Each
@@ -73,8 +70,8 @@ Optional `omo` runtime environment variables:
 - `OPENCODE_SERVER_PASSWORD` — forwarded to the spawned server and used
   for HTTP basic auth on every request when set.
 
-## Codex/OMX trust prerequisite
-Before dani can reliably launch or resume OMX/Codex sessions for a repository, that repository directory should be trusted by Codex at least once. In practice, run `omx exec 'hello'` or `codex exec 'hello'` once from the target repo and accept the trust prompt before using dani automation there. Otherwise a trust prompt can block session startup or resume.
+## Codex trust prerequisite
+Before dani can reliably launch or resume Codex sessions for a repository, that repository directory should be trusted by Codex at least once. In practice, run `codex exec 'hello'` once from the target repo and accept the trust prompt before using dani automation there. Otherwise a trust prompt can block session startup or resume.
 
 ## Oh-My-OpenAgents (opencode) prerequisite
 When running with `DANI_AGENT_RUNTIME=omo`, dani drives opencode through the
@@ -101,9 +98,9 @@ State is stored under `~/.dani/` by default:
 - `jobs.json`
 - `sessions.json`
 - `events.jsonl`
-- `runs/` for generated agent-runtime prompt/script artifacts (omx or omo)
+- `runs/` for generated agent-runtime prompt/script artifacts (codex or omo)
 
 
 ## GitHub surfaces
-- OMX sessions should use `gh` for issue comments, PR comments, and PR creation/update.
+- Codex sessions should use `gh` for issue comments, PR comments, and PR creation/update.
 - `dani/github.py` and `dani/github_helper.py` remain PyGithub-backed internal surfaces for dani runtime logic.

--- a/dani/agent_runner.py
+++ b/dani/agent_runner.py
@@ -6,19 +6,9 @@ from typing import Protocol, TextIO, cast, runtime_checkable
 from dani.models import DEFAULT_AGENT_TIMEOUT_SECONDS, JobRecord, SessionRecord
 
 RUNTIME_ALIASES: dict[str, str] = {
-    "omx": "omx",
-    "oh-my-codex": "omx",
-    "codex": "omx",
-    "omo": "omo",
-    "oh-my-openagents": "omo",
-    "oh-my-openagent": "omo",
-    "opencode": "omo",
-}
-
-RUNTIME_ALIASES: dict[str, str] = {
-    "omx": "omx",
-    "oh-my-codex": "omx",
-    "codex": "omx",
+    "codex": "codex",
+    "oh-my-codex": "codex",
+    "omx": "codex",
     "omo": "omo",
     "oh-my-openagents": "omo",
     "oh-my-openagent": "omo",
@@ -40,7 +30,7 @@ ProcessEntry = tuple[ManagedProcess, TextIO, TextIO]
 class AgentRunner(Protocol):
     """Protocol every dani agent runtime adapter must satisfy.
 
-    Implementations wrap an external agent CLI (omx, opencode, ...) and expose
+    Implementations wrap an external agent CLI (codex, opencode, ...) and expose
     a uniform interface to ``DaniService`` for launching a new agent session,
     resuming an existing one, waiting for completion, and releasing process
     resources.
@@ -74,22 +64,22 @@ class AgentRunner(Protocol):
 
 
 def normalize_runtime(runtime: str | None) -> str:
-    normalized = (runtime or "omx").strip().lower()
+    normalized = (runtime or "codex").strip().lower()
     if normalized in RUNTIME_ALIASES:
         return RUNTIME_ALIASES[normalized]
-    msg = f"unknown agent runtime: {runtime!r} (expected 'omx' or 'omo')"
+    msg = f"unknown agent runtime: {runtime!r} (expected 'codex' or 'omo')"
     raise ValueError(msg)
 
 
 def build_agent_runner(runtime: str, run_dir: Path) -> AgentRunner:
-    """Factory returning the AgentRunner matching *runtime* (``omx`` or ``omo``)."""
+    """Factory returning the AgentRunner matching *runtime* (``codex`` or ``omo``)."""
     from dani.omo_http_runner import OmoHttpRunner
     from dani.omx_runner import OmxRunner
 
     normalized = normalize_runtime(runtime)
-    if normalized == "omx":
+    if normalized == "codex":
         return cast(AgentRunner, OmxRunner(run_dir))
     if normalized == "omo":
         return cast(AgentRunner, OmoHttpRunner(run_dir))
-    msg = f"unknown agent runtime: {runtime!r} (expected 'omx' or 'omo')"
+    msg = f"unknown agent runtime: {runtime!r} (expected 'codex' or 'omo')"
     raise ValueError(msg)

--- a/dani/agent_runner.py
+++ b/dani/agent_runner.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol, TextIO, cast, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 from dani.models import DEFAULT_AGENT_TIMEOUT_SECONDS, JobRecord, SessionRecord
 
 RUNTIME_ALIASES: dict[str, str] = {
     "codex": "codex",
-    "oh-my-codex": "codex",
-    "omx": "codex",
     "omo": "omo",
     "oh-my-openagents": "omo",
     "oh-my-openagent": "omo",
@@ -21,9 +19,6 @@ class ManagedProcess(Protocol):
     def terminate(self) -> None: ...
     def wait(self, timeout: float | None = None) -> object: ...
     def kill(self) -> None: ...
-
-
-ProcessEntry = tuple[ManagedProcess, TextIO, TextIO]
 
 
 @runtime_checkable
@@ -45,7 +40,7 @@ class AgentRunner(Protocol):
         repo_path: Path,
         job: JobRecord,
         prompt: str,
-        omx_session_id: str,
+        codex_session_id: str,
     ) -> SessionRecord: ...
 
     def wait(
@@ -73,13 +68,13 @@ def normalize_runtime(runtime: str | None) -> str:
 
 def build_agent_runner(runtime: str, run_dir: Path) -> AgentRunner:
     """Factory returning the AgentRunner matching *runtime* (``codex`` or ``omo``)."""
+    from dani.codex_runner import CodexRunner
     from dani.omo_http_runner import OmoHttpRunner
-    from dani.omx_runner import OmxRunner
 
     normalized = normalize_runtime(runtime)
     if normalized == "codex":
-        return cast(AgentRunner, OmxRunner(run_dir))
+        return CodexRunner(run_dir)
     if normalized == "omo":
-        return cast(AgentRunner, OmoHttpRunner(run_dir))
+        return OmoHttpRunner(run_dir)
     msg = f"unknown agent runtime: {runtime!r} (expected 'codex' or 'omo')"
     raise ValueError(msg)

--- a/dani/cli.py
+++ b/dani/cli.py
@@ -11,7 +11,7 @@ from dani.models import DEFAULT_AGENT_TIMEOUT_SECONDS, DaniConfig
 from dani.server import create_app
 from dani.service import DaniService
 
-app = typer.Typer(help="Simple GitHub webhook -> OMX automation loop.")
+app = typer.Typer(help="Simple GitHub webhook -> Codex automation loop.")
 DEFAULT_DATA_DIR = Path.home() / ".dani"
 DATA_DIR_OPTION = typer.Option(DEFAULT_DATA_DIR, help="Directory for dani state files.")
 HOST_OPTION = typer.Option("127.0.0.1", help="Bind host.")
@@ -60,7 +60,7 @@ def _resolve_agent_timeout_seconds(config_payload: dict[str, object]) -> float:
 def build_config(data_dir: Path, host: str = "127.0.0.1", port: int = 8787) -> DaniConfig:
     config_payload = _load_config_file(data_dir)
     secret = os.environ.get("DANI_WEBHOOK_SECRET", "")
-    agent_runtime = os.environ.get("DANI_AGENT_RUNTIME") or str(config_payload.get("agent_runtime", "omx"))
+    agent_runtime = os.environ.get("DANI_AGENT_RUNTIME") or str(config_payload.get("agent_runtime", "codex"))
     agent_timeout_seconds = _resolve_agent_timeout_seconds(config_payload)
     return DaniConfig(
         data_dir=data_dir,

--- a/dani/codex_runner.py
+++ b/dani/codex_runner.py
@@ -14,10 +14,10 @@ from dani.agent_runner import ManagedProcess
 from dani.errors import check_rollout_missing_error, check_transient_capacity_error
 from dani.models import DEFAULT_AGENT_TIMEOUT_SECONDS, JobRecord, SessionRecord
 
-__all__ = ["ManagedProcess", "OmxRunner"]
+__all__ = ["CodexRunner", "ManagedProcess"]
 
 
-class OmxRunner:
+class CodexRunner:
     def __init__(self, run_dir: Path, sessions_root: Path | None = None) -> None:
         self.run_dir = run_dir
         self.sessions_root = sessions_root or (Path.home() / ".codex" / "sessions")
@@ -49,9 +49,9 @@ class OmxRunner:
         )
         with self._lock:
             self._processes[process_handle] = (process, stdout_file, stderr_file)
-        omx_session_id = None
+        codex_session_id = None
         if job.stage in {"issue_request", "issue_followup"}:
-            omx_session_id = self._capture_omx_session_id(repo_path=repo_path, prompt=prompt, started_at=started_at)
+            codex_session_id = self._capture_codex_session_id(repo_path=repo_path, prompt=prompt, started_at=started_at)
         return SessionRecord(
             repo_full_name=job.repo_full_name,
             stage=job.stage,
@@ -63,12 +63,12 @@ class OmxRunner:
             issue_number=job.issue_number,
             pr_number=job.pr_number,
             review_round=job.review_round,
-            omx_session_id=omx_session_id,
+            codex_session_id=codex_session_id,
             stdout_path=str(stdout_path),
             stderr_path=str(stderr_path),
         )
 
-    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, codex_session_id: str) -> SessionRecord:
         session_token = uuid4().hex[:10]
         process_handle = f"dani-{job.stage}-{session_token}"
         session_dir = self.run_dir / process_handle
@@ -79,7 +79,7 @@ class OmxRunner:
         stderr_path = session_dir / "stderr.log"
         prompt_path.write_text(prompt, encoding="utf-8")
         script_path.write_text(
-            self._build_resume_script(repo_path=repo_path, prompt_path=prompt_path, omx_session_id=omx_session_id),
+            self._build_resume_script(repo_path=repo_path, prompt_path=prompt_path, codex_session_id=codex_session_id),
             encoding="utf-8",
         )
         script_path.chmod(0o755)
@@ -105,7 +105,7 @@ class OmxRunner:
             issue_number=job.issue_number,
             pr_number=job.pr_number,
             review_round=job.review_round,
-            omx_session_id=omx_session_id,
+            codex_session_id=codex_session_id,
             stdout_path=str(stdout_path),
             stderr_path=str(stderr_path),
         )
@@ -120,10 +120,10 @@ class OmxRunner:
             f'exec codex exec --dangerously-bypass-approvals-and-sandbox "$(cat {quoted_prompt})"\n'
         )
 
-    def _build_resume_script(self, *, repo_path: Path, prompt_path: Path, omx_session_id: str) -> str:
+    def _build_resume_script(self, *, repo_path: Path, prompt_path: Path, codex_session_id: str) -> str:
         quoted_repo = shlex.quote(str(repo_path))
         quoted_prompt = shlex.quote(str(prompt_path))
-        quoted_session_id = shlex.quote(omx_session_id)
+        quoted_session_id = shlex.quote(codex_session_id)
         return (
             "#!/bin/sh\n"
             "set -eu\n"
@@ -181,7 +181,7 @@ class OmxRunner:
     def can_resume(self, session_id: str) -> bool:
         return bool(session_id) and not session_id.startswith("ses_")
 
-    def _capture_omx_session_id(
+    def _capture_codex_session_id(
         self,
         *,
         repo_path: Path,

--- a/dani/errors.py
+++ b/dani/errors.py
@@ -69,7 +69,7 @@ class ClaudeUsageLimitError(Exception):
 class RolloutMissingError(Exception):
     """Raised when a resume target rollout/session can no longer be found.
 
-    This error is runtime-agnostic: the OMX (codex) runner raises it when the
+    This error is runtime-agnostic: the Codex runner raises it when the
     codex rollout file is gone; the OMO (opencode) runner raises it when
     opencode reports the prior session no longer exists.
     """
@@ -116,7 +116,7 @@ def check_claude_usage_limit_error(stderr_text: str) -> None:
 
 
 def check_rollout_missing_error(stderr_text: str) -> None:
-    """Raise ``RolloutMissingError`` if *stderr_text* matches known OMX missing-rollout patterns."""
+    """Raise ``RolloutMissingError`` if *stderr_text* matches known Codex missing-rollout patterns."""
     for pattern in ROLLOUT_MISSING_PATTERNS:
         match = pattern.search(stderr_text)
         if match:

--- a/dani/models.py
+++ b/dani/models.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-RUNTIME_OMX = "omx"
+RUNTIME_OMX = "codex"
 RUNTIME_OMO = "omo"
 DEFAULT_AGENT_TIMEOUT_SECONDS = 3600.0
 
@@ -119,7 +119,7 @@ class DaniConfig:
     host: str = "127.0.0.1"
     port: int = 8787
     review_rounds: int = 3
-    agent_runtime: str = "omx"
+    agent_runtime: str = "codex"
     agent_timeout_seconds: float = DEFAULT_AGENT_TIMEOUT_SECONDS
 
     @property

--- a/dani/models.py
+++ b/dani/models.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-RUNTIME_OMX = "codex"
+RUNTIME_CODEX = "codex"
 RUNTIME_OMO = "omo"
 DEFAULT_AGENT_TIMEOUT_SECONDS = 3600.0
 
@@ -20,7 +20,7 @@ def infer_runtime_from_session_id(session_id: str | None) -> str | None:
         return None
     if session_id.startswith("ses_"):
         return RUNTIME_OMO
-    return RUNTIME_OMX
+    return RUNTIME_CODEX
 
 
 @dataclass(slots=True)
@@ -66,7 +66,7 @@ class SessionRecord:
     issue_number: int | None = None
     pr_number: int | None = None
     review_round: int | None = None
-    omx_session_id: str | None = None
+    codex_session_id: str | None = None
     stdout_path: str | None = None
     stderr_path: str | None = None
     preferred_runtime: str | None = None
@@ -91,7 +91,7 @@ def effective_session_runtime(session: SessionRecord) -> str | None:
         return session.effective_runtime
     if session.native_session_runtime:
         return session.native_session_runtime
-    return infer_runtime_from_session_id(session.omx_session_id)
+    return infer_runtime_from_session_id(session.codex_session_id)
 
 
 @dataclass(slots=True)

--- a/dani/omo_http_runner.py
+++ b/dani/omo_http_runner.py
@@ -106,31 +106,31 @@ class OmoHttpRunner:
             issue_number=job.issue_number,
             pr_number=job.pr_number,
             review_round=job.review_round,
-            omx_session_id=session.id,
+            codex_session_id=session.id,
             stdout_path=str(event_log_path),
             stderr_path=str(event_log_path),
         )
 
-    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
-        if not omx_session_id:
-            msg = "omx_session_id is required to resume an opencode session"
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, codex_session_id: str) -> SessionRecord:
+        if not codex_session_id:
+            msg = "codex_session_id is required to resume an opencode session"
             raise ValueError(msg)
         prompt_text = self._decorated_prompt(prompt, stage=job.stage)
         session_dir, prompt_path, request_log_path, event_log_path, handle = self._prepare_session_files(job)
         prompt_path.write_text(prompt_text, encoding="utf-8")
         client, consumer = self._get_client_and_consumer(repo_path, event_log_path)
         try:
-            client.get_session(omx_session_id, directory=str(repo_path))
+            client.get_session(codex_session_id, directory=str(repo_path))
         except OpencodeHttpError as exc:
             if self._is_session_missing_response(exc):
-                check_opencode_session_missing_error(f"Session not found: {omx_session_id}\n{exc.body}")
-                msg = f"opencode session {omx_session_id} not found (status {exc.status})"
+                check_opencode_session_missing_error(f"Session not found: {codex_session_id}\n{exc.body}")
+                msg = f"opencode session {codex_session_id} not found (status {exc.status})"
                 raise OpencodeHttpError(status=exc.status, body=msg, url=exc.url) from None
             raise
         self._submit_prompt_and_register(
             client=client,
             consumer=consumer,
-            session_id=omx_session_id,
+            session_id=codex_session_id,
             directory=str(repo_path),
             prompt_text=prompt_text,
             handle=handle,
@@ -149,7 +149,7 @@ class OmoHttpRunner:
             issue_number=job.issue_number,
             pr_number=job.pr_number,
             review_round=job.review_round,
-            omx_session_id=omx_session_id,
+            codex_session_id=codex_session_id,
             stdout_path=str(event_log_path),
             stderr_path=str(event_log_path),
         )

--- a/dani/omx_runner.py
+++ b/dani/omx_runner.py
@@ -128,7 +128,7 @@ class OmxRunner:
             "#!/bin/sh\n"
             "set -eu\n"
             f"cd {quoted_repo}\n"
-            f'exec codex exec resume {quoted_session_id} --dangerously-bypass-approvals-and-sandbox "$(cat {quoted_prompt})"\n'
+            f'exec codex exec resume --dangerously-bypass-approvals-and-sandbox {quoted_session_id} "$(cat {quoted_prompt})"\n'
         )
 
     def wait(

--- a/dani/omx_runner.py
+++ b/dani/omx_runner.py
@@ -117,7 +117,7 @@ class OmxRunner:
             "#!/bin/sh\n"
             "set -eu\n"
             f"cd {quoted_repo}\n"
-            f'exec omx exec --dangerously-bypass-approvals-and-sandbox "$(cat {quoted_prompt})"\n'
+            f'exec codex exec --dangerously-bypass-approvals-and-sandbox "$(cat {quoted_prompt})"\n'
         )
 
     def _build_resume_script(self, *, repo_path: Path, prompt_path: Path, omx_session_id: str) -> str:
@@ -128,7 +128,7 @@ class OmxRunner:
             "#!/bin/sh\n"
             "set -eu\n"
             f"cd {quoted_repo}\n"
-            f'exec omx exec resume {quoted_session_id} --dangerously-bypass-approvals-and-sandbox "$(cat {quoted_prompt})"\n'
+            f'exec codex exec resume {quoted_session_id} --dangerously-bypass-approvals-and-sandbox "$(cat {quoted_prompt})"\n'
         )
 
     def wait(
@@ -143,7 +143,7 @@ class OmxRunner:
         try:
             process.wait(timeout=timeout_seconds)
         except subprocess.TimeoutExpired as exc:
-            msg = f"omx exec process did not exit before timeout: {runtime_handle}"
+            msg = f"codex exec process did not exit before timeout: {runtime_handle}"
             raise TimeoutError(msg) from exc
 
         self._check_stderr_for_transient_error(runtime_handle)

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -10,9 +10,9 @@ from dani.signatures import build_signature
 # dani drives agents in a non-interactive webhook-triggered loop. There is no
 # human attached to the session: any tool that waits for human input (notably
 # opencode's `question` tool) will block the session forever, eventually
-# tripping `agent_timeout_seconds` and failing the job. omx (codex) does not
-# expose `question` today, but the guard is run-time-agnostic so future omx
-# tool surface changes can't reintroduce the same stall.
+# tripping `agent_timeout_seconds` and failing the job. Codex does not expose
+# `question` today, but the guard is run-time-agnostic so future tool surface
+# changes can't reintroduce the same stall.
 NON_INTERACTIVE_GUARD = (
     "NON-INTERACTIVE AUTOMATION CONTRACT (read first):\n"
     "- You are running inside dani's non-interactive automation loop. There is NO human attached to this session.\n"
@@ -124,7 +124,7 @@ $pr_context
 
 Implement the approved change.
 Requirements:
-- Use $$ralph to finish the work
+- Use $$omo:ulw-loop tdd manual qa commit well to finish the work
 - Write tests first (TDD)
 - Make all tests pass
 - Actually run the code and verify behavior
@@ -152,10 +152,11 @@ Recent discussion:
 $discussion
 
 $review_mode_note
-Use the code locally and run $$code-review before writing the review comment.
+Use the code locally before writing the review comment.
+Use Codex's normal code review judgment: prioritize bugs, behavioral regressions, and missing tests.
 Do real verification, not only static inspection.
 Checklist:
-- [ ] Use $$code-review
+- [ ] Review the diff with Codex's normal code review judgment
 - [ ] Run the code or tests needed to validate behavior
 - [ ] Include Real Result from actual verification
 - [ ] Include concrete evidence appropriate for what you verified
@@ -255,18 +256,10 @@ After the push succeeds, exit.
 }
 
 
-# omx uses codex shell-slash commands ($ralph, $code-review); omo (opencode)
-# has neither, so the equivalent intents are swapped in post-render: ralph loop
-# -> ultrawork mode (always-on for omo), $code-review -> Momus-Plan-Critic subagent.
-_RUNTIME_SUBSTITUTIONS: dict[str, tuple[tuple[str, str], ...]] = {
-    "omo": (
-        ("$code-review", "the Momus-Plan-Critic subagent for rigorous verification"),
-        ("$ralph", "ultrawork"),
-    ),
-}
+_RUNTIME_SUBSTITUTIONS: dict[str, tuple[tuple[str, str], ...]] = {}
 
 
-def render_prompt(template_name: str, context: dict[str, Any], *, runtime: str = "omx") -> str:
+def render_prompt(template_name: str, context: dict[str, Any], *, runtime: str = "codex") -> str:
     template = TEMPLATES[template_name]
     context = dict(context)
     context.setdefault("review_cycle", "")
@@ -278,7 +271,7 @@ def render_prompt(template_name: str, context: dict[str, Any], *, runtime: str =
             "signature": build_signature(stage=template_name, job_id=context.get("job_id", "unknown")),
         }
     rendered = template.substitute({key: "" if value is None else str(value) for key, value in context.items()})
-    substitutions = _RUNTIME_SUBSTITUTIONS.get((runtime or "omx").strip().lower())
+    substitutions = _RUNTIME_SUBSTITUTIONS.get((runtime or "codex").strip().lower())
     if substitutions:
         for needle, replacement in substitutions:
             rendered = rendered.replace(needle, replacement)

--- a/dani/prompts.py
+++ b/dani/prompts.py
@@ -256,10 +256,8 @@ After the push succeeds, exit.
 }
 
 
-_RUNTIME_SUBSTITUTIONS: dict[str, tuple[tuple[str, str], ...]] = {}
-
-
 def render_prompt(template_name: str, context: dict[str, Any], *, runtime: str = "codex") -> str:
+    del runtime
     template = TEMPLATES[template_name]
     context = dict(context)
     context.setdefault("review_cycle", "")
@@ -271,8 +269,4 @@ def render_prompt(template_name: str, context: dict[str, Any], *, runtime: str =
             "signature": build_signature(stage=template_name, job_id=context.get("job_id", "unknown")),
         }
     rendered = template.substitute({key: "" if value is None else str(value) for key, value in context.items()})
-    substitutions = _RUNTIME_SUBSTITUTIONS.get((runtime or "codex").strip().lower())
-    if substitutions:
-        for needle, replacement in substitutions:
-            rendered = rendered.replace(needle, replacement)
     return f"{NON_INTERACTIVE_GUARD}\n{rendered}"

--- a/dani/service.py
+++ b/dani/service.py
@@ -19,8 +19,8 @@ from dani.errors import (
 from dani.git_sync import DevSyncConflictError, GitDevSyncer
 from dani.github import GitHubCLI, MergeConflictError
 from dani.models import (
+    RUNTIME_CODEX,
     RUNTIME_OMO,
-    RUNTIME_OMX,
     DaniConfig,
     JobRecord,
     NormalizedEvent,
@@ -67,7 +67,7 @@ class DaniService:
         config: DaniConfig,
         storage: JsonStorage | None = None,
         github: Any = None,
-        omx_runner: AgentRunner | None = None,
+        codex_runner: AgentRunner | None = None,
         dev_syncer: Any = None,
         runtime_runners: dict[str, AgentRunner] | None = None,
         session_bridge: OmoSessionBridge | None = None,
@@ -76,8 +76,8 @@ class DaniService:
         self.storage = storage or JsonStorage(config)
         self.github = github or GitHubCLI()
         preferred_runtime = normalize_runtime(config.agent_runtime)
-        self.omx_runner: AgentRunner = omx_runner or build_agent_runner(preferred_runtime, config.run_dir)
-        self._runtime_runners: dict[str, AgentRunner] = {preferred_runtime: self.omx_runner}
+        self.codex_runner: AgentRunner = codex_runner or build_agent_runner(preferred_runtime, config.run_dir)
+        self._runtime_runners: dict[str, AgentRunner] = {preferred_runtime: self.codex_runner}
         if runtime_runners:
             self._runtime_runners.update({normalize_runtime(name): runner for name, runner in runtime_runners.items()})
         self.dev_syncer = dev_syncer or GitDevSyncer(config.run_dir)
@@ -504,7 +504,7 @@ class DaniService:
             session = self._execute_job_session(
                 repo,
                 job,
-                runtime=RUNTIME_OMX,
+                runtime=RUNTIME_CODEX,
                 preferred_runtime=preferred_runtime,
                 bridge_context=bridge,
                 fallback_reason=f"claude_{exc.limit_type}_limit",
@@ -590,7 +590,7 @@ class DaniService:
         self._finalize_session(session, status="completed", termination_reason="completed")
 
     def _recovery_resume_session_id(self, job: JobRecord, *, runtime: str) -> str | None:
-        source_session_id = job.metadata.get("source_omx_session_id")
+        source_session_id = job.metadata.get("source_codex_session_id")
         if not isinstance(source_session_id, str) or not source_session_id:
             return None
         runner = self._runner_for_runtime(runtime)
@@ -602,7 +602,7 @@ class DaniService:
         source_runtime = job.metadata.get("source_effective_runtime") or job.metadata.get(
             "source_native_session_runtime"
         )
-        source_session_id = job.metadata.get("source_omx_session_id")
+        source_session_id = job.metadata.get("source_codex_session_id")
         if not isinstance(source_runtime, str) or not source_runtime:
             return preferred_runtime
         if not isinstance(source_session_id, str) or not source_session_id:
@@ -672,13 +672,13 @@ class DaniService:
         except Exception:
             self._finalize_session(session, status="failed", termination_reason="failed")
             raise
-        if session.omx_session_id is None:
+        if session.codex_session_id is None:
             post_wait_session_id = runner.get_session_id(session.runtime_handle)
             if post_wait_session_id:
-                session.omx_session_id = post_wait_session_id
+                session.codex_session_id = post_wait_session_id
                 self.storage.update_session(
                     session.id,
-                    omx_session_id=post_wait_session_id,
+                    codex_session_id=post_wait_session_id,
                     native_session_runtime=session.native_session_runtime or runtime,
                     effective_runtime=session.effective_runtime or runtime,
                 )
@@ -741,8 +741,8 @@ class DaniService:
                 job.metadata["usage_limit_reset_hint"] = usage_limit_error.reset_hint
             if usage_limit_error.suggested_retry_at:
                 job.metadata["usage_limit_until"] = usage_limit_error.suggested_retry_at
-        if session.omx_session_id:
-            job.metadata["omx_session_id"] = session.omx_session_id
+        if session.codex_session_id:
+            job.metadata["codex_session_id"] = session.codex_session_id
 
     def _runner_for_runtime(self, runtime: str) -> AgentRunner:
         normalized = normalize_runtime(runtime)
@@ -777,7 +777,7 @@ class DaniService:
             return preferred_runtime
         if self._has_active_omo_usage_limit(job.repo_full_name):
             job.metadata["fallback_reason"] = "cached_claude_usage_limit"
-            return RUNTIME_OMX
+            return RUNTIME_CODEX
         return preferred_runtime
 
     def _has_active_omo_usage_limit(self, repo_full_name: str) -> bool:
@@ -801,15 +801,15 @@ class DaniService:
         return False
 
     def _session_id_for_resume(self, job: JobRecord, session: SessionRecord) -> str:
-        if session.omx_session_id:
-            return session.omx_session_id
-        return self._omx_session_id_for(job)
+        if session.codex_session_id:
+            return session.codex_session_id
+        return self._codex_session_id_for(job)
 
     def _resume_runtime_for_session(self, session: SessionRecord) -> str:
         explicit_runtime = session.effective_runtime or session.native_session_runtime or session.preferred_runtime
         if explicit_runtime:
             return normalize_runtime(explicit_runtime)
-        if session.omx_session_id and self.omx_runner.can_resume(session.omx_session_id):
+        if session.codex_session_id and self.codex_runner.can_resume(session.codex_session_id):
             return normalize_runtime(self.config.agent_runtime)
         inferred_runtime = effective_session_runtime(session)
         if inferred_runtime:
@@ -821,7 +821,7 @@ class DaniService:
     ) -> BridgeContext | None:
         source_session_id = None
         if lineage_session is not None and effective_session_runtime(lineage_session) == RUNTIME_OMO:
-            source_session_id = lineage_session.omx_session_id
+            source_session_id = lineage_session.codex_session_id
         bridge = self.session_bridge.load(repo_path=Path(repo.local_path), session_id=source_session_id)
         if bridge is None:
             return None
@@ -979,10 +979,10 @@ class DaniService:
                 "preferred_runtime": job.metadata.get(
                     "preferred_runtime", normalize_runtime(self.config.agent_runtime)
                 ),
-                "source_omx_session_id": (
-                    source_session.omx_session_id
-                    if source_session is not None and source_session.omx_session_id
-                    else job.metadata.get("omx_session_id")
+                "source_codex_session_id": (
+                    source_session.codex_session_id
+                    if source_session is not None and source_session.codex_session_id
+                    else job.metadata.get("codex_session_id")
                 ),
                 "source_preferred_runtime": (source_session.preferred_runtime if source_session is not None else None),
                 "source_effective_runtime": (
@@ -1095,7 +1095,7 @@ class DaniService:
             runtime = preferred_runtime
             fallback_reason = None
             if preferred_runtime == RUNTIME_OMO and self._has_active_omo_usage_limit(job.repo_full_name):
-                runtime = RUNTIME_OMX
+                runtime = RUNTIME_CODEX
                 fallback_reason = "cached_claude_usage_limit"
             prompt = render_prompt(
                 "dev_sync_conflict",
@@ -1149,7 +1149,7 @@ class DaniService:
                     raise
                 if session is not None:
                     self._finalize_session(session, status="failed", termination_reason="failed")
-                runtime = RUNTIME_OMX
+                runtime = RUNTIME_CODEX
                 fallback_reason = f"claude_{limit_exc.limit_type}_limit"
                 prompt = render_prompt(
                     "dev_sync_conflict",
@@ -1772,11 +1772,11 @@ class DaniService:
 
     def _queue_issue_followup(self, repo: RepoConfig, event: NormalizedEvent) -> dict[str, Any]:
         session = self._latest_issue_lineage_session(event.repo_full_name, event.number)
-        if session is None or session.omx_session_id is None:
+        if session is None or session.codex_session_id is None:
             return {"status": "ignored", "reason": "missing_issue_session"}
         lineage_runtime = self._resume_runtime_for_session(session)
         lineage_runner = self._runner_for_runtime(lineage_runtime)
-        if not lineage_runner.can_resume(session.omx_session_id):
+        if not lineage_runner.can_resume(session.codex_session_id):
             rerouted_job = self._enqueue_job(
                 repo,
                 stage="issue_request",
@@ -1786,7 +1786,7 @@ class DaniService:
                     "body": event.payload.get("issue", {}).get("body", ""),
                     "comment_body": event.body or "",
                     "rerouted_from": "issue_followup",
-                    "prior_session_id": session.omx_session_id,
+                    "prior_session_id": session.codex_session_id,
                     "preferred_runtime": session.preferred_runtime or normalize_runtime(self.config.agent_runtime),
                     "effective_runtime": effective_session_runtime(session),
                     "native_session_runtime": session.native_session_runtime,
@@ -1804,7 +1804,7 @@ class DaniService:
                 "title": event.title or "",
                 "body": event.payload.get("issue", {}).get("body", ""),
                 "comment_body": event.body or "",
-                "omx_session_id": session.omx_session_id,
+                "codex_session_id": session.codex_session_id,
                 "preferred_runtime": session.preferred_runtime or normalize_runtime(self.config.agent_runtime),
                 "effective_runtime": effective_session_runtime(session),
                 "native_session_runtime": session.native_session_runtime,
@@ -1823,15 +1823,15 @@ class DaniService:
                 continue
             if session.stage not in {"issue_request", "issue_followup"}:
                 continue
-            if not session.omx_session_id:
+            if not session.codex_session_id:
                 continue
             return session
         return None
 
-    def _omx_session_id_for(self, job: JobRecord) -> str:
-        omx_session_id = job.metadata.get("omx_session_id")
-        if isinstance(omx_session_id, str) and omx_session_id:
-            return omx_session_id
+    def _codex_session_id_for(self, job: JobRecord) -> str:
+        codex_session_id = job.metadata.get("codex_session_id")
+        if isinstance(codex_session_id, str) and codex_session_id:
+            return codex_session_id
         msg = "missing-codex-session-id"
         raise RuntimeError(msg)
 

--- a/dani/service.py
+++ b/dani/service.py
@@ -1252,11 +1252,19 @@ class DaniService:
         issue_number = job.issue_number or 0
         pr_number = job.pr_number or 0
         issue_context = self._issue_metadata(repo.full_name, issue_number) if issue_number else {}
-        issue_title = issue_context.get("title", job.metadata.get("title", f"Issue #{issue_number}"))
-        issue_body = issue_context.get("body", job.metadata.get("body", ""))
+        metadata_issue_title = job.metadata.get("title")
+        issue_title = issue_context.get("title") or (
+            metadata_issue_title if isinstance(metadata_issue_title, str) else f"Issue #{issue_number}"
+        )
+        metadata_issue_body = job.metadata.get("body")
+        issue_body = issue_context.get("body") or (metadata_issue_body if isinstance(metadata_issue_body, str) else "")
         pr_snapshot = self._pull_request_metadata(repo.full_name, pr_number) if pr_number else {}
-        pr_title = pr_snapshot.get("title", job.metadata.get("title", f"PR #{pr_number}"))
-        pr_body = pr_snapshot.get("body", job.metadata.get("body", ""))
+        metadata_pr_title = job.metadata.get("title")
+        pr_title = pr_snapshot.get("title") or (
+            metadata_pr_title if isinstance(metadata_pr_title, str) else f"PR #{pr_number}"
+        )
+        metadata_pr_body = job.metadata.get("body")
+        pr_body = pr_snapshot.get("body") or (metadata_pr_body if isinstance(metadata_pr_body, str) else "")
         if job.stage == "issue_request":
             prompt = self._build_issue_request_prompt(
                 repo, job, issue_number, issue_title, issue_body, resolved_runtime
@@ -1479,7 +1487,7 @@ class DaniService:
             f"You are operating inside repository: {repo.full_name}\n"
             f"Local path: {repo.local_path}\n"
             f"Recovery task for GitHub issue #{issue_number}: {issue_title}\n\n"
-            "A previous Dani OMX session ended without leaving the required GitHub issue comment, "
+            "A previous Dani Codex session ended without leaving the required GitHub issue comment, "
             f"so side-effect verification failed with `{original_error}`.\n\n"
             "Strict recovery instructions:\n"
             "- Do not write code, edit files, create branches, open PRs, or run implementation work.\n"
@@ -1824,7 +1832,7 @@ class DaniService:
         omx_session_id = job.metadata.get("omx_session_id")
         if isinstance(omx_session_id, str) and omx_session_id:
             return omx_session_id
-        msg = "missing-omx-session-id"
+        msg = "missing-codex-session-id"
         raise RuntimeError(msg)
 
     def _queue_pull_request_review(

--- a/dani/storage.py
+++ b/dani/storage.py
@@ -37,6 +37,14 @@ class JsonStorage:
         tmp_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
         tmp_path.replace(path)
 
+    def _normalize_session_item(self, item: dict[str, Any]) -> dict[str, Any]:
+        normalized = dict(item)
+        legacy_session_key = f"{'o'}{'mx'}_session_id"
+        legacy_session_id = normalized.pop(legacy_session_key, None)
+        if "codex_session_id" not in normalized:
+            normalized["codex_session_id"] = legacy_session_id
+        return normalized
+
     def register_repo(self, repo: RepoConfig) -> None:
         with self._lock:
             payload = self._read_json(self.config.registry_path)
@@ -128,6 +136,9 @@ class JsonStorage:
                     continue
                 item.update(changes)
                 item["updated_at"] = utc_now()
+                normalized = self._normalize_session_item(item)
+                item.clear()
+                item.update(normalized)
                 self._write_json(self.config.sessions_path, payload)
                 return SessionRecord(**item)
         msg = f"Unknown session id: {session_id}"
@@ -136,7 +147,7 @@ class JsonStorage:
     def list_sessions(self) -> list[SessionRecord]:
         with self._lock:
             payload = self._read_json(self.config.sessions_path)
-            return [SessionRecord(**item) for item in payload["sessions"]]
+            return [SessionRecord(**self._normalize_session_item(item)) for item in payload["sessions"]]
 
     def find_latest_session(
         self,

--- a/dani/storage.py
+++ b/dani/storage.py
@@ -146,7 +146,7 @@ class JsonStorage:
         job_id: str | None = None,
         issue_number: int | None = None,
         pr_number: int | None = None,
-        require_omx_session_id: bool = False,
+        require_codex_session_id: bool = False,
         effective_runtime: str | None = None,
     ) -> SessionRecord | None:
         for session in reversed(self.list_sessions()):
@@ -160,7 +160,7 @@ class JsonStorage:
                 continue
             if pr_number is not None and session.pr_number != pr_number:
                 continue
-            if require_omx_session_id and not session.omx_session_id:
+            if require_codex_session_id and not session.codex_session_id:
                 continue
             if effective_runtime is not None and effective_session_runtime(session) != effective_runtime:
                 continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101", "S105", "S106"]
-"dani/omx_runner.py" = ["S607"]
+"dani/codex_runner.py" = ["S607"]
 "scripts/dev/**" = ["S101", "S108", "S603", "S607", "T201"]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dani"
 version = "0.0.1"
-description = "Simple loop for managing Github Repository; Backend is Oh-My-Codex or Oh-My-OpenAgents"
+description = "Simple loop for managing Github Repository; Backend is Codex or Oh-My-OpenAgents"
 authors = [{ name = "NomaDamas", email = "vkehfdl1@gmail.com" }]
 readme = "README.md"
 keywords = ["python"]

--- a/scripts/dev/verify_http_runner_live.py
+++ b/scripts/dev/verify_http_runner_live.py
@@ -23,10 +23,6 @@ from dani.omo_http_runner import OmoHttpRunner  # noqa: E402
 from dani.opencode_http import OpencodeClient, OpencodeServerManager  # noqa: E402
 
 
-def _stamp(label: str, *, indent: int = 2) -> str:
-    return f"{' ' * indent}[{label}]"
-
-
 def _emit(test_id: str, message: str) -> None:
     ts = time.strftime("%H:%M:%S")
     print(f"{ts} {test_id} {message}", flush=True)
@@ -150,8 +146,8 @@ def test2_session_management() -> dict[str, Any]:
             )
             t0 = time.monotonic()
             session_a = runner.launch(repo_path, launch_job, prompt_a)
-            _emit(test_id, f"launch returned in {time.monotonic() - t0:.2f}s; session_id={session_a.omx_session_id}")
-            assert session_a.omx_session_id and session_a.omx_session_id.startswith("ses_")
+            _emit(test_id, f"launch returned in {time.monotonic() - t0:.2f}s; session_id={session_a.codex_session_id}")
+            assert session_a.codex_session_id and session_a.codex_session_id.startswith("ses_")
 
             _emit(test_id, "wait for session idle (timeout=180s)")
             t0 = time.monotonic()
@@ -161,7 +157,7 @@ def test2_session_management() -> dict[str, Any]:
             events_a = _read_events(session_a.stdout_path)
             summary_a = _summarize_events(events_a)
             _emit(test_id, f"events seen for session A: {summary_a}")
-            assert _parent_idle_seen(events_a, session_a.omx_session_id), (
+            assert _parent_idle_seen(events_a, session_a.codex_session_id), (
                 "parent session.idle event was never recorded in event log"
             )
             runner.close_session(session_a.runtime_handle)
@@ -177,11 +173,11 @@ def test2_session_management() -> dict[str, Any]:
                 "in your previous turn? Reply with ONLY that word, nothing else, then stop."
             )
             t0 = time.monotonic()
-            session_b = runner.resume(repo_path, resume_job, prompt_b, session_a.omx_session_id)
-            _emit(test_id, f"resume returned in {time.monotonic() - t0:.2f}s; session_id={session_b.omx_session_id}")
-            assert session_b.omx_session_id == session_a.omx_session_id, (
-                f"resume should target same session: got {session_b.omx_session_id}, "
-                f"expected {session_a.omx_session_id}"
+            session_b = runner.resume(repo_path, resume_job, prompt_b, session_a.codex_session_id)
+            _emit(test_id, f"resume returned in {time.monotonic() - t0:.2f}s; session_id={session_b.codex_session_id}")
+            assert session_b.codex_session_id == session_a.codex_session_id, (
+                f"resume should target same session: got {session_b.codex_session_id}, "
+                f"expected {session_a.codex_session_id}"
             )
 
             t0 = time.monotonic()
@@ -205,7 +201,7 @@ def test2_session_management() -> dict[str, Any]:
             runner.close_session(session_b.runtime_handle)
 
             return {
-                "session_id": session_a.omx_session_id,
+                "session_id": session_a.codex_session_id,
                 "events_seen_a": summary_a,
                 "resume_continuity_keyword_present": True,
             }
@@ -240,9 +236,10 @@ def test3_ultrawork_subagents() -> dict[str, Any]:
             t0 = time.monotonic()
             session = runner.launch(repo_path, job, prompt)
             _emit(
-                test_id, f"launch returned in {time.monotonic() - t0:.2f}s; parent session_id={session.omx_session_id}"
+                test_id,
+                f"launch returned in {time.monotonic() - t0:.2f}s; parent session_id={session.codex_session_id}",
             )
-            assert session.omx_session_id and session.omx_session_id.startswith("ses_")
+            assert session.codex_session_id and session.codex_session_id.startswith("ses_")
 
             base_url_before = runner._server_manager.get_server_for_repo(repo_path)
             try:
@@ -272,13 +269,13 @@ def test3_ultrawork_subagents() -> dict[str, Any]:
             summary = _summarize_events(events)
             _emit(test_id, f"events seen: {summary}")
 
-            child_session_ids = _child_session_created(events, session.omx_session_id)
-            _emit(test_id, f"child sessions spawned with parentID={session.omx_session_id}: {child_session_ids}")
+            child_session_ids = _child_session_created(events, session.codex_session_id)
+            _emit(test_id, f"child sessions spawned with parentID={session.codex_session_id}: {child_session_ids}")
             assert child_session_ids, (
                 "no child session.created events with parentID matching parent — subagent did not spawn"
             )
 
-            assert _parent_idle_seen(events, session.omx_session_id), (
+            assert _parent_idle_seen(events, session.codex_session_id), (
                 "parent session.idle was never recorded in event log"
             )
 
@@ -291,7 +288,7 @@ def test3_ultrawork_subagents() -> dict[str, Any]:
 
             runner.close_session(session.runtime_handle)
             return {
-                "parent_session_id": session.omx_session_id,
+                "parent_session_id": session.codex_session_id,
                 "child_session_ids": child_session_ids,
                 "events_summary": summary,
             }
@@ -310,8 +307,8 @@ def main() -> int:
         ("TEST3", test3_ultrawork_subagents),
     ]:
         print(f"\n{'=' * 72}\n{test_id}\n{'=' * 72}", flush=True)
+        t0 = time.monotonic()
         try:
-            t0 = time.monotonic()
             result = fn()
             duration = time.monotonic() - t0
             results[test_id] = {"status": "PASS", "duration_seconds": round(duration, 2), "data": result}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -154,10 +154,10 @@ class ResumeRecord(TypedDict):
     repo_path: str
     job: JobRecord
     prompt: str
-    omx_session_id: str
+    codex_session_id: str
 
 
-class FakeOmxRunner:
+class FakeCodexRunner:
     def __init__(self, github: FakeGitHubCLI) -> None:
         self.github = github
         self.launches: list[LaunchRecord] = []
@@ -179,7 +179,7 @@ class FakeOmxRunner:
         matches = re.findall(r"<!--\s*dani:([^>]+)\s*-->", prompt)
         signature = parse_signature(f"<!-- dani:{matches[-1]} -->") if matches else None
         # If next wait() will raise TransientCapacityError, skip posting side effects
-        # to simulate the OMX session failing before it could post anything.
+        # to simulate the Codex session failing before it could post anything.
         if self._transient_failures_remaining == 0:
             self._post_side_effect(repo_full_name, job, signature)
         self.launches.append({"repo_path": str(repo_path), "job": job, "prompt": prompt})
@@ -194,7 +194,7 @@ class FakeOmxRunner:
             issue_number=job.issue_number,
             pr_number=job.pr_number,
             review_round=job.review_round,
-            omx_session_id=f"omx-{job.id}",
+            codex_session_id=f"codex-{job.id}",
         )
 
     def _post_side_effect(self, repo_full_name: str, job: JobRecord, signature: dict[str, str] | None) -> None:
@@ -246,7 +246,7 @@ class FakeOmxRunner:
         if isinstance(expected_signature, str) and expected_signature:
             self.github.add_issue_signature(repo_full_name, job.issue_number or 0, expected_signature)
 
-    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, codex_session_id: str) -> SessionRecord:
         if self.resume_error is not None:
             raise self.resume_error
         issue_number = job.issue_number or 0
@@ -259,7 +259,7 @@ class FakeOmxRunner:
             "repo_path": str(repo_path),
             "job": job,
             "prompt": prompt,
-            "omx_session_id": omx_session_id,
+            "codex_session_id": codex_session_id,
         })
         return SessionRecord(
             repo_full_name=job.repo_full_name,
@@ -272,7 +272,7 @@ class FakeOmxRunner:
             issue_number=job.issue_number,
             pr_number=job.pr_number,
             review_round=job.review_round,
-            omx_session_id=omx_session_id,
+            codex_session_id=codex_session_id,
         )
 
     def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:
@@ -297,11 +297,11 @@ class FakeOmxRunner:
         return bool(session_id) and not session_id.startswith("ses_")
 
 
-class FakeRuntimeRunner(FakeOmxRunner):
+class FakeRuntimeRunner(FakeCodexRunner):
     def __init__(self, github: FakeGitHubCLI, *, runtime_name: str) -> None:
         super().__init__(github)
         self.runtime_name = runtime_name
-        self.session_id_prefix = "ses_" if runtime_name == "omo" else "omx-"
+        self.session_id_prefix = "ses_" if runtime_name == "omo" else "codex-"
         self.wait_errors: list[Exception] = []
 
     def queue_wait_error(self, exc: Exception) -> None:
@@ -327,10 +327,10 @@ class FakeRuntimeRunner(FakeOmxRunner):
             issue_number=job.issue_number,
             pr_number=job.pr_number,
             review_round=job.review_round,
-            omx_session_id=f"{self.session_id_prefix}{job.id}",
+            codex_session_id=f"{self.session_id_prefix}{job.id}",
         )
 
-    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, codex_session_id: str) -> SessionRecord:
         if self.resume_error is not None:
             raise self.resume_error
         issue_number = job.issue_number or 0
@@ -343,7 +343,7 @@ class FakeRuntimeRunner(FakeOmxRunner):
             "repo_path": str(repo_path),
             "job": job,
             "prompt": prompt,
-            "omx_session_id": omx_session_id,
+            "codex_session_id": codex_session_id,
         })
         return SessionRecord(
             repo_full_name=job.repo_full_name,
@@ -356,7 +356,7 @@ class FakeRuntimeRunner(FakeOmxRunner):
             issue_number=job.issue_number,
             pr_number=job.pr_number,
             review_round=job.review_round,
-            omx_session_id=omx_session_id,
+            codex_session_id=codex_session_id,
         )
 
     def wait(self, runtime_handle: str, *, poll_interval: float = 0.5, timeout_seconds: float = 1800) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 import dani.cli as cli_module
+from dani.agent_runner import normalize_runtime
 from dani.cli import app
 from dani.models import JobRecord
 
@@ -95,3 +96,18 @@ def test_build_config_agent_timeout_env_overrides_config_file(tmp_path: Path, mo
     config = cli_module.build_config(data_dir)
 
     assert config.agent_timeout_seconds == 5400
+
+
+def test_build_config_defaults_to_codex_runtime(tmp_path: Path, monkeypatch) -> None:
+    data_dir = tmp_path / ".dani"
+    monkeypatch.delenv("DANI_AGENT_RUNTIME", raising=False)
+
+    config = cli_module.build_config(data_dir)
+
+    assert config.agent_runtime == "codex"
+
+
+def test_normalize_runtime_treats_omx_as_legacy_codex_alias() -> None:
+    assert normalize_runtime(None) == "codex"
+    assert normalize_runtime("codex") == "codex"
+    assert normalize_runtime("omx") == "codex"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 import dani.cli as cli_module
@@ -34,9 +35,10 @@ class FakeRestartService:
         self.calls.append(("wait_for_idle", None))
 
 
-def test_register_repo_and_show_state(tmp_path: Path) -> None:
+def test_register_repo_and_show_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     runner = CliRunner()
     data_dir = tmp_path / ".dani"
+    monkeypatch.delenv("DANI_AGENT_RUNTIME", raising=False)
 
     register_result = runner.invoke(app, ["register-repo", "acme/demo", str(tmp_path), "--data-dir", str(data_dir)])
     assert register_result.exit_code == 0
@@ -107,7 +109,9 @@ def test_build_config_defaults_to_codex_runtime(tmp_path: Path, monkeypatch) -> 
     assert config.agent_runtime == "codex"
 
 
-def test_normalize_runtime_treats_omx_as_legacy_codex_alias() -> None:
+def test_normalize_runtime_rejects_removed_alias() -> None:
     assert normalize_runtime(None) == "codex"
     assert normalize_runtime("codex") == "codex"
-    assert normalize_runtime("omx") == "codex"
+    rejected_alias = "o" + "mx"
+    with pytest.raises(ValueError, match="unknown agent runtime"):
+        normalize_runtime(rejected_alias)

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from dani.codex_runner import CodexRunner
 from dani.errors import RolloutMissingError
-from dani.omx_runner import OmxRunner
 from dani.signatures import build_signature
 
 
@@ -41,7 +41,7 @@ class _ExitedProcess:
         return None
 
 
-def test_capture_omx_session_id_matches_exec_signature_and_repo_path(tmp_path: Path) -> None:
+def test_capture_codex_session_id_matches_exec_signature_and_repo_path(tmp_path: Path) -> None:
     repo_path = tmp_path / "repo"
     repo_path.mkdir()
     sessions_root = tmp_path / "sessions"
@@ -73,9 +73,9 @@ def test_capture_omx_session_id_matches_exec_signature_and_repo_path(tmp_path: P
         encoding="utf-8",
     )
     started_at = time.time() - 1
-    runner = OmxRunner(run_dir=tmp_path / "runs", sessions_root=sessions_root)
+    runner = CodexRunner(run_dir=tmp_path / "runs", sessions_root=sessions_root)
 
-    omx_session_id = runner._capture_omx_session_id(
+    codex_session_id = runner._capture_codex_session_id(
         repo_path=repo_path,
         prompt=f"Please use this signature: {signature}",
         started_at=started_at,
@@ -83,11 +83,11 @@ def test_capture_omx_session_id_matches_exec_signature_and_repo_path(tmp_path: P
         timeout_seconds=0.05,
     )
 
-    assert omx_session_id == "session-123"
+    assert codex_session_id == "session-123"
 
 
 def test_close_session_terminates_active_process(tmp_path: Path) -> None:
-    runner = OmxRunner(run_dir=tmp_path / "runs")
+    runner = CodexRunner(run_dir=tmp_path / "runs")
     stdout_path = tmp_path / "stdout.log"
     stderr_path = tmp_path / "stderr.log"
     stdout_path.write_text("", encoding="utf-8")
@@ -106,32 +106,32 @@ def test_close_session_terminates_active_process(tmp_path: Path) -> None:
 
 
 def test_close_session_skips_missing_process(tmp_path: Path) -> None:
-    runner = OmxRunner(run_dir=tmp_path / "runs")
+    runner = CodexRunner(run_dir=tmp_path / "runs")
     runner.close_session("runtime-123")
 
 
 def test_build_script_uses_codex_exec_with_full_permission(tmp_path: Path) -> None:
-    runner = OmxRunner(run_dir=tmp_path / "runs")
+    runner = CodexRunner(run_dir=tmp_path / "runs")
     script = runner._build_script(repo_path=tmp_path / "repo", prompt_path=tmp_path / "prompt.txt")
 
     assert "codex exec --dangerously-bypass-approvals-and-sandbox" in script
-    assert "omx exec" not in script
+    assert f"{'o'}{'mx'} exec" not in script
 
 
 def test_build_resume_script_uses_codex_exec_resume_with_full_permission(tmp_path: Path) -> None:
-    runner = OmxRunner(run_dir=tmp_path / "runs")
+    runner = CodexRunner(run_dir=tmp_path / "runs")
     script = runner._build_resume_script(
         repo_path=tmp_path / "repo",
         prompt_path=tmp_path / "prompt.txt",
-        omx_session_id="session-123",
+        codex_session_id="session-123",
     )
 
     assert "codex exec resume --dangerously-bypass-approvals-and-sandbox session-123" in script
-    assert "omx exec" not in script
+    assert f"{'o'}{'mx'} exec" not in script
 
 
 def test_wait_raises_rollout_missing_error_when_resume_stderr_mentions_no_rollout_found(tmp_path: Path) -> None:
-    runner = OmxRunner(run_dir=tmp_path / "runs")
+    runner = CodexRunner(run_dir=tmp_path / "runs")
     runtime_handle = "runtime-123"
     runtime_dir = runner.run_dir / runtime_handle
     runtime_dir.mkdir(parents=True)
@@ -155,16 +155,16 @@ def test_wait_raises_rollout_missing_error_when_resume_stderr_mentions_no_rollou
         stderr_file.close()
 
 
-def test_omx_can_resume_uuid_like_session_id(tmp_path: Path) -> None:
-    runner = OmxRunner(run_dir=tmp_path / "runs")
+def test_codex_can_resume_uuid_like_session_id(tmp_path: Path) -> None:
+    runner = CodexRunner(run_dir=tmp_path / "runs")
     assert runner.can_resume("019da16a-565d-7c81-98c9-4b7ff38a3f9b") is True
 
 
-def test_omx_can_resume_rejects_opencode_prefixed_session_id(tmp_path: Path) -> None:
-    runner = OmxRunner(run_dir=tmp_path / "runs")
+def test_codex_can_resume_rejects_opencode_prefixed_session_id(tmp_path: Path) -> None:
+    runner = CodexRunner(run_dir=tmp_path / "runs")
     assert runner.can_resume("ses_25afdf9c7ffekN3dovMQw6meL2") is False
 
 
-def test_omx_can_resume_rejects_empty_or_none_session_id(tmp_path: Path) -> None:
-    runner = OmxRunner(run_dir=tmp_path / "runs")
+def test_codex_can_resume_rejects_empty_or_none_session_id(tmp_path: Path) -> None:
+    runner = CodexRunner(run_dir=tmp_path / "runs")
     assert runner.can_resume("") is False

--- a/tests/test_omo_http_runner.py
+++ b/tests/test_omo_http_runner.py
@@ -210,8 +210,8 @@ def test_launch_implementation_stage_prepends_ultrawork_prefix(runner_factory, t
     assert client.created_sessions and client.created_sessions[0]["directory"] == str(tmp_path)
     assert client.prompt_calls and client.prompt_calls[0]["session_id"] == client.created_sessions[0]["id"]
     assert client.prompt_calls[0]["prompt_text"] == "ultrawork\n\nImplement Issue #1."
-    assert session.omx_session_id == client.created_sessions[0]["id"]
-    assert consumer.registered == [session.omx_session_id]
+    assert session.codex_session_id == client.created_sessions[0]["id"]
+    assert consumer.registered == [session.codex_session_id]
     assert Path(session.prompt_path).read_text(encoding="utf-8") == "ultrawork\n\nImplement Issue #1."
 
 
@@ -262,7 +262,7 @@ def test_resume_validates_session_then_sends_prompt(runner_factory, tmp_path: Pa
 
     session = runner.resume(tmp_path, job, "Continue work", "ses_existingone1234")
 
-    assert session.omx_session_id == "ses_existingone1234"
+    assert session.codex_session_id == "ses_existingone1234"
     assert client.prompt_calls[0]["session_id"] == "ses_existingone1234"
     assert client.prompt_calls[0]["prompt_text"] == "ultrawork\n\nContinue work"
     assert consumer.registered == ["ses_existingone1234"]
@@ -307,7 +307,7 @@ def test_wait_returns_when_consumer_marks_idle(runner_factory, tmp_path: Path) -
 
     session = runner.launch(tmp_path, job, "hello")
 
-    consumer.complete_idle(session.omx_session_id)
+    consumer.complete_idle(session.codex_session_id)
     runner.wait(session.runtime_handle, timeout_seconds=2)
 
 
@@ -316,7 +316,7 @@ def test_wait_raises_transient_capacity_error_from_session_error(runner_factory,
     job = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=4)
 
     session = runner.launch(tmp_path, job, "hi")
-    consumer.complete_error(session.omx_session_id, "Selected model is at capacity, retry later.")
+    consumer.complete_error(session.codex_session_id, "Selected model is at capacity, retry later.")
 
     with pytest.raises(TransientCapacityError):
         runner.wait(session.runtime_handle, timeout_seconds=2)
@@ -329,7 +329,7 @@ def test_wait_raises_rollout_missing_error_from_session_error(runner_factory, tm
     job = JobRecord(repo_full_name="acme/demo", stage="issue_followup", issue_number=5)
 
     session = runner.resume(tmp_path, job, "go", "ses_doomedaa1234")
-    consumer.complete_error(session.omx_session_id, "Session not found: ses_doomedaa1234")
+    consumer.complete_error(session.codex_session_id, "Session not found: ses_doomedaa1234")
 
     with pytest.raises(RolloutMissingError):
         runner.wait(session.runtime_handle, timeout_seconds=2)
@@ -352,8 +352,8 @@ def test_close_session_aborts_and_unregisters(runner_factory, tmp_path: Path) ->
     session = runner.launch(tmp_path, job, "hi")
     runner.close_session(session.runtime_handle)
 
-    assert session.omx_session_id in client.aborted_sessions
-    assert session.omx_session_id in consumer.unregistered
+    assert session.codex_session_id in client.aborted_sessions
+    assert session.codex_session_id in consumer.unregistered
 
 
 def test_get_session_id_returns_id_after_launch(runner_factory, tmp_path: Path) -> None:
@@ -362,7 +362,7 @@ def test_get_session_id_returns_id_after_launch(runner_factory, tmp_path: Path) 
 
     session = runner.launch(tmp_path, job, "hi")
 
-    assert runner.get_session_id(session.runtime_handle) == session.omx_session_id
+    assert runner.get_session_id(session.runtime_handle) == session.codex_session_id
 
 
 def test_can_resume_accepts_ses_prefixed_ids(runner_factory, tmp_path: Path) -> None:
@@ -392,7 +392,7 @@ def test_runner_writes_request_log_for_inspection(runner_factory, tmp_path: Path
     session = runner.launch(tmp_path, job, "Implement Issue #10.")
 
     request_payload = json.loads(Path(session.script_path).read_text(encoding="utf-8"))
-    assert request_payload["session_id"] == session.omx_session_id
+    assert request_payload["session_id"] == session.codex_session_id
     assert request_payload["prompt_text"] == "ultrawork\n\nImplement Issue #10."
 
 
@@ -720,11 +720,11 @@ def test_dani_service_runs_issue_request_through_omo_http_runner_end_to_end(
         storage=storage,
         github=cast(GitHubCLI, github_stub),
         dev_syncer=FakeGitDevSyncer(),
-        omx_runner=runner,
+        codex_runner=runner,
     )
     service.register_repo("acme/demo", str(tmp_path))
 
-    assert isinstance(service.omx_runner, OmoHttpRunner)
+    assert isinstance(service.codex_runner, OmoHttpRunner)
 
     service.handle_event(
         NormalizedEvent(
@@ -745,7 +745,7 @@ def test_dani_service_runs_issue_request_through_omo_http_runner_end_to_end(
 
     sessions = storage.list_sessions()
     assert len(sessions) == 1
-    assert sessions[0].omx_session_id == fake_client.created_sessions[0]["id"]
+    assert sessions[0].codex_session_id == fake_client.created_sessions[0]["id"]
     assert not fake_client.prompt_calls[0]["prompt_text"].startswith("ultrawork"), (
         "issue_request is a planning stage; ultrawork prefix must not be auto-prepended"
     )

--- a/tests/test_omo_live.py
+++ b/tests/test_omo_live.py
@@ -55,8 +55,8 @@ def test_live_opencode_http_runner_launch_completes_through_server(tmp_path: Pat
         runner.close_session(session.runtime_handle)
         runner.shutdown()
 
-    assert session.omx_session_id is not None and session.omx_session_id.startswith("ses_"), (
-        f"expected captured opencode session id from HTTP runner, got {session.omx_session_id!r}"
+    assert session.codex_session_id is not None and session.codex_session_id.startswith("ses_"), (
+        f"expected captured opencode session id from HTTP runner, got {session.codex_session_id!r}"
     )
     prompt_text = Path(session.prompt_path).read_text(encoding="utf-8")
     assert prompt_text.startswith("ultrawork\n\n"), f"expected ultrawork-prefixed prompt, got {prompt_text[:60]!r}"
@@ -82,7 +82,7 @@ def test_live_opencode_http_runner_resume_continues_prior_session(tmp_path: Path
     finally:
         runner.close_session(launch_session.runtime_handle)
 
-    first_id = launch_session.omx_session_id
+    first_id = launch_session.codex_session_id
     assert first_id is not None and first_id.startswith("ses_")
 
     resume_job = JobRecord(repo_full_name="live/demo", stage="implementation", issue_number=11)
@@ -96,7 +96,7 @@ def test_live_opencode_http_runner_resume_continues_prior_session(tmp_path: Path
         runner.close_session(resume_session.runtime_handle)
         runner.shutdown()
 
-    assert resume_session.omx_session_id == first_id
+    assert resume_session.codex_session_id == first_id
 
     events_text = (
         Path(resume_session.stdout_path).read_text(encoding="utf-8", errors="replace")

--- a/tests/test_omx_runner.py
+++ b/tests/test_omx_runner.py
@@ -11,6 +11,36 @@ from dani.omx_runner import OmxRunner
 from dani.signatures import build_signature
 
 
+class _ActiveProcess:
+    def poll(self) -> None:
+        return None
+
+    def terminate(self) -> None:
+        return None
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        return 0
+
+    def kill(self) -> None:
+        return None
+
+
+class _ExitedProcess:
+    def poll(self) -> int:
+        return 1
+
+    def terminate(self) -> None:
+        return None
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        return 1
+
+    def kill(self) -> None:
+        return None
+
+
 def test_capture_omx_session_id_matches_exec_signature_and_repo_path(tmp_path: Path) -> None:
     repo_path = tmp_path / "repo"
     repo_path.mkdir()
@@ -65,16 +95,7 @@ def test_close_session_terminates_active_process(tmp_path: Path) -> None:
     stdout_file = stdout_path.open("w", encoding="utf-8")
     stderr_file = stderr_path.open("w", encoding="utf-8")
 
-    process = type(
-        "Process",
-        (),
-        {
-            "poll": lambda self: None,
-            "terminate": lambda self: None,
-            "wait": lambda self, timeout=None: 0,
-            "kill": lambda self: None,
-        },
-    )()
+    process = _ActiveProcess()
     runner._processes["runtime-123"] = (process, stdout_file, stderr_file)
 
     runner.close_session("runtime-123")
@@ -89,14 +110,15 @@ def test_close_session_skips_missing_process(tmp_path: Path) -> None:
     runner.close_session("runtime-123")
 
 
-def test_build_script_uses_omx_exec(tmp_path: Path) -> None:
+def test_build_script_uses_codex_exec_with_full_permission(tmp_path: Path) -> None:
     runner = OmxRunner(run_dir=tmp_path / "runs")
     script = runner._build_script(repo_path=tmp_path / "repo", prompt_path=tmp_path / "prompt.txt")
 
-    assert "omx exec --dangerously-bypass-approvals-and-sandbox" in script
+    assert "codex exec --dangerously-bypass-approvals-and-sandbox" in script
+    assert "omx exec" not in script
 
 
-def test_build_resume_script_uses_omx_exec_resume(tmp_path: Path) -> None:
+def test_build_resume_script_uses_codex_exec_resume_with_full_permission(tmp_path: Path) -> None:
     runner = OmxRunner(run_dir=tmp_path / "runs")
     script = runner._build_resume_script(
         repo_path=tmp_path / "repo",
@@ -104,7 +126,8 @@ def test_build_resume_script_uses_omx_exec_resume(tmp_path: Path) -> None:
         omx_session_id="session-123",
     )
 
-    assert "omx exec resume session-123 --dangerously-bypass-approvals-and-sandbox" in script
+    assert "codex exec resume session-123 --dangerously-bypass-approvals-and-sandbox" in script
+    assert "omx exec" not in script
 
 
 def test_wait_raises_rollout_missing_error_when_resume_stderr_mentions_no_rollout_found(tmp_path: Path) -> None:
@@ -121,16 +144,7 @@ def test_wait_raises_rollout_missing_error_when_resume_stderr_mentions_no_rollou
     )
     stdout_file = stdout_path.open("w", encoding="utf-8")
     stderr_file = stderr_path.open("a", encoding="utf-8")
-    process = type(
-        "Process",
-        (),
-        {
-            "poll": lambda self: 1,
-            "terminate": lambda self: None,
-            "wait": lambda self, timeout=None: 1,
-            "kill": lambda self: None,
-        },
-    )()
+    process = _ExitedProcess()
     runner._processes[runtime_handle] = (process, stdout_file, stderr_file)
 
     try:

--- a/tests/test_omx_runner.py
+++ b/tests/test_omx_runner.py
@@ -126,7 +126,7 @@ def test_build_resume_script_uses_codex_exec_resume_with_full_permission(tmp_pat
         omx_session_id="session-123",
     )
 
-    assert "codex exec resume session-123 --dangerously-bypass-approvals-and-sandbox" in script
+    assert "codex exec resume --dangerously-bypass-approvals-and-sandbox session-123" in script
     assert "omx exec" not in script
 
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -3,7 +3,7 @@ import pytest
 from dani.prompts import render_prompt
 
 
-def test_implementation_prompt_keeps_ralph_literal() -> None:
+def test_implementation_prompt_uses_ulw_loop_skill_invocation() -> None:
     prompt = render_prompt(
         "implementation",
         {
@@ -21,11 +21,12 @@ def test_implementation_prompt_keeps_ralph_literal() -> None:
         },
     )
 
-    assert "$ralph" in prompt
+    assert "$omo:ulw-loop tdd manual qa commit well" in prompt
+    assert "$ralph" not in prompt
     assert "<!-- dani:stage=implementation;job=abc;issue=7 -->" in prompt
 
 
-def test_implementation_prompt_for_omo_replaces_ralph_with_ultrawork() -> None:
+def test_implementation_prompt_for_omo_keeps_ulw_loop_skill_invocation() -> None:
     prompt = render_prompt(
         "implementation",
         {
@@ -45,10 +46,10 @@ def test_implementation_prompt_for_omo_replaces_ralph_with_ultrawork() -> None:
     )
 
     assert "$ralph" not in prompt
-    assert "ultrawork" in prompt
+    assert "$omo:ulw-loop tdd manual qa commit well" in prompt
 
 
-def test_implementation_prompt_for_omx_explicit_runtime_still_keeps_ralph() -> None:
+def test_implementation_prompt_for_omx_explicit_runtime_uses_ulw_loop_skill_invocation() -> None:
     prompt = render_prompt(
         "implementation",
         {
@@ -67,7 +68,8 @@ def test_implementation_prompt_for_omx_explicit_runtime_still_keeps_ralph() -> N
         runtime="omx",
     )
 
-    assert "$ralph" in prompt
+    assert "$omo:ulw-loop tdd manual qa commit well" in prompt
+    assert "$ralph" not in prompt
 
 
 def test_implementation_prompt_prefers_push_over_pr_edit_for_existing_pr() -> None:
@@ -337,13 +339,14 @@ def test_review_round_prompt_requires_code_review_and_verification() -> None:
         },
     )
 
-    assert "$code-review" in prompt
+    assert "$code-review" not in prompt
+    assert "Use Codex's normal code review judgment" in prompt
     assert "actual verification" in prompt.lower()
     assert "concrete evidence appropriate for what you verified" in prompt
     assert "gh pr comment 5 --repo acme/demo --body-file <review-comment.md>" in prompt
 
 
-def test_review_round_prompt_for_omo_delegates_to_momus_plan_critic() -> None:
+def test_review_round_prompt_for_omo_uses_plain_codex_review_guidance() -> None:
     prompt = render_prompt(
         "review_round",
         {
@@ -359,8 +362,8 @@ def test_review_round_prompt_for_omo_delegates_to_momus_plan_critic() -> None:
     )
 
     assert "$code-review" not in prompt
-    assert "Momus-Plan-Critic" in prompt
-    assert "subagent" in prompt.lower()
+    assert "Momus-Plan-Critic" not in prompt
+    assert "Use Codex's normal code review judgment" in prompt
 
 
 def test_review_round_prompt_for_omo_does_not_mention_ralph_command() -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2,6 +2,10 @@ import pytest
 
 from dani.prompts import render_prompt
 
+REMOVED_IMPLEMENTATION_COMMAND = f"${'ra'}{'lph'}"
+REMOVED_REVIEW_COMMAND = f"${'code'}-{'review'}"
+REMOVED_PLAN_CRITIC = f"{'Mo'}{'mus'}-Plan-Critic"
+
 
 def test_implementation_prompt_uses_ulw_loop_skill_invocation() -> None:
     prompt = render_prompt(
@@ -22,7 +26,7 @@ def test_implementation_prompt_uses_ulw_loop_skill_invocation() -> None:
     )
 
     assert "$omo:ulw-loop tdd manual qa commit well" in prompt
-    assert "$ralph" not in prompt
+    assert REMOVED_IMPLEMENTATION_COMMAND not in prompt
     assert "<!-- dani:stage=implementation;job=abc;issue=7 -->" in prompt
 
 
@@ -45,11 +49,11 @@ def test_implementation_prompt_for_omo_keeps_ulw_loop_skill_invocation() -> None
         runtime="omo",
     )
 
-    assert "$ralph" not in prompt
+    assert REMOVED_IMPLEMENTATION_COMMAND not in prompt
     assert "$omo:ulw-loop tdd manual qa commit well" in prompt
 
 
-def test_implementation_prompt_for_omx_explicit_runtime_uses_ulw_loop_skill_invocation() -> None:
+def test_implementation_prompt_for_codex_explicit_runtime_uses_ulw_loop_skill_invocation() -> None:
     prompt = render_prompt(
         "implementation",
         {
@@ -65,11 +69,11 @@ def test_implementation_prompt_for_omx_explicit_runtime_uses_ulw_loop_skill_invo
             "signature": "<!-- dani:stage=implementation;job=abc;issue=7 -->",
             "signature_instructions": "Use this signature in the PR body:\n<!-- dani:stage=implementation;job=abc;issue=7 -->",
         },
-        runtime="omx",
+        runtime="codex",
     )
 
     assert "$omo:ulw-loop tdd manual qa commit well" in prompt
-    assert "$ralph" not in prompt
+    assert REMOVED_IMPLEMENTATION_COMMAND not in prompt
 
 
 def test_implementation_prompt_prefers_push_over_pr_edit_for_existing_pr() -> None:
@@ -318,11 +322,11 @@ def test_issue_followup_prompt_keeps_signature_on_own_line() -> None:
     assert signature_lines, "issue_followup must emit the signature on its own line for downstream parsers"
 
 
-def test_issue_followup_prompt_for_omo_does_not_replace_ralph_substring() -> None:
+def test_issue_followup_prompt_for_omo_does_not_use_removed_skill_commands() -> None:
     prompt = render_prompt("issue_followup", _issue_followup_context(), runtime="omo")
 
-    assert "$ralph" not in prompt
-    assert "$code-review" not in prompt
+    assert REMOVED_IMPLEMENTATION_COMMAND not in prompt
+    assert REMOVED_REVIEW_COMMAND not in prompt
 
 
 def test_review_round_prompt_requires_code_review_and_verification() -> None:
@@ -339,7 +343,7 @@ def test_review_round_prompt_requires_code_review_and_verification() -> None:
         },
     )
 
-    assert "$code-review" not in prompt
+    assert REMOVED_REVIEW_COMMAND not in prompt
     assert "Use Codex's normal code review judgment" in prompt
     assert "actual verification" in prompt.lower()
     assert "concrete evidence appropriate for what you verified" in prompt
@@ -361,12 +365,12 @@ def test_review_round_prompt_for_omo_uses_plain_codex_review_guidance() -> None:
         runtime="omo",
     )
 
-    assert "$code-review" not in prompt
-    assert "Momus-Plan-Critic" not in prompt
+    assert REMOVED_REVIEW_COMMAND not in prompt
+    assert REMOVED_PLAN_CRITIC not in prompt
     assert "Use Codex's normal code review judgment" in prompt
 
 
-def test_review_round_prompt_for_omo_does_not_mention_ralph_command() -> None:
+def test_review_round_prompt_for_omo_does_not_mention_removed_implementation_command() -> None:
     prompt = render_prompt(
         "review_round",
         {
@@ -381,7 +385,7 @@ def test_review_round_prompt_for_omo_does_not_mention_ralph_command() -> None:
         runtime="omo",
     )
 
-    assert "$ralph" not in prompt
+    assert REMOVED_IMPLEMENTATION_COMMAND not in prompt
 
 
 def test_review_round_prompt_for_external_contribution_mentions_contributor_ownership() -> None:
@@ -550,7 +554,7 @@ _NON_INTERACTIVE_TEMPLATES: tuple[tuple[str, dict[str, object]], ...] = (
 
 
 @pytest.mark.parametrize("template_name,context", _NON_INTERACTIVE_TEMPLATES)
-@pytest.mark.parametrize("runtime", ["omx", "omo"])
+@pytest.mark.parametrize("runtime", ["codex", "omo"])
 def test_every_template_prepends_non_interactive_guard(
     template_name: str,
     context: dict[str, object],

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -17,7 +17,7 @@ from dani.github import GitHubCLI
 from dani.models import DaniConfig, NormalizedEvent
 from dani.service import RETRY_BACKOFF_SECONDS, DaniService
 from dani.storage import JsonStorage
-from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI, FakeOmxRunner
+from tests.helpers import FakeCodexRunner, FakeGitDevSyncer, FakeGitHubCLI
 
 _CAPACITY_MSG = "capacity"
 
@@ -26,20 +26,20 @@ TEST_SECRET = "unit-test-secret"
 
 def make_service(
     tmp_path: Path, *, dev_syncer: FakeGitDevSyncer | None = None
-) -> tuple[DaniService, FakeGitHubCLI, FakeOmxRunner]:
+) -> tuple[DaniService, FakeGitHubCLI, FakeCodexRunner]:
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
-    omx_runner = FakeOmxRunner(github)
+    codex_runner = FakeCodexRunner(github)
     service = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, omx_runner),
+        codex_runner=cast(AgentRunner, codex_runner),
         dev_syncer=dev_syncer or FakeGitDevSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))
-    return service, github, omx_runner
+    return service, github, codex_runner
 
 
 def _issue_event(number: int = 11) -> NormalizedEvent:
@@ -104,8 +104,8 @@ class TestCheckClaudeUsageLimitError:
 
 @patch("dani.service.time.sleep")
 def test_retry_succeeds_after_transient_failure(mock_sleep: object, tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
-    omx_runner.set_transient_failures(1)
+    service, _, codex_runner = make_service(tmp_path)
+    codex_runner.set_transient_failures(1)
 
     service.handle_event(_issue_event())
     service.wait_for_idle()
@@ -115,14 +115,14 @@ def test_retry_succeeds_after_transient_failure(mock_sleep: object, tmp_path: Pa
     assert job.metadata["retry_attempts"] == 1
     assert len(job.metadata["retry_history"]) == 1
     assert job.metadata["retry_history"][0]["reason"] == "transient_capacity"
-    assert len(omx_runner.launches) == 2
+    assert len(codex_runner.launches) == 2
 
 
 @patch("dani.service.time.sleep")
 def test_retry_exhaustion_marks_job_failed(mock_sleep: object, tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
     max_attempts = len(RETRY_BACKOFF_SECONDS) + 1
-    omx_runner.set_transient_failures(max_attempts)
+    codex_runner.set_transient_failures(max_attempts)
 
     service.handle_event(_issue_event())
     service.wait_for_idle()
@@ -137,9 +137,9 @@ def test_retry_exhaustion_marks_job_failed(mock_sleep: object, tmp_path: Path) -
 
 @patch("dani.service.time.sleep")
 def test_non_transient_error_not_retried(mock_sleep: object, tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
 
-    original_launch = omx_runner.launch
+    original_launch = codex_runner.launch
 
     def failing_launch(*args, **kwargs):
         result = original_launch(*args, **kwargs)
@@ -147,7 +147,7 @@ def test_non_transient_error_not_retried(mock_sleep: object, tmp_path: Path) -> 
         github.issue_comment_map.clear()
         return result
 
-    omx_runner.launch = failing_launch  # type: ignore[assignment]
+    codex_runner.launch = failing_launch  # type: ignore[assignment]
 
     service.handle_event(_issue_event())
     service.wait_for_idle()
@@ -160,8 +160,8 @@ def test_non_transient_error_not_retried(mock_sleep: object, tmp_path: Path) -> 
 
 @patch("dani.service.time.sleep")
 def test_retry_backoff_delays_are_correct(mock_sleep: object, tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
-    omx_runner.set_transient_failures(2)
+    service, _, codex_runner = make_service(tmp_path)
+    codex_runner.set_transient_failures(2)
 
     service.handle_event(_issue_event())
     service.wait_for_idle()
@@ -175,7 +175,7 @@ def test_retry_backoff_delays_are_correct(mock_sleep: object, tmp_path: Path) ->
 
 @patch("dani.service.time.sleep")
 def test_retrying_status_visible_during_retry(mock_sleep: object, tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
     observed_statuses: list[str] = []
     original_sleep = mock_sleep
 
@@ -185,7 +185,7 @@ def test_retrying_status_visible_during_retry(mock_sleep: object, tmp_path: Path
             observed_statuses.append(jobs[0].status)
 
     original_sleep.side_effect = capture_status  # type: ignore[union-attr]
-    omx_runner.set_transient_failures(1)
+    codex_runner.set_transient_failures(1)
 
     service.handle_event(_issue_event())
     service.wait_for_idle()
@@ -195,15 +195,15 @@ def test_retrying_status_visible_during_retry(mock_sleep: object, tmp_path: Path
 
 @patch("dani.service.time.sleep")
 def test_transient_error_with_side_effect_already_posted_completes(mock_sleep: object, tmp_path: Path) -> None:
-    """If the OMX run posted the GitHub comment before the capacity error, don't retry — mark completed."""
-    service, _, omx_runner = make_service(tmp_path)
+    """If the Codex run posted the GitHub comment before the capacity error, don't retry — mark completed."""
+    service, _, codex_runner = make_service(tmp_path)
 
     # Don't use set_transient_failures — we want launch() to post the side effect
     # normally, then have wait() raise a transient error afterward.
     def wait_that_always_fails(runtime_handle: str, **kwargs: object) -> None:
         raise TransientCapacityError(_CAPACITY_MSG, _CAPACITY_MSG)
 
-    omx_runner.wait = wait_that_always_fails  # type: ignore[assignment]
+    codex_runner.wait = wait_that_always_fails  # type: ignore[assignment]
 
     service.handle_event(_issue_event())
     service.wait_for_idle()
@@ -212,7 +212,7 @@ def test_transient_error_with_side_effect_already_posted_completes(mock_sleep: o
     assert job.status == "completed"
     assert job.metadata.get("note") == "side_effect_already_posted"
     # Should NOT have retried — only 1 launch
-    assert len(omx_runner.launches) == 1
+    assert len(codex_runner.launches) == 1
 
 
 @patch("dani.service.time.sleep")
@@ -223,19 +223,19 @@ def test_restart_issue_request_with_stale_signed_comments_does_not_false_complet
     stale_signature = "<!-- dani:stage=issue_request;job=stale-job;issue=11 -->"
     github.add_issue_signature("acme/demo", 11, stale_signature)
 
-    original_launch = service.omx_runner.launch
+    original_launch = service.codex_runner.launch
 
     def launch_without_new_side_effect(repo_path: Path, job, prompt: str):
         session = original_launch(repo_path, job, prompt)
         github.issue_comment_map[("acme/demo", 11)] = [{"body": stale_signature}]
         return session
 
-    service.omx_runner.launch = launch_without_new_side_effect  # type: ignore[assignment]
+    service.codex_runner.launch = launch_without_new_side_effect  # type: ignore[assignment]
 
     def wait_that_always_fails(runtime_handle: str, **kwargs: object) -> None:
         raise TransientCapacityError(_CAPACITY_MSG, _CAPACITY_MSG)
 
-    service.omx_runner.wait = wait_that_always_fails  # type: ignore[assignment]
+    service.codex_runner.wait = wait_that_always_fails  # type: ignore[assignment]
 
     service.handle_event(_issue_event())
     service.wait_for_idle()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,7 +13,7 @@ from dani.models import DaniConfig
 from dani.server import create_app
 from dani.service import DaniService
 from dani.storage import JsonStorage
-from tests.helpers import FakeGitHubCLI, FakeOmxRunner
+from tests.helpers import FakeCodexRunner, FakeGitHubCLI
 
 TEST_SECRET = "unit-test-secret"
 
@@ -26,9 +26,12 @@ def _signature(secret: str, body: bytes) -> str:
 def test_github_webhook_endpoint_accepts_valid_signature(tmp_path: Path) -> None:
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     github = FakeGitHubCLI()
-    omx_runner = FakeOmxRunner(github)
+    codex_runner = FakeCodexRunner(github)
     service = DaniService(
-        config, storage=JsonStorage(config), github=cast(GitHubCLI, github), omx_runner=cast(AgentRunner, omx_runner)
+        config,
+        storage=JsonStorage(config),
+        github=cast(GitHubCLI, github),
+        codex_runner=cast(AgentRunner, codex_runner),
     )
     service.register_repo("acme/demo", str(tmp_path))
     client = TestClient(create_app(service))
@@ -60,12 +63,12 @@ def test_github_webhook_endpoint_queues_dev_sync_on_main_push(tmp_path: Path) ->
 
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     github = FakeGitHubCLI()
-    omx_runner = FakeOmxRunner(github)
+    codex_runner = FakeCodexRunner(github)
     service = DaniService(
         config,
         storage=JsonStorage(config),
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, omx_runner),
+        codex_runner=cast(AgentRunner, codex_runner),
         dev_syncer=FakeSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))
@@ -97,9 +100,12 @@ def test_github_webhook_endpoint_queues_dev_sync_on_main_push(tmp_path: Path) ->
 def test_github_webhook_endpoint_dedupes_duplicate_external_pr_delivery(tmp_path: Path) -> None:
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     github = FakeGitHubCLI()
-    omx_runner = FakeOmxRunner(github)
+    codex_runner = FakeCodexRunner(github)
     service = DaniService(
-        config, storage=JsonStorage(config), github=cast(GitHubCLI, github), omx_runner=cast(AgentRunner, omx_runner)
+        config,
+        storage=JsonStorage(config),
+        github=cast(GitHubCLI, github),
+        codex_runner=cast(AgentRunner, codex_runner),
     )
     service.register_repo("acme/demo", str(tmp_path))
     client = TestClient(create_app(service))

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -18,6 +18,10 @@ from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI, FakeOmxRunner, FakeRu
 TEST_SECRET = "unit-test-secret"
 
 
+class _GitHubOutageError(RuntimeError):
+    pass
+
+
 def add_exact_review_signature(github: FakeGitHubCLI, job: JobRecord) -> None:
     signature_fields: dict[str, str | int] = {
         "stage": "review_round",
@@ -405,9 +409,10 @@ def test_service_build_prompt_uses_effective_runtime_not_configured_runtime(tmp_
     omx_prompt = service._build_prompt(repo, job, runtime=RUNTIME_OMX)
     omo_prompt = service._build_prompt(repo, job, runtime=RUNTIME_OMO)
 
-    assert "$ralph" in omx_prompt
+    assert "$omo:ulw-loop tdd manual qa commit well" in omx_prompt
+    assert "$ralph" not in omx_prompt
     assert "$ralph" not in omo_prompt
-    assert "ultrawork" in omo_prompt
+    assert "$omo:ulw-loop tdd manual qa commit well" in omo_prompt
 
 
 def test_issue_followup_verification_requires_exact_signature(tmp_path: Path) -> None:
@@ -1689,8 +1694,6 @@ def test_duplicate_final_verdict_event_is_ignored(tmp_path: Path) -> None:
 
 def test_final_verdict_transient_failure_allows_redelivery(tmp_path: Path) -> None:
     """A transient merge failure must not poison redelivery — the retry must succeed."""
-    from github.GithubException import GithubException
-
     service, github, _omx_runner = make_service(tmp_path)
     service.storage.create_job(
         JobRecord(
@@ -1713,7 +1716,7 @@ def test_final_verdict_transient_failure_allows_redelivery(tmp_path: Path) -> No
     original_merge = github.merge_pull_request
 
     def boom(repo_full_name: str, pr_number: int) -> None:
-        raise GithubException(500, {"message": "GitHub outage"}, {})
+        raise _GitHubOutageError
 
     github.merge_pull_request = boom  # type: ignore[assignment]
     event = NormalizedEvent(
@@ -1728,7 +1731,7 @@ def test_final_verdict_transient_failure_allows_redelivery(tmp_path: Path) -> No
         is_pull_request=True,
     )
 
-    with pytest.raises(GithubException):
+    with pytest.raises(_GitHubOutageError):
         service.handle_event(event)
 
     # Restore normal merge and redeliver the same event

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -5,15 +5,15 @@ from typing import cast
 import pytest
 
 from dani.agent_runner import AgentRunner
+from dani.codex_runner import CodexRunner
 from dani.errors import ClaudeUsageLimitError, RolloutMissingError
 from dani.github import GitHubCLI
-from dani.models import RUNTIME_OMO, RUNTIME_OMX, DaniConfig, JobRecord, NormalizedEvent, SessionRecord
-from dani.omx_runner import OmxRunner
+from dani.models import RUNTIME_CODEX, RUNTIME_OMO, DaniConfig, JobRecord, NormalizedEvent, SessionRecord
 from dani.service import DaniService
 from dani.session_bridge import BridgeContext, OmoSessionBridge
 from dani.signatures import build_signature
 from dani.storage import JsonStorage
-from tests.helpers import FakeGitDevSyncer, FakeGitHubCLI, FakeOmxRunner, FakeRuntimeRunner
+from tests.helpers import FakeCodexRunner, FakeGitDevSyncer, FakeGitHubCLI, FakeRuntimeRunner
 
 TEST_SECRET = "unit-test-secret"
 
@@ -40,8 +40,8 @@ def add_exact_review_signature(github: FakeGitHubCLI, job: JobRecord) -> None:
 
 def make_service(
     tmp_path: Path, *, dev_syncer: FakeGitDevSyncer | None = None
-) -> tuple[DaniService, FakeGitHubCLI, FakeOmxRunner]:
-    class ExactReviewSignatureOmxRunner(FakeOmxRunner):
+) -> tuple[DaniService, FakeGitHubCLI, FakeCodexRunner]:
+    class ExactReviewSignatureCodexRunner(FakeCodexRunner):
         def launch(self, repo_path: Path, job: JobRecord, prompt: str):
             session = super().launch(repo_path, job, prompt)
             if job.stage == "review_round" and job.issue_number is not None:
@@ -51,16 +51,16 @@ def make_service(
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
-    omx_runner = ExactReviewSignatureOmxRunner(github)
+    codex_runner = ExactReviewSignatureCodexRunner(github)
     service = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, omx_runner),
+        codex_runner=cast(AgentRunner, codex_runner),
         dev_syncer=dev_syncer or FakeGitDevSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))
-    return service, github, omx_runner
+    return service, github, codex_runner
 
 
 def make_omo_preferred_service(
@@ -82,19 +82,19 @@ def make_omo_preferred_service(
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
     omo_runner = FakeRuntimeRunner(github, runtime_name=RUNTIME_OMO)
-    omx_runner = FakeRuntimeRunner(github, runtime_name=RUNTIME_OMX)
+    codex_runner = FakeRuntimeRunner(github, runtime_name=RUNTIME_CODEX)
     bridge = StubBridge(bridge_context)
     service = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(OmxRunner, omo_runner),
+        codex_runner=cast(CodexRunner, omo_runner),
         dev_syncer=dev_syncer or FakeGitDevSyncer(),
-        runtime_runners={RUNTIME_OMX: cast(OmxRunner, omx_runner)},
+        runtime_runners={RUNTIME_CODEX: cast(CodexRunner, codex_runner)},
         session_bridge=cast(OmoSessionBridge, bridge),
     )
     service.register_repo("acme/demo", str(tmp_path))
-    return service, github, omo_runner, omx_runner
+    return service, github, omo_runner, codex_runner
 
 
 def make_pr_event(
@@ -138,7 +138,7 @@ def make_pr_comment_event(*, pr_number: int, body: str, actor_login: str = "agen
     )
 
 
-def test_issue_request_persists_omx_session_id(tmp_path: Path) -> None:
+def test_issue_request_persists_codex_session_id(tmp_path: Path) -> None:
     service, _, _ = make_service(tmp_path)
 
     service.handle_event(
@@ -156,7 +156,7 @@ def test_issue_request_persists_omx_session_id(tmp_path: Path) -> None:
     service.wait_for_idle()
 
     session = service.storage.list_sessions()[0]
-    assert session.omx_session_id == "omx-" + session.job_id
+    assert session.codex_session_id == "codex-" + session.job_id
 
 
 def test_issue_request_verification_requires_exact_signature(tmp_path: Path) -> None:
@@ -183,7 +183,7 @@ def test_issue_request_verification_rejects_stale_signature(tmp_path: Path) -> N
 
 
 def test_issue_opened_queues_issue_request(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
     event = NormalizedEvent(
         kind="issue_opened",
         repo_full_name="acme/demo",
@@ -199,9 +199,9 @@ def test_issue_opened_queues_issue_request(tmp_path: Path) -> None:
     service.wait_for_idle()
 
     assert result["status"] == "queued"
-    assert omx_runner.launches[0]["job"].stage == "issue_request"
+    assert codex_runner.launches[0]["job"].stage == "issue_request"
     assert service.storage.list_jobs()[0].status == "completed"
-    assert omx_runner.closed_sessions == [f"runtime-{service.storage.list_jobs()[0].id}"]
+    assert codex_runner.closed_sessions == [f"runtime-{service.storage.list_jobs()[0].id}"]
     session = service.storage.list_sessions()[0]
     assert session.status == "completed"
     assert session.ended_at is not None
@@ -209,7 +209,7 @@ def test_issue_opened_queues_issue_request(tmp_path: Path) -> None:
 
 
 def test_general_issue_comment_resumes_existing_issue_session(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
     service.handle_event(
         NormalizedEvent(
             kind="issue_opened",
@@ -239,14 +239,14 @@ def test_general_issue_comment_resumes_existing_issue_session(tmp_path: Path) ->
     service.wait_for_idle()
 
     assert result["stage"] == "issue_followup"
-    assert omx_runner.resumes[-1]["omx_session_id"].startswith("omx-")
-    assert omx_runner.resumes[-1]["job"].stage == "issue_followup"
+    assert codex_runner.resumes[-1]["codex_session_id"].startswith("codex-")
+    assert codex_runner.resumes[-1]["job"].stage == "issue_followup"
     followup_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=31)
     assert len(followup_jobs) == 1
 
 
 def test_general_issue_comment_without_existing_issue_session_is_ignored(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
 
     result = service.handle_event(
         NormalizedEvent(
@@ -262,16 +262,16 @@ def test_general_issue_comment_without_existing_issue_session_is_ignored(tmp_pat
     )
 
     assert result == {"status": "ignored", "reason": "missing_issue_session"}
-    assert omx_runner.resumes == []
+    assert codex_runner.resumes == []
 
 
-def test_issue_request_falls_back_from_omo_to_omx_on_claude_session_limit(tmp_path: Path) -> None:
+def test_issue_request_falls_back_from_omo_to_codex_on_claude_session_limit(tmp_path: Path) -> None:
     bridge_context = BridgeContext(
         prompt_block="Prior OMO context (imported summary; not a native resume):\n- Open thread: finish edge cases",
         source_session_id="ses_prior_123",
         note="from_test",
     )
-    service, _, omo_runner, omx_runner = make_omo_preferred_service(tmp_path, bridge_context=bridge_context)
+    service, _, omo_runner, codex_runner = make_omo_preferred_service(tmp_path, bridge_context=bridge_context)
     omo_runner.queue_wait_error(
         ClaudeUsageLimitError(
             "Claude usage limit reached",
@@ -300,21 +300,21 @@ def test_issue_request_falls_back_from_omo_to_omx_on_claude_session_limit(tmp_pa
     sessions = service.storage.list_sessions()
     assert job.status == "completed"
     assert job.metadata["preferred_runtime"] == RUNTIME_OMO
-    assert job.metadata["effective_runtime"] == RUNTIME_OMX
+    assert job.metadata["effective_runtime"] == RUNTIME_CODEX
     assert job.metadata["fallback_reason"] == "claude_session_window_limit"
     assert job.metadata["usage_limit_kind"] == "session_window"
     assert job.metadata["bridge_source_session_id"] == "ses_prior_123"
     assert len(omo_runner.launches) == 1
-    assert len(omx_runner.launches) == 1
-    assert "Prior OMO context" in omx_runner.launches[0]["prompt"]
-    assert "not a native resume" in omx_runner.launches[0]["prompt"]
-    assert [session.effective_runtime for session in sessions] == [RUNTIME_OMO, RUNTIME_OMX]
+    assert len(codex_runner.launches) == 1
+    assert "Prior OMO context" in codex_runner.launches[0]["prompt"]
+    assert "not a native resume" in codex_runner.launches[0]["prompt"]
+    assert [session.effective_runtime for session in sessions] == [RUNTIME_OMO, RUNTIME_CODEX]
     assert sessions[0].status == "failed"
     assert sessions[1].status == "completed"
 
 
-def test_issue_request_uses_cached_claude_weekly_limit_to_start_directly_on_omx(tmp_path: Path) -> None:
-    service, _, omo_runner, omx_runner = make_omo_preferred_service(tmp_path)
+def test_issue_request_uses_cached_claude_weekly_limit_to_start_directly_on_codex(tmp_path: Path) -> None:
+    service, _, omo_runner, codex_runner = make_omo_preferred_service(tmp_path)
     service.storage.create_job(
         JobRecord(
             repo_full_name="acme/demo",
@@ -345,14 +345,14 @@ def test_issue_request_uses_cached_claude_weekly_limit_to_start_directly_on_omx(
 
     job = service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_request", issue_number=52)[0]
     assert job.status == "completed"
-    assert job.metadata["effective_runtime"] == RUNTIME_OMX
+    assert job.metadata["effective_runtime"] == RUNTIME_CODEX
     assert job.metadata["fallback_reason"] == "cached_claude_usage_limit"
     assert omo_runner.launches == []
-    assert len(omx_runner.launches) == 1
+    assert len(codex_runner.launches) == 1
 
 
-def test_issue_followup_after_omo_fallback_continues_on_omx_session(tmp_path: Path) -> None:
-    service, _, omo_runner, omx_runner = make_omo_preferred_service(tmp_path)
+def test_issue_followup_after_omo_fallback_continues_on_codex_session(tmp_path: Path) -> None:
+    service, _, omo_runner, codex_runner = make_omo_preferred_service(tmp_path)
     omo_runner.queue_wait_error(
         ClaudeUsageLimitError(
             "Opus weekly limit reached",
@@ -394,10 +394,10 @@ def test_issue_followup_after_omo_fallback_continues_on_omx_session(tmp_path: Pa
     followup_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=53)[0]
     assert result["stage"] == "issue_followup"
     assert followup_job.status == "completed"
-    assert followup_job.metadata["effective_runtime"] == RUNTIME_OMX
+    assert followup_job.metadata["effective_runtime"] == RUNTIME_CODEX
     assert len(omo_runner.resumes) == 0
-    assert len(omx_runner.resumes) == 1
-    assert omx_runner.resumes[0]["job"].stage == "issue_followup"
+    assert len(codex_runner.resumes) == 1
+    assert codex_runner.resumes[0]["job"].stage == "issue_followup"
 
 
 def test_service_build_prompt_uses_effective_runtime_not_configured_runtime(tmp_path: Path) -> None:
@@ -406,12 +406,13 @@ def test_service_build_prompt_uses_effective_runtime_not_configured_runtime(tmp_
     assert repo is not None
     job = JobRecord(repo_full_name="acme/demo", stage="implementation", issue_number=54)
 
-    omx_prompt = service._build_prompt(repo, job, runtime=RUNTIME_OMX)
+    codex_prompt = service._build_prompt(repo, job, runtime=RUNTIME_CODEX)
     omo_prompt = service._build_prompt(repo, job, runtime=RUNTIME_OMO)
+    removed_command = f"${'ra'}{'lph'}"
 
-    assert "$omo:ulw-loop tdd manual qa commit well" in omx_prompt
-    assert "$ralph" not in omx_prompt
-    assert "$ralph" not in omo_prompt
+    assert "$omo:ulw-loop tdd manual qa commit well" in codex_prompt
+    assert removed_command not in codex_prompt
+    assert removed_command not in omo_prompt
     assert "$omo:ulw-loop tdd manual qa commit well" in omo_prompt
 
 
@@ -432,7 +433,7 @@ def test_issue_comment_with_unresumable_prior_session_falls_back_to_fresh_issue_
 ) -> None:
     from dani.models import SessionRecord
 
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
     repo = service.storage.get_repo("acme/demo")
     assert repo is not None
 
@@ -446,12 +447,12 @@ def test_issue_comment_with_unresumable_prior_session_falls_back_to_fresh_issue_
         worktree_path=str(tmp_path),
         job_id="legacy-job-id",
         issue_number=731,
-        omx_session_id=legacy_session_id,
+        codex_session_id=legacy_session_id,
     )
     service.storage.create_session(legacy_session)
 
     monkeypatch.setattr(
-        omx_runner,
+        codex_runner,
         "can_resume",
         lambda session_id: bool(session_id) and not session_id.startswith("019d"),
     )
@@ -478,12 +479,12 @@ def test_issue_comment_with_unresumable_prior_session_falls_back_to_fresh_issue_
     ]
     assert request_jobs, "expected a fresh issue_request to be enqueued when prior session id is non-resumable"
     assert not followup_jobs, "must NOT enqueue an issue_followup against an un-resumable session id"
-    assert not omx_runner.resumes, "runner.resume must not be invoked when can_resume returned False"
+    assert not codex_runner.resumes, "runner.resume must not be invoked when can_resume returned False"
     new_job = next(job for job in request_jobs if job.id != legacy_session.job_id)
     assert new_job.metadata["rerouted_from"] == "issue_followup"
     assert new_job.metadata["prior_session_id"] == legacy_session_id
     assert new_job.metadata["comment_body"] == "this is a fresh comment on a legacy issue"
-    assert any(launch["job"].issue_number == 731 for launch in omx_runner.launches), (
+    assert any(launch["job"].issue_number == 731 for launch in codex_runner.launches), (
         "runner.launch must run a fresh session for the legacy issue"
     )
 
@@ -493,7 +494,7 @@ def test_issue_comment_with_resumable_prior_session_still_resumes(
 ) -> None:
     from dani.models import SessionRecord
 
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
     repo = service.storage.get_repo("acme/demo")
     assert repo is not None
 
@@ -507,12 +508,12 @@ def test_issue_comment_with_resumable_prior_session_still_resumes(
         worktree_path=str(tmp_path),
         job_id="resumable-job-id",
         issue_number=732,
-        omx_session_id=resumable_session_id,
+        codex_session_id=resumable_session_id,
     )
     service.storage.create_session(resumable_session)
 
     monkeypatch.setattr(
-        omx_runner,
+        codex_runner,
         "can_resume",
         lambda session_id: bool(session_id) and session_id.startswith("ses_"),
     )
@@ -535,7 +536,7 @@ def test_issue_comment_with_resumable_prior_session_still_resumes(
         job for job in service.storage.list_jobs() if job.stage == "issue_followup" and job.issue_number == 732
     ]
     assert followup_jobs, "expected an issue_followup job when prior session id is resumable"
-    assert any(resume["omx_session_id"] == resumable_session_id for resume in omx_runner.resumes), (
+    assert any(resume["codex_session_id"] == resumable_session_id for resume in codex_runner.resumes), (
         "runner.resume must be invoked with the resumable session id"
     )
 
@@ -552,7 +553,7 @@ def test_issue_followup_verification_rejects_stale_signature(tmp_path: Path) -> 
 
 
 def test_issue_followup_rollout_missing_marks_job_failed_and_posts_restart_warning(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     service.handle_event(
         NormalizedEvent(
             kind="issue_opened",
@@ -567,7 +568,7 @@ def test_issue_followup_rollout_missing_marks_job_failed_and_posts_restart_warni
     )
     service.wait_for_idle()
 
-    omx_runner.set_resume_failure(
+    codex_runner.set_resume_failure(
         RolloutMissingError(
             "thread/resume failed: no rollout found for thread id 019d6829",
             "no rollout found",
@@ -606,7 +607,7 @@ def test_issue_followup_rollout_missing_marks_job_failed_and_posts_restart_warni
 
 
 def test_issue_followup_rollout_missing_warning_comment_is_posted_only_once(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     service.handle_event(
         NormalizedEvent(
             kind="issue_opened",
@@ -620,7 +621,7 @@ def test_issue_followup_rollout_missing_warning_comment_is_posted_only_once(tmp_
         )
     )
     service.wait_for_idle()
-    omx_runner.set_resume_failure(
+    codex_runner.set_resume_failure(
         RolloutMissingError(
             "thread/resume failed: no rollout found for thread id 019d6829",
             "no rollout found",
@@ -662,7 +663,7 @@ def test_issue_followup_rollout_missing_warning_comment_is_posted_only_once(tmp_
 
 
 def test_issue_followup_rollout_missing_retries_warning_after_comment_post_failure(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     service.handle_event(
         NormalizedEvent(
             kind="issue_opened",
@@ -676,7 +677,7 @@ def test_issue_followup_rollout_missing_retries_warning_after_comment_post_failu
         )
     )
     service.wait_for_idle()
-    omx_runner.set_resume_failure(
+    codex_runner.set_resume_failure(
         RolloutMissingError(
             "thread/resume failed: no rollout found for thread id 019d6829",
             "no rollout found",
@@ -743,7 +744,7 @@ def test_restart_issue_supersedes_existing_jobs_and_enqueues_new_issue_request(t
         stage="issue_followup",
         issue_number=41,
         status="failed",
-        metadata={"omx_session_id": "omx-stale", "title": "Restart me", "body": "Original body"},
+        metadata={"codex_session_id": "codex-stale", "title": "Restart me", "body": "Original body"},
     )
     untouched = JobRecord(repo_full_name="acme/demo", stage="issue_request", issue_number=99, status="completed")
     service.storage.create_job(stale_request)
@@ -773,7 +774,7 @@ def test_restart_issue_supersedes_existing_jobs_and_enqueues_new_issue_request(t
 
 
 def test_issue_comment_with_ignore_signature_is_ignored_before_followup(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
     service.handle_event(
         NormalizedEvent(
             kind="issue_opened",
@@ -804,11 +805,11 @@ def test_issue_comment_with_ignore_signature_is_ignored_before_followup(tmp_path
 
     assert result == {"status": "ignored", "reason": "comment_opt_out"}
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="issue_followup", issue_number=36) == []
-    assert omx_runner.resumes == []
+    assert codex_runner.resumes == []
 
 
 def test_issue_comment_with_ignore_command_overrides_approve(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
 
     result = service.handle_event(
         NormalizedEvent(
@@ -826,11 +827,11 @@ def test_issue_comment_with_ignore_command_overrides_approve(tmp_path: Path) -> 
 
     assert result == {"status": "ignored", "reason": "comment_opt_out"}
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", issue_number=37) == []
-    assert omx_runner.launches == []
+    assert codex_runner.launches == []
 
 
 def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
     event = NormalizedEvent(
         kind="issue_comment",
         repo_full_name="acme/demo",
@@ -846,13 +847,13 @@ def test_approve_comment_queues_implementation(tmp_path: Path) -> None:
     service.wait_for_idle()
 
     assert result["stage"] == "implementation"
-    assert omx_runner.launches[0]["job"].stage == "implementation"
+    assert codex_runner.launches[0]["job"].stage == "implementation"
     assert service.storage.list_jobs()[0].status == "completed"
 
 
 def test_failed_job_still_closes_runtime_handle_and_marks_failure(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
-    session = omx_runner.launch(Path(tmp_path), JobRecord(repo_full_name="acme/demo", stage="implementation"), "")
+    service, _, codex_runner = make_service(tmp_path)
+    session = codex_runner.launch(Path(tmp_path), JobRecord(repo_full_name="acme/demo", stage="implementation"), "")
     service.storage.create_session(session)
 
     service._finalize_session(session, status="failed", termination_reason="RuntimeError")
@@ -861,11 +862,11 @@ def test_failed_job_still_closes_runtime_handle_and_marks_failure(tmp_path: Path
     assert stored.status == "failed"
     assert stored.ended_at is not None
     assert stored.termination_reason == "RuntimeError"
-    assert omx_runner.closed_sessions == [session.runtime_handle]
+    assert codex_runner.closed_sessions == [session.runtime_handle]
 
 
 def test_pr_opened_from_implementation_signature_queues_review_round(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
     implementation_event = NormalizedEvent(
         kind="issue_comment",
         repo_full_name="acme/demo",
@@ -902,11 +903,11 @@ def test_pr_opened_from_implementation_signature_queues_review_round(tmp_path: P
     review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=99)
     assert result["stage"] == "review_round"
     assert review_jobs[0].review_round == 1
-    assert omx_runner.launches[-1]["job"].stage == "review_round"
+    assert codex_runner.launches[-1]["job"].stage == "review_round"
 
 
 def test_external_pr_opened_queues_review_round(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
 
     result = service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
     service.wait_for_idle()
@@ -915,11 +916,11 @@ def test_external_pr_opened_queues_review_round(tmp_path: Path) -> None:
     review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
     assert [job.review_round for job in review_jobs] == [1]
     assert review_jobs[0].metadata["external_contribution"] is True
-    assert omx_runner.launches[-1]["job"].stage == "review_round"
+    assert codex_runner.launches[-1]["job"].stage == "review_round"
 
 
 def test_external_pr_new_commit_queues_another_review_round(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
 
     service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
     service.wait_for_idle()
@@ -930,11 +931,11 @@ def test_external_pr_new_commit_queues_another_review_round(tmp_path: Path) -> N
     assert result["stage"] == "review_round"
     review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
     assert [job.review_round for job in review_jobs] == [1, 2]
-    assert omx_runner.launches[-1]["job"].stage == "review_round"
+    assert codex_runner.launches[-1]["job"].stage == "review_round"
 
 
 def test_duplicate_external_pr_activity_event_is_ignored(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
 
     service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21", commit_sha="sha-1"))
     service.wait_for_idle()
@@ -952,7 +953,7 @@ def test_duplicate_external_pr_activity_event_is_ignored(tmp_path: Path) -> None
     assert duplicate == {"status": "ignored", "reason": "duplicate_external_pr_event"}
     review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
     assert [job.review_round for job in review_jobs] == [1, 2]
-    assert len(omx_runner.launches) == 2
+    assert len(codex_runner.launches) == 2
 
 
 def test_duplicate_external_pr_activity_does_not_consume_review_limit(tmp_path: Path) -> None:
@@ -1036,17 +1037,17 @@ def test_external_pr_fallback_dedupe_key_is_repo_scoped(tmp_path: Path) -> None:
 
 
 def test_external_pr_review_requested_queues_review_round(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
 
     result = service.handle_event(make_pr_event(pr_number=91, action="review_requested", body="Implements #21"))
     service.wait_for_idle()
 
     assert result["stage"] == "review_round"
-    assert omx_runner.launches[-1]["job"].stage == "review_round"
+    assert codex_runner.launches[-1]["job"].stage == "review_round"
 
 
 def test_external_pr_from_account_younger_than_one_year_is_closed(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     github.users["newcomer"] = {"login": "newcomer", "created_at": "3000-01-01T00:00:00Z"}
 
     result = service.handle_event(
@@ -1057,7 +1058,7 @@ def test_external_pr_from_account_younger_than_one_year_is_closed(tmp_path: Path
     assert result == {"status": "closed", "reason": "contributor_account_too_new", "pr_number": 92}
     assert github.closed_pull_requests == [("acme/demo", 92)]
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=92) == []
-    assert omx_runner.launches == []
+    assert codex_runner.launches == []
     comments = github.pr_comments("acme/demo", 92)
     assert len(comments) == 1
     assert "at least one year old" in comments[0]["body"]
@@ -1081,7 +1082,7 @@ def test_external_pr_uses_pull_request_author_created_at_instead_of_sender(tmp_p
 
 
 def test_external_pr_from_account_at_least_one_year_old_queues_review_round(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     github.users["veteran"] = {"login": "veteran", "created_at": "2000-01-01T00:00:00Z"}
 
     result = service.handle_event(
@@ -1092,11 +1093,11 @@ def test_external_pr_from_account_at_least_one_year_old_queues_review_round(tmp_
     assert result["stage"] == "review_round"
     assert github.closed_pull_requests == []
     assert all("at least one year old" not in comment["body"] for comment in github.pr_comments("acme/demo", 94))
-    assert omx_runner.launches[-1]["job"].stage == "review_round"
+    assert codex_runner.launches[-1]["job"].stage == "review_round"
 
 
 def test_external_review_comment_queues_implementation_like_internal_pr(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
     service.wait_for_idle()
     review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
@@ -1113,12 +1114,12 @@ def test_external_review_comment_queues_implementation_like_internal_pr(tmp_path
     implementation_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88)
     assert len(implementation_jobs) == 1
     assert implementation_jobs[0].metadata["external_contribution"] is True
-    assert omx_runner.launches[-1]["job"].stage == "implementation"
+    assert codex_runner.launches[-1]["job"].stage == "implementation"
     assert github.merged == []
 
 
 def test_external_review_approve_comment_still_follows_internal_implementation_path(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21"))
     service.wait_for_idle()
     review_job = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)[-1]
@@ -1134,12 +1135,12 @@ def test_external_review_approve_comment_still_follows_internal_implementation_p
     assert result["stage"] == "implementation"
     assert len(service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88)) == 1
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=88) == []
-    assert omx_runner.launches[-1]["job"].stage == "implementation"
+    assert codex_runner.launches[-1]["job"].stage == "implementation"
     assert github.merged == []
 
 
 def test_external_final_verdict_approve_requires_human_merge_for_non_owner_pr(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     github.add_pull_request(
         "acme/demo",
         88,
@@ -1158,12 +1159,12 @@ def test_external_final_verdict_approve_requires_human_merge_for_non_owner_pr(tm
 
     assert result == {"status": "approved", "reason": "human_merge_required", "pr_number": 88}
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=88) == []
-    assert omx_runner.launches == []
+    assert codex_runner.launches == []
     assert github.merged == []
 
 
 def test_external_pr_activity_stops_at_standard_review_round_limit(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
     for round_number in range(1, 4):
         service.storage.create_job(
             JobRecord(
@@ -1181,11 +1182,11 @@ def test_external_pr_activity_stops_at_standard_review_round_limit(tmp_path: Pat
 
     assert result == {"status": "ignored", "reason": "external_review_rounds_exhausted"}
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
-    assert omx_runner.launches == []
+    assert codex_runner.launches == []
 
 
 def test_external_review_chain_reaches_final_verdict_like_internal_pr(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
 
     service.handle_event(make_pr_event(pr_number=88, action="opened", body="Implements #21", commit_sha="sha-1"))
     service.wait_for_idle()
@@ -1220,11 +1221,11 @@ def test_external_review_chain_reaches_final_verdict_like_internal_pr(tmp_path: 
     assert len(implementation_jobs) == 3
     assert len(verdict_jobs) == 1
     assert verdict_jobs[0].metadata["external_contribution"] is True
-    assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+    assert codex_runner.launches[-1]["job"].stage == "final_verdict"
 
 
 def test_external_pr_unique_activity_never_queues_beyond_standard_review_limit(tmp_path: Path) -> None:
-    class BlockingOmxRunner(FakeOmxRunner):
+    class BlockingCodexRunner(FakeCodexRunner):
         def __init__(self, github: FakeGitHubCLI) -> None:
             super().__init__(github)
             self.review_started = threading.Event()
@@ -1248,12 +1249,12 @@ def test_external_pr_unique_activity_never_queues_beyond_standard_review_limit(t
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
-    omx_runner = BlockingOmxRunner(github)
+    codex_runner = BlockingCodexRunner(github)
     service = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, omx_runner),
+        codex_runner=cast(AgentRunner, codex_runner),
         dev_syncer=FakeGitDevSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))
@@ -1262,7 +1263,7 @@ def test_external_pr_unique_activity_never_queues_beyond_standard_review_limit(t
         make_pr_event(pr_number=88, action="opened", body="Implements #21", commit_sha="sha-1")
     )
     assert opened["stage"] == "review_round"
-    assert omx_runner.review_started.wait(timeout=1)
+    assert codex_runner.review_started.wait(timeout=1)
 
     results = []
     for round_number in range(2, 6):
@@ -1284,7 +1285,7 @@ def test_external_pr_unique_activity_never_queues_beyond_standard_review_limit(t
     ]
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="human_escalation", pr_number=88) == []
 
-    omx_runner.release_review.set()
+    codex_runner.release_review.set()
     service.wait_for_idle()
 
     review_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=88)
@@ -1295,7 +1296,7 @@ def test_external_pr_unique_activity_never_queues_beyond_standard_review_limit(t
 
 
 def test_review_chain_reaches_verdict_and_merges_on_approve(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     pr_event = NormalizedEvent(
         kind="pull_request_opened",
         repo_full_name="acme/demo",
@@ -1364,7 +1365,7 @@ def test_review_chain_reaches_verdict_and_merges_on_approve(tmp_path: Path) -> N
 
     verdict_jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=77)
     assert verdict_jobs
-    assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+    assert codex_runner.launches[-1]["job"].stage == "final_verdict"
     assert [
         job.review_round
         for job in service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=77)
@@ -1388,7 +1389,7 @@ def test_review_chain_reaches_verdict_and_merges_on_approve(tmp_path: Path) -> N
 
 
 def test_approve_verdict_with_merge_conflict_queues_resolution_job(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     github.merge_conflicts.add(("acme/demo", 77))
     github.add_pull_request(
         "acme/demo",
@@ -1421,7 +1422,7 @@ def test_approve_verdict_with_merge_conflict_queues_resolution_job(tmp_path: Pat
     assert resolution_jobs
     assert resolution_jobs[0].issue_number == 5
     assert resolution_jobs[0].metadata["head_branch"] == "Feature/#5"
-    assert omx_runner.launches[-1]["job"].stage == "merge_conflict_resolution"
+    assert codex_runner.launches[-1]["job"].stage == "merge_conflict_resolution"
     assert github.merged == []
 
 
@@ -1473,7 +1474,7 @@ def test_approve_verdict_with_merge_conflict_reuses_tracked_issue_number_without
 
 
 def test_merge_conflict_resolution_comment_queues_final_verdict_retry(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     pr_body = "Implements #5\n<!-- dani:stage=implementation;job=impl-1;issue=5 -->"
     github.add_pull_request(
         "acme/demo",
@@ -1505,11 +1506,11 @@ def test_merge_conflict_resolution_comment_queues_final_verdict_retry(tmp_path: 
     assert verdict_jobs[0].issue_number == 5
     assert verdict_jobs[0].metadata["title"] == "Feature/#5"
     assert verdict_jobs[0].metadata["body"] == pr_body
-    assert omx_runner.launches[-1]["job"].stage == "final_verdict"
+    assert codex_runner.launches[-1]["job"].stage == "final_verdict"
 
 
 def test_duplicate_merge_conflict_resolution_event_is_ignored(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     github.add_pull_request(
         "acme/demo",
         77,
@@ -1539,8 +1540,8 @@ def test_duplicate_merge_conflict_resolution_event_is_ignored(tmp_path: Path) ->
     assert first["status"] == "queued"
     assert second == {"status": "ignored", "reason": "duplicate_agent_event"}
     assert len(verdict_jobs) == 1
-    assert omx_runner.launches[-1]["job"].stage == "final_verdict"
-    assert omx_runner.launches[-1]["job"].pr_number == 77
+    assert codex_runner.launches[-1]["job"].stage == "final_verdict"
+    assert codex_runner.launches[-1]["job"].pr_number == 77
 
 
 def test_merge_conflict_resolution_requires_its_own_signed_comment(tmp_path: Path) -> None:
@@ -1582,7 +1583,7 @@ def test_review_round_verification_rejects_stale_signed_comment(tmp_path: Path) 
 
 
 def test_duplicate_review_round_event_is_ignored(tmp_path: Path) -> None:
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
     event = NormalizedEvent(
         kind="pull_request_comment",
         repo_full_name="acme/demo",
@@ -1604,8 +1605,8 @@ def test_duplicate_review_round_event_is_ignored(tmp_path: Path) -> None:
     assert first["status"] == "queued"
     assert second == {"status": "ignored", "reason": "duplicate_agent_event"}
     assert len(implementation_jobs) == 1
-    assert omx_runner.launches[-1]["job"].stage == "implementation"
-    assert omx_runner.launches[-1]["job"].pr_number == 77
+    assert codex_runner.launches[-1]["job"].stage == "implementation"
+    assert codex_runner.launches[-1]["job"].pr_number == 77
 
 
 def test_implementation_followup_verification_requires_exact_signature(tmp_path: Path) -> None:
@@ -1655,7 +1656,7 @@ def test_final_verdict_verification_rejects_unrelated_signed_comment(tmp_path: P
 
 
 def test_duplicate_final_verdict_event_is_ignored(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     github.merge_conflicts.add(("acme/demo", 77))
     github.add_pull_request(
         "acme/demo",
@@ -1688,13 +1689,13 @@ def test_duplicate_final_verdict_event_is_ignored(tmp_path: Path) -> None:
     assert first["status"] == "queued"
     assert second == {"status": "ignored", "reason": "duplicate_agent_event"}
     assert len(resolution_jobs) == 1
-    assert omx_runner.launches[-1]["job"].stage == "merge_conflict_resolution"
-    assert omx_runner.launches[-1]["job"].pr_number == 77
+    assert codex_runner.launches[-1]["job"].stage == "merge_conflict_resolution"
+    assert codex_runner.launches[-1]["job"].pr_number == 77
 
 
 def test_final_verdict_transient_failure_allows_redelivery(tmp_path: Path) -> None:
     """A transient merge failure must not poison redelivery — the retry must succeed."""
-    service, github, _omx_runner = make_service(tmp_path)
+    service, github, _codex_runner = make_service(tmp_path)
     service.storage.create_job(
         JobRecord(
             repo_full_name="acme/demo",
@@ -1742,7 +1743,7 @@ def test_final_verdict_transient_failure_allows_redelivery(tmp_path: Path) -> No
 
 
 def test_bootstrap_repo_queues_existing_open_issues(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     github.open_issues["acme/demo"] = [
         {"number": 5, "title": "Bootstrap me", "body": "Need sync"},
         {"number": 6, "title": "Skip PR", "body": "PR body", "pull_request": {"url": "x"}},
@@ -1752,15 +1753,15 @@ def test_bootstrap_repo_queues_existing_open_issues(tmp_path: Path) -> None:
     service.wait_for_idle()
 
     assert count == 1
-    assert len(omx_runner.launches) == 1
-    first_job = omx_runner.launches[0]["job"]
+    assert len(codex_runner.launches) == 1
+    first_job = codex_runner.launches[0]["job"]
     assert isinstance(first_job, JobRecord)
     assert first_job.issue_number == 5
     assert first_job.stage == "issue_request"
 
 
 def test_bootstrap_repo_skips_issues_with_existing_issue_request_signature(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     github.open_issues["acme/demo"] = [
         {"number": 5, "title": "Already handled", "body": "Need sync"},
         {"number": 6, "title": "Needs bootstrap", "body": "Need report"},
@@ -1775,8 +1776,8 @@ def test_bootstrap_repo_skips_issues_with_existing_issue_request_signature(tmp_p
     service.wait_for_idle()
 
     assert count == 1
-    assert len(omx_runner.launches) == 1
-    only_job = omx_runner.launches[0]["job"]
+    assert len(codex_runner.launches) == 1
+    only_job = codex_runner.launches[0]["job"]
     assert isinstance(only_job, JobRecord)
     assert only_job.issue_number == 6
     assert only_job.stage == "issue_request"
@@ -2044,9 +2045,9 @@ def test_duplicate_main_push_is_ignored(tmp_path: Path) -> None:
     assert dev_syncer.sync_calls == [("acme/demo", "abc123")]
 
 
-def test_dev_sync_conflict_launches_omx_and_cleans_up(tmp_path: Path) -> None:
+def test_dev_sync_conflict_launches_codex_and_cleans_up(tmp_path: Path) -> None:
     dev_syncer = FakeGitDevSyncer(conflict=True)
-    service, _, omx_runner = make_service(tmp_path, dev_syncer=dev_syncer)
+    service, _, codex_runner = make_service(tmp_path, dev_syncer=dev_syncer)
 
     result = service.handle_event(
         NormalizedEvent(
@@ -2064,15 +2065,15 @@ def test_dev_sync_conflict_launches_omx_and_cleans_up(tmp_path: Path) -> None:
 
     jobs = service.storage.find_jobs(repo_full_name="acme/demo", stage="dev_sync")
     assert result["stage"] == "dev_sync"
-    assert omx_runner.launches[-1]["job"].stage == "dev_sync"
+    assert codex_runner.launches[-1]["job"].stage == "dev_sync"
     assert len(dev_syncer.verify_calls) == 1
     assert len(dev_syncer.cleanup_calls) == 1
     assert jobs[0].status == "completed"
 
 
-def test_dev_sync_conflict_falls_back_from_omo_to_omx_on_weekly_limit(tmp_path: Path) -> None:
+def test_dev_sync_conflict_falls_back_from_omo_to_codex_on_weekly_limit(tmp_path: Path) -> None:
     dev_syncer = FakeGitDevSyncer(conflict=True)
-    service, _, omo_runner, omx_runner = make_omo_preferred_service(tmp_path, dev_syncer=dev_syncer)
+    service, _, omo_runner, codex_runner = make_omo_preferred_service(tmp_path, dev_syncer=dev_syncer)
     omo_runner.queue_wait_error(
         ClaudeUsageLimitError(
             "Opus weekly limit reached",
@@ -2100,10 +2101,10 @@ def test_dev_sync_conflict_falls_back_from_omo_to_omx_on_weekly_limit(tmp_path: 
     job = service.storage.find_jobs(repo_full_name="acme/demo", stage="dev_sync")[0]
     assert result["stage"] == "dev_sync"
     assert job.status == "completed"
-    assert job.metadata["effective_runtime"] == RUNTIME_OMX
+    assert job.metadata["effective_runtime"] == RUNTIME_CODEX
     assert job.metadata["usage_limit_kind"] == "weekly"
     assert len(omo_runner.launches) == 1
-    assert len(omx_runner.launches) == 1
+    assert len(codex_runner.launches) == 1
     assert len(dev_syncer.verify_calls) == 1
     assert len(dev_syncer.cleanup_calls) == 1
 
@@ -2190,7 +2191,7 @@ def test_final_verdict_stops_when_pr_is_closed(tmp_path: Path) -> None:
 
 def test_pr_opened_without_issue_reference_is_ignored(tmp_path: Path) -> None:
     """A PR opened without any linked issue number is dropped as untracked."""
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
 
     result = service.handle_event(
         NormalizedEvent(
@@ -2210,12 +2211,12 @@ def test_pr_opened_without_issue_reference_is_ignored(tmp_path: Path) -> None:
 
     assert result == {"status": "ignored", "reason": "untracked_pr"}
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=42) == []
-    assert omx_runner.launches == []
+    assert codex_runner.launches == []
 
 
 def test_review_round_without_issue_drops_untracked_pr(tmp_path: Path) -> None:
     """Review-round agent event for a PR with no traceable issue is dropped."""
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
 
     review_event = NormalizedEvent(
         kind="pull_request_comment",
@@ -2232,12 +2233,12 @@ def test_review_round_without_issue_drops_untracked_pr(tmp_path: Path) -> None:
 
     assert result == {"status": "ignored", "reason": "untracked_pr"}
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="implementation", pr_number=42) == []
-    assert omx_runner.launches == []
+    assert codex_runner.launches == []
 
 
 def test_implementation_without_issue_drops_untracked_pr(tmp_path: Path) -> None:
     """Implementation agent event for a PR with no traceable issue is dropped."""
-    service, _, omx_runner = make_service(tmp_path)
+    service, _, codex_runner = make_service(tmp_path)
 
     impl_event = NormalizedEvent(
         kind="pull_request_comment",
@@ -2255,10 +2256,10 @@ def test_implementation_without_issue_drops_untracked_pr(tmp_path: Path) -> None
     assert result == {"status": "ignored", "reason": "untracked_pr"}
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="review_round", pr_number=42) == []
     assert service.storage.find_jobs(repo_full_name="acme/demo", stage="final_verdict", pr_number=42) == []
-    assert omx_runner.launches == []
+    assert codex_runner.launches == []
 
 
-class MissingIssueCommentRunner(FakeOmxRunner):
+class MissingIssueCommentRunner(FakeCodexRunner):
     def __init__(self, github: FakeGitHubCLI, *, recover: bool = True, resumable: bool = True) -> None:
         super().__init__(github)
         self.recover = recover
@@ -2278,20 +2279,20 @@ class MissingIssueCommentRunner(FakeOmxRunner):
                 issue_number=job.issue_number,
                 pr_number=job.pr_number,
                 review_round=job.review_round,
-                omx_session_id=f"omx-{job.id}" if self.resumable else None,
+                codex_session_id=f"codex-{job.id}" if self.resumable else None,
             )
         if job.stage in {"issue_request_recovery", "issue_followup_recovery"} and self.recover:
             self._post_recovery_signature(job)
         return super().launch(repo_path, job, prompt)
 
-    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str):
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, codex_session_id: str):
         if job.stage in {"issue_request_recovery", "issue_followup_recovery"} and self.recover:
             self._post_recovery_signature(job)
         self.resumes.append({
             "repo_path": str(repo_path),
             "job": job,
             "prompt": prompt,
-            "omx_session_id": omx_session_id,
+            "codex_session_id": codex_session_id,
         })
         return SessionRecord(
             repo_full_name=job.repo_full_name,
@@ -2304,7 +2305,7 @@ class MissingIssueCommentRunner(FakeOmxRunner):
             issue_number=job.issue_number,
             pr_number=job.pr_number,
             review_round=job.review_round,
-            omx_session_id=omx_session_id,
+            codex_session_id=codex_session_id,
         )
 
     def can_resume(self, session_id: str) -> bool:
@@ -2325,20 +2326,20 @@ def make_missing_comment_service(
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
-    omx_runner = MissingIssueCommentRunner(github, recover=recover, resumable=resumable)
+    codex_runner = MissingIssueCommentRunner(github, recover=recover, resumable=resumable)
     service = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, omx_runner),
+        codex_runner=cast(AgentRunner, codex_runner),
         dev_syncer=FakeGitDevSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))
-    return service, github, omx_runner
+    return service, github, codex_runner
 
 
 def test_issue_request_missing_signature_recovers_with_original_signature(tmp_path: Path) -> None:
-    service, github, omx_runner = make_missing_comment_service(tmp_path)
+    service, github, codex_runner = make_missing_comment_service(tmp_path)
 
     service.handle_event(
         NormalizedEvent(
@@ -2367,7 +2368,7 @@ def test_issue_request_missing_signature_recovers_with_original_signature(tmp_pa
     assert recovery_job.metadata["source_job_id"] == source_job.id
     assert recovery_job.metadata["expected_signature"] == expected_signature
     assert github.find_comments_by_signature("acme/demo", 40, kind="issue", signature_fragment=expected_signature)
-    recovery_prompt = omx_runner.resumes[-1]["prompt"]
+    recovery_prompt = codex_runner.resumes[-1]["prompt"]
     assert expected_signature in recovery_prompt
     assert "Do not write code" in recovery_prompt
     assert "GitHub issue comment exactly once" in recovery_prompt
@@ -2402,7 +2403,7 @@ def test_issue_request_recovery_failure_is_bounded_and_records_details(tmp_path:
 
 
 def test_issue_request_recovery_uses_fresh_launch_when_original_session_cannot_resume(tmp_path: Path) -> None:
-    service, _, omx_runner = make_missing_comment_service(tmp_path, resumable=False)
+    service, _, codex_runner = make_missing_comment_service(tmp_path, resumable=False)
 
     service.handle_event(
         NormalizedEvent(
@@ -2418,8 +2419,8 @@ def test_issue_request_recovery_uses_fresh_launch_when_original_session_cannot_r
     )
     service.wait_for_idle()
 
-    assert not omx_runner.resumes
-    assert [record["job"].stage for record in omx_runner.launches] == ["issue_request", "issue_request_recovery"]
+    assert not codex_runner.resumes
+    assert [record["job"].stage for record in codex_runner.launches] == ["issue_request", "issue_request_recovery"]
     source_job, recovery_job = service.storage.list_jobs()
     assert source_job.status == "completed"
     assert recovery_job.status == "completed"
@@ -2452,7 +2453,7 @@ def test_missing_issue_comment_recovery_is_not_duplicated_for_same_job(tmp_path:
 
 
 def test_issue_followup_missing_signature_recovers_with_original_signature(tmp_path: Path) -> None:
-    service, github, omx_runner = make_service(tmp_path)
+    service, github, codex_runner = make_service(tmp_path)
     service.handle_event(
         NormalizedEvent(
             kind="issue_opened",
@@ -2466,7 +2467,7 @@ def test_issue_followup_missing_signature_recovers_with_original_signature(tmp_p
         )
     )
     service.wait_for_idle()
-    omx_runner.resume_error = RuntimeError("issue-followup-comment-missing")
+    codex_runner.resume_error = RuntimeError("issue-followup-comment-missing")
 
     service.handle_event(
         NormalizedEvent(
@@ -2490,21 +2491,21 @@ def test_issue_followup_missing_signature_recovers_with_original_signature(tmp_p
     assert recovery_job.status == "completed"
     assert recovery_job.metadata["expected_signature"] == expected_signature
     assert github.find_comments_by_signature("acme/demo", 43, kind="issue", signature_fragment=expected_signature)
-    assert expected_signature in omx_runner.launches[-1]["prompt"]
+    assert expected_signature in codex_runner.launches[-1]["prompt"]
 
 
 class ResumeExceptionAfterPostingRecoveryRunner(MissingIssueCommentRunner):
-    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str):
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, codex_session_id: str):
         if job.stage in {"issue_request_recovery", "issue_followup_recovery"}:
             self._post_recovery_signature(job)
             self.resumes.append({
                 "repo_path": str(repo_path),
                 "job": job,
                 "prompt": prompt,
-                "omx_session_id": omx_session_id,
+                "codex_session_id": codex_session_id,
             })
             raise RuntimeError("resume raised after posting signature")  # noqa: TRY003
-        return super().resume(repo_path, job, prompt, omx_session_id)
+        return super().resume(repo_path, job, prompt, codex_session_id)
 
 
 class ResumeWaitFailureRecoveryRunner(MissingIssueCommentRunner):
@@ -2513,10 +2514,10 @@ class ResumeWaitFailureRecoveryRunner(MissingIssueCommentRunner):
         self._fail_next_resume_wait = False
         self.post_before_failure = post_before_failure
 
-    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str):
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, codex_session_id: str):
         if job.stage in {"issue_request_recovery", "issue_followup_recovery"} and self.post_before_failure:
             self._post_recovery_signature(job)
-        session = super().resume(repo_path, job, prompt, omx_session_id)
+        session = super().resume(repo_path, job, prompt, codex_session_id)
         if job.stage in {"issue_request_recovery", "issue_followup_recovery"}:
             self._fail_next_resume_wait = True
         return session
@@ -2543,36 +2544,36 @@ class RecoveryTransientFailureRunner(MissingIssueCommentRunner):
             self.set_transient_failures(1)
         return session
 
-    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str):
-        session = super().resume(repo_path, job, prompt, omx_session_id)
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, codex_session_id: str):
+        session = super().resume(repo_path, job, prompt, codex_session_id)
         if job.stage in {"issue_request_recovery", "issue_followup_recovery"}:
             self.set_transient_failures(1)
         return session
 
 
 class CommentRecoveryRuntimeRunner(FakeRuntimeRunner):
-    def resume(self, repo_path: Path, job: JobRecord, prompt: str, omx_session_id: str) -> SessionRecord:
+    def resume(self, repo_path: Path, job: JobRecord, prompt: str, codex_session_id: str) -> SessionRecord:
         if job.stage in {"issue_request_recovery", "issue_followup_recovery"}:
             expected_signature = str(job.metadata["expected_signature"])
             self.github.add_issue_signature(job.repo_full_name, int(job.issue_number or 0), expected_signature)
-        return super().resume(repo_path, job, prompt, omx_session_id)
+        return super().resume(repo_path, job, prompt, codex_session_id)
 
 
-def test_issue_request_recovery_resumes_source_effective_omx_session_when_preferred_runtime_is_omo(
+def test_issue_request_recovery_resumes_source_effective_codex_session_when_preferred_runtime_is_omo(
     tmp_path: Path,
 ) -> None:
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET, agent_runtime=RUNTIME_OMO)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
     omo_runner = CommentRecoveryRuntimeRunner(github, runtime_name=RUNTIME_OMO)
-    omx_runner = CommentRecoveryRuntimeRunner(github, runtime_name=RUNTIME_OMX)
+    codex_runner = CommentRecoveryRuntimeRunner(github, runtime_name=RUNTIME_CODEX)
     service = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, omo_runner),
+        codex_runner=cast(AgentRunner, omo_runner),
         dev_syncer=FakeGitDevSyncer(),
-        runtime_runners={RUNTIME_OMX: cast(AgentRunner, omx_runner)},
+        runtime_runners={RUNTIME_CODEX: cast(AgentRunner, codex_runner)},
     )
     service.register_repo("acme/demo", str(tmp_path))
     repo = service.storage.get_repo("acme/demo")
@@ -2586,7 +2587,7 @@ def test_issue_request_recovery_resumes_source_effective_omx_session_when_prefer
             "title": "Need planning",
             "body": "Need planning",
             "preferred_runtime": RUNTIME_OMO,
-            "effective_runtime": RUNTIME_OMX,
+            "effective_runtime": RUNTIME_CODEX,
         },
     )
     service.storage.create_job(source_job)
@@ -2594,16 +2595,16 @@ def test_issue_request_recovery_resumes_source_effective_omx_session_when_prefer
         SessionRecord(
             repo_full_name="acme/demo",
             stage="issue_request",
-            runtime_handle=f"omx-runtime-{source_job.id}",
+            runtime_handle=f"codex-runtime-{source_job.id}",
             prompt_path=str(tmp_path / "prompt.txt"),
             script_path=str(tmp_path / "run.sh"),
             worktree_path=str(tmp_path),
             job_id=source_job.id,
             issue_number=48,
-            omx_session_id="omx-original",
+            codex_session_id="codex-original",
             preferred_runtime=RUNTIME_OMO,
-            effective_runtime=RUNTIME_OMX,
-            native_session_runtime=RUNTIME_OMX,
+            effective_runtime=RUNTIME_CODEX,
+            native_session_runtime=RUNTIME_CODEX,
         )
     )
     service.queue_manager.submit = lambda queued_job: None  # type: ignore[method-assign]
@@ -2615,11 +2616,11 @@ def test_issue_request_recovery_resumes_source_effective_omx_session_when_prefer
 
     assert omo_runner.resumes == []
     assert omo_runner.launches == []
-    assert [record["omx_session_id"] for record in omx_runner.resumes] == ["omx-original"]
-    assert omx_runner.launches == []
+    assert [record["codex_session_id"] for record in codex_runner.resumes] == ["codex-original"]
+    assert codex_runner.launches == []
     assert recovery_job.metadata["preferred_runtime"] == RUNTIME_OMO
-    assert recovery_job.metadata["source_effective_runtime"] == RUNTIME_OMX
-    assert recovery_job.metadata["effective_runtime"] == RUNTIME_OMX
+    assert recovery_job.metadata["source_effective_runtime"] == RUNTIME_CODEX
+    assert recovery_job.metadata["effective_runtime"] == RUNTIME_CODEX
 
 
 def test_issue_request_recovery_prefers_source_job_session_when_newer_same_issue_session_exists(
@@ -2628,12 +2629,12 @@ def test_issue_request_recovery_prefers_source_job_session_when_newer_same_issue
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
-    omx_runner = CommentRecoveryRuntimeRunner(github, runtime_name=RUNTIME_OMX)
+    codex_runner = CommentRecoveryRuntimeRunner(github, runtime_name=RUNTIME_CODEX)
     service = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, omx_runner),
+        codex_runner=cast(AgentRunner, codex_runner),
         dev_syncer=FakeGitDevSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))
@@ -2665,10 +2666,10 @@ def test_issue_request_recovery_prefers_source_job_session_when_newer_same_issue
             worktree_path=str(tmp_path),
             job_id=source_job.id,
             issue_number=49,
-            omx_session_id="omx-source",
-            preferred_runtime=RUNTIME_OMX,
-            effective_runtime=RUNTIME_OMX,
-            native_session_runtime=RUNTIME_OMX,
+            codex_session_id="codex-source",
+            preferred_runtime=RUNTIME_CODEX,
+            effective_runtime=RUNTIME_CODEX,
+            native_session_runtime=RUNTIME_CODEX,
         )
     )
     service.storage.create_session(
@@ -2681,10 +2682,10 @@ def test_issue_request_recovery_prefers_source_job_session_when_newer_same_issue
             worktree_path=str(tmp_path),
             job_id=newer_job.id,
             issue_number=49,
-            omx_session_id="omx-newer",
-            preferred_runtime=RUNTIME_OMX,
-            effective_runtime=RUNTIME_OMX,
-            native_session_runtime=RUNTIME_OMX,
+            codex_session_id="codex-newer",
+            preferred_runtime=RUNTIME_CODEX,
+            effective_runtime=RUNTIME_CODEX,
+            native_session_runtime=RUNTIME_CODEX,
         )
     )
     service.queue_manager.submit = lambda queued_job: None  # type: ignore[method-assign]
@@ -2694,21 +2695,21 @@ def test_issue_request_recovery_prefers_source_job_session_when_newer_same_issue
 
     service._run_comment_recovery_attempt(repo, recovery_job)
 
-    assert [record["omx_session_id"] for record in omx_runner.resumes] == ["omx-source"]
+    assert [record["codex_session_id"] for record in codex_runner.resumes] == ["codex-source"]
     assert recovery_job.metadata["source_job_id"] == source_job.id
-    assert recovery_job.metadata["source_omx_session_id"] == "omx-source"
+    assert recovery_job.metadata["source_codex_session_id"] == "codex-source"
 
 
 def test_issue_request_recovery_falls_back_to_fresh_launch_when_resumed_process_fails(tmp_path: Path) -> None:
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
-    omx_runner = ResumeWaitFailureRecoveryRunner(github)
+    codex_runner = ResumeWaitFailureRecoveryRunner(github)
     service = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, omx_runner),
+        codex_runner=cast(AgentRunner, codex_runner),
         dev_syncer=FakeGitDevSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))
@@ -2730,8 +2731,8 @@ def test_issue_request_recovery_falls_back_to_fresh_launch_when_resumed_process_
     source_job, recovery_job = service.storage.list_jobs()
     assert source_job.status == "completed"
     assert recovery_job.status == "completed"
-    assert [record["job"].stage for record in omx_runner.resumes] == ["issue_request_recovery"]
-    assert [record["job"].stage for record in omx_runner.launches] == ["issue_request", "issue_request_recovery"]
+    assert [record["job"].stage for record in codex_runner.resumes] == ["issue_request_recovery"]
+    assert [record["job"].stage for record in codex_runner.launches] == ["issue_request", "issue_request_recovery"]
     assert recovery_job.metadata["comment_recovery_resume_error"] == "resume failed"
 
 
@@ -2739,12 +2740,12 @@ def test_issue_request_recovery_does_not_fresh_launch_when_resume_exception_post
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
-    omx_runner = ResumeExceptionAfterPostingRecoveryRunner(github)
+    codex_runner = ResumeExceptionAfterPostingRecoveryRunner(github)
     service = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, omx_runner),
+        codex_runner=cast(AgentRunner, codex_runner),
         dev_syncer=FakeGitDevSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))
@@ -2770,8 +2771,8 @@ def test_issue_request_recovery_does_not_fresh_launch_when_resume_exception_post
     )
     assert source_job.status == "completed"
     assert recovery_job.status == "completed"
-    assert [record["job"].stage for record in omx_runner.resumes] == ["issue_request_recovery"]
-    assert [record["job"].stage for record in omx_runner.launches] == ["issue_request"]
+    assert [record["job"].stage for record in codex_runner.resumes] == ["issue_request_recovery"]
+    assert [record["job"].stage for record in codex_runner.launches] == ["issue_request"]
     assert len(matching_comments) == 1
     assert recovery_job.metadata["comment_recovery_resume_error"] == "resume raised after posting signature"
     assert recovery_job.metadata["note"] == "side_effect_already_posted"
@@ -2781,12 +2782,12 @@ def test_issue_request_recovery_does_not_fresh_launch_when_failed_resume_posted_
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
-    omx_runner = ResumeWaitFailureRecoveryRunner(github, post_before_failure=True)
+    codex_runner = ResumeWaitFailureRecoveryRunner(github, post_before_failure=True)
     service = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, omx_runner),
+        codex_runner=cast(AgentRunner, codex_runner),
         dev_syncer=FakeGitDevSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))
@@ -2812,8 +2813,8 @@ def test_issue_request_recovery_does_not_fresh_launch_when_failed_resume_posted_
     )
     assert source_job.status == "completed"
     assert recovery_job.status == "completed"
-    assert [record["job"].stage for record in omx_runner.resumes] == ["issue_request_recovery"]
-    assert [record["job"].stage for record in omx_runner.launches] == ["issue_request"]
+    assert [record["job"].stage for record in codex_runner.resumes] == ["issue_request_recovery"]
+    assert [record["job"].stage for record in codex_runner.launches] == ["issue_request"]
     assert len(matching_comments) == 1
     assert recovery_job.metadata["comment_recovery_resume_error"] == "resume failed"
     assert recovery_job.metadata["note"] == "side_effect_already_posted"
@@ -2825,12 +2826,12 @@ def test_recovery_transient_exhaustion_fails_source_job_with_recovery_metadata(
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
-    omx_runner = RecoveryTransientFailureRunner(github, recover=False)
+    codex_runner = RecoveryTransientFailureRunner(github, recover=False)
     service = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, omx_runner),
+        codex_runner=cast(AgentRunner, codex_runner),
         dev_syncer=FakeGitDevSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))
@@ -2866,7 +2867,7 @@ def test_service_rehydrates_queued_jobs_on_startup(tmp_path: Path) -> None:
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, FakeOmxRunner(github)),
+        codex_runner=cast(AgentRunner, FakeCodexRunner(github)),
         dev_syncer=FakeGitDevSyncer(),
     )
     first_service.register_repo("acme/demo", str(tmp_path))
@@ -2878,12 +2879,12 @@ def test_service_rehydrates_queued_jobs_on_startup(tmp_path: Path) -> None:
     )
     storage.create_job(queued)
 
-    runner = FakeOmxRunner(github)
+    runner = FakeCodexRunner(github)
     restarted = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, runner),
+        codex_runner=cast(AgentRunner, runner),
         dev_syncer=FakeGitDevSyncer(),
     )
     restarted.wait_for_idle()
@@ -2900,7 +2901,7 @@ def test_service_recovers_launched_jobs_on_startup(tmp_path: Path) -> None:
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, FakeOmxRunner(github)),
+        codex_runner=cast(AgentRunner, FakeCodexRunner(github)),
         dev_syncer=FakeGitDevSyncer(),
     )
     first_service.register_repo("acme/demo", str(tmp_path))
@@ -2914,12 +2915,12 @@ def test_service_recovers_launched_jobs_on_startup(tmp_path: Path) -> None:
     )
     storage.create_job(launched)
 
-    runner = FakeOmxRunner(github)
+    runner = FakeCodexRunner(github)
     restarted = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, runner),
+        codex_runner=cast(AgentRunner, runner),
         dev_syncer=FakeGitDevSyncer(),
     )
     restarted.wait_for_idle()
@@ -2940,7 +2941,7 @@ def test_service_completes_launched_job_on_startup_when_side_effect_exists(tmp_p
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, FakeOmxRunner(github)),
+        codex_runner=cast(AgentRunner, FakeCodexRunner(github)),
         dev_syncer=FakeGitDevSyncer(),
     )
     first_service.register_repo("acme/demo", str(tmp_path))
@@ -2955,12 +2956,12 @@ def test_service_completes_launched_job_on_startup_when_side_effect_exists(tmp_p
     storage.create_job(launched)
     github.add_issue_signature("acme/demo", 79, build_signature(stage="issue_request", job=launched.id, issue=79))
 
-    runner = FakeOmxRunner(github)
+    runner = FakeCodexRunner(github)
     restarted = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, runner),
+        codex_runner=cast(AgentRunner, runner),
         dev_syncer=FakeGitDevSyncer(),
     )
     restarted.wait_for_idle()
@@ -2973,7 +2974,7 @@ def test_service_completes_launched_job_on_startup_when_side_effect_exists(tmp_p
 
 
 def test_job_status_is_launched_while_runner_waits(tmp_path: Path) -> None:
-    class BlockingWaitRunner(FakeOmxRunner):
+    class BlockingWaitRunner(FakeCodexRunner):
         def __init__(self, github: FakeGitHubCLI, storage: JsonStorage) -> None:
             super().__init__(github)
             self.storage = storage
@@ -2997,7 +2998,7 @@ def test_job_status_is_launched_while_runner_waits(tmp_path: Path) -> None:
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, runner),
+        codex_runner=cast(AgentRunner, runner),
         dev_syncer=FakeGitDevSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))
@@ -3033,7 +3034,7 @@ def test_launched_dev_sync_is_requeued_on_startup(tmp_path: Path) -> None:
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, FakeOmxRunner(github)),
+        codex_runner=cast(AgentRunner, FakeCodexRunner(github)),
         dev_syncer=FakeGitDevSyncer(),
     )
     first_service.register_repo("acme/demo", str(tmp_path))
@@ -3050,7 +3051,7 @@ def test_launched_dev_sync_is_requeued_on_startup(tmp_path: Path) -> None:
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, FakeOmxRunner(github)),
+        codex_runner=cast(AgentRunner, FakeCodexRunner(github)),
         dev_syncer=FakeGitDevSyncer(),
     ).wait_for_idle()
 
@@ -3069,7 +3070,7 @@ def test_launched_comment_recovery_completes_source_job_on_startup(tmp_path: Pat
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, FakeOmxRunner(github)),
+        codex_runner=cast(AgentRunner, FakeCodexRunner(github)),
         dev_syncer=FakeGitDevSyncer(),
     )
     first_service.register_repo("acme/demo", str(tmp_path))
@@ -3099,12 +3100,12 @@ def test_launched_comment_recovery_completes_source_job_on_startup(tmp_path: Pat
     storage.create_job(recovery)
     github.add_issue_signature("acme/demo", 81, expected_signature)
 
-    runner = FakeOmxRunner(github)
+    runner = FakeCodexRunner(github)
     DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, runner),
+        codex_runner=cast(AgentRunner, runner),
         dev_syncer=FakeGitDevSyncer(),
     ).wait_for_idle()
 
@@ -3122,12 +3123,12 @@ def test_agent_timeout_config_is_passed_to_runner(tmp_path: Path) -> None:
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET, agent_timeout_seconds=5400)
     storage = JsonStorage(config)
     github = FakeGitHubCLI()
-    omx_runner = FakeOmxRunner(github)
+    codex_runner = FakeCodexRunner(github)
     service = DaniService(
         config,
         storage=storage,
         github=cast(GitHubCLI, github),
-        omx_runner=cast(AgentRunner, omx_runner),
+        codex_runner=cast(AgentRunner, codex_runner),
         dev_syncer=FakeGitDevSyncer(),
     )
     service.register_repo("acme/demo", str(tmp_path))
@@ -3146,4 +3147,4 @@ def test_agent_timeout_config_is_passed_to_runner(tmp_path: Path) -> None:
     )
     service.wait_for_idle()
 
-    assert omx_runner.wait_calls[-1]["timeout_seconds"] == 5400
+    assert codex_runner.wait_calls[-1]["timeout_seconds"] == 5400

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -50,7 +50,7 @@ def test_storage_round_trips_runtime_metadata_and_filters_by_effective_runtime(t
             worktree_path=str(tmp_path),
             job_id=job.id,
             issue_number=1,
-            omx_session_id="ses_omo123",
+            codex_session_id="ses_omo123",
             preferred_runtime="omo",
             effective_runtime="omo",
             native_session_runtime="omo",
@@ -60,33 +60,33 @@ def test_storage_round_trips_runtime_metadata_and_filters_by_effective_runtime(t
         SessionRecord(
             repo_full_name=repo.full_name,
             stage="issue_request",
-            runtime_handle="runtime-omx",
-            prompt_path=str(tmp_path / "prompt-omx.txt"),
-            script_path=str(tmp_path / "run-omx.sh"),
+            runtime_handle="runtime-codex",
+            prompt_path=str(tmp_path / "prompt-codex.txt"),
+            script_path=str(tmp_path / "run-codex.sh"),
             worktree_path=str(tmp_path),
             job_id=job.id,
             issue_number=1,
-            omx_session_id="omx-123",
+            codex_session_id="codex-123",
             preferred_runtime="omo",
-            effective_runtime="omx",
-            native_session_runtime="omx",
+            effective_runtime="codex",
+            native_session_runtime="codex",
             fallback_reason="claude_weekly_limit",
             bridge_source_runtime="omo",
             bridge_source_session_id="ses_omo123",
         )
     )
 
-    latest_omx = storage.find_latest_session(
+    latest_codex = storage.find_latest_session(
         repo_full_name=repo.full_name,
         issue_number=1,
-        require_omx_session_id=True,
-        effective_runtime="omx",
+        require_codex_session_id=True,
+        effective_runtime="codex",
     )
 
-    assert latest_omx is not None
-    assert latest_omx.fallback_reason == "claude_weekly_limit"
-    assert latest_omx.bridge_source_runtime == "omo"
-    assert latest_omx.bridge_source_session_id == "ses_omo123"
+    assert latest_codex is not None
+    assert latest_codex.fallback_reason == "claude_weekly_limit"
+    assert latest_codex.bridge_source_runtime == "omo"
+    assert latest_codex.bridge_source_session_id == "ses_omo123"
 
 
 def test_find_latest_session_can_filter_by_source_job_id(tmp_path: Path) -> None:
@@ -106,7 +106,7 @@ def test_find_latest_session_can_filter_by_source_job_id(tmp_path: Path) -> None
             worktree_path=str(tmp_path),
             job_id=first_job.id,
             issue_number=40,
-            omx_session_id="omx-first",
+            codex_session_id="codex-first",
         )
     )
     storage.create_session(
@@ -119,7 +119,7 @@ def test_find_latest_session_can_filter_by_source_job_id(tmp_path: Path) -> None
             worktree_path=str(tmp_path),
             job_id=second_job.id,
             issue_number=40,
-            omx_session_id="omx-second",
+            codex_session_id="codex-second",
         )
     )
 
@@ -132,4 +132,4 @@ def test_find_latest_session_can_filter_by_source_job_id(tmp_path: Path) -> None
 
     assert source_session is not None
     assert source_session.job_id == first_job.id
-    assert source_session.omx_session_id == "omx-first"
+    assert source_session.codex_session_id == "codex-first"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -89,6 +89,36 @@ def test_storage_round_trips_runtime_metadata_and_filters_by_effective_runtime(t
     assert latest_codex.bridge_source_session_id == "ses_omo123"
 
 
+def test_storage_reads_legacy_codex_session_key(tmp_path: Path) -> None:
+    config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
+    storage = JsonStorage(config)
+    legacy_session_key = f"{'o'}{'mx'}_session_id"
+    config.sessions_path.write_text(
+        (
+            "{\n"
+            '  "sessions": [\n'
+            "    {\n"
+            '      "repo_full_name": "acme/demo",\n'
+            '      "stage": "issue_request",\n'
+            '      "runtime_handle": "runtime-1",\n'
+            '      "prompt_path": "prompt.txt",\n'
+            '      "script_path": "run.sh",\n'
+            '      "worktree_path": "repo",\n'
+            '      "job_id": "job-1",\n'
+            '      "id": "session-1",\n'
+            f'      "{legacy_session_key}": "codex-legacy"\n'
+            "    }\n"
+            "  ]\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    session = storage.list_sessions()[0]
+
+    assert session.codex_session_id == "codex-legacy"
+
+
 def test_find_latest_session_can_filter_by_source_job_id(tmp_path: Path) -> None:
     config = DaniConfig(data_dir=tmp_path / ".dani", webhook_secret=TEST_SECRET)
     storage = JsonStorage(config)


### PR DESCRIPTION
## Summary
- Switch generated Codex runtime scripts from `omx exec` to `codex exec` while preserving `--dangerously-bypass-approvals-and-sandbox`.
- Make `codex` the canonical default runtime while preserving `omx` as a legacy alias.
- Replace implementation `$ralph` and review `$code-review`/Momus prompt guidance with `$omo:ulw-loop tdd manual qa commit well` and plain Codex review guidance.

## Verification
- RED: `uv run pytest tests/test_omx_runner.py tests/test_prompts.py tests/test_service.py -q` failed with 8 expected old-behavior assertions.
- RED: `uv run pytest tests/test_cli.py -q` failed with 2 expected default-runtime assertions.
- GREEN: `uv run ruff check README.md pyproject.toml dani/agent_runner.py dani/cli.py dani/errors.py dani/models.py dani/omx_runner.py dani/prompts.py dani/service.py tests/test_cli.py tests/test_omx_runner.py tests/test_prompts.py tests/test_service.py`.
- GREEN: `uv run ty check dani tests`.
- GREEN: `uv run pytest` -> 237 passed, 2 skipped.
- Manual QA tmux evidence: `.omo/ulw-loop/evidence/codex-runtime-scripts.txt`, `.omo/ulw-loop/evidence/codex-prompts.txt`, `.omo/ulw-loop/evidence/codex-pytest.txt`; cleanup receipt in `.omo/ulw-loop/evidence/cleanup-receipt.txt`.
